### PR TITLE
Proposition for improvement: Replacing pefile (and custom format parsing) with lief

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 capstone>=4.0.1
 keystone-engine>=0.9.1.post3
 unicorn>=1.0.2rc1
-pefile>=2019.4.18
+lief>=0.9.0
 python-registry>=1.3.1


### PR DESCRIPTION
Hi,

I've noticed `qiling` uses `pefile` for PE file parsing. `pefile` is these days not very well maintained, nor documented. I've personally come into cases that `pefile` didn't handle well (such as Windows ARM64 support).
That's why in this PR, I've replaced it with the [LIEF](https://lief.quarkslab.com/) project under very active development, really clear coding style and [extremely well documented](https://lief.quarkslab.com/doc/latest/index.html). Implementing `lief` makes Qiling code more Pythonic, and also more extensible.
In order to unify the parsing process, I've also used this opportunity to modify the Mach-O and ELF parsing functions to `lief`, which I believe, add more readability to it.

Thanks,