### PR TITLE
Set Up DllMain Args and Restructured import_symbols and import_address_table to Allow Ordinal Imports

### DIFF
--- a/CREDITS.TXT
+++ b/CREDITS.TXT
@@ -23,6 +23,7 @@ Contributors (in no particular order)
 =====================================
 klks - The Code Refectorer, Advisor
 Kevin (chfl4gs) Foo - Travis, Dockerfile, Documentation and Website
+jhumble - Dll Ordinal Imports
 
 
 Alpha testers (in no particular order, named by github id)

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -47,14 +47,21 @@ class Process:
         # cache depends on address base
         fcache = path + ".%x.cache" % self.ql.DLL_LAST_ADDR
 
+        # Add dll to IAT
+        try:
+            self.import_address_table[dll_name] = {}
+        except KeyError as ke:
+            pass
+
         if not os.path.exists(fcache):
             dll = pefile.PE(path, fast_load=True)
             dll.parse_data_directories()
             data = bytearray(dll.get_memory_mapped_image())
 
             for entry in dll.DIRECTORY_ENTRY_EXPORT.symbols:
-                self.import_symbols[self.ql.DLL_LAST_ADDR + entry.address] = entry.name
-                self.import_address_table[entry.name] = self.ql.DLL_LAST_ADDR + entry.address
+                self.import_symbols[self.ql.DLL_LAST_ADDR + entry.address] = {'name': entry.name, 'ordinal': entry.ordinal}
+                self.import_address_table[dll_name][entry.name] = self.ql.DLL_LAST_ADDR + entry.address
+                self.import_address_table[dll_name][entry.ordinal] = self.ql.DLL_LAST_ADDR + entry.address
                 self.set_cmdline(entry, data)
             if self.ql.libcache:
                 # cache this dll file
@@ -273,14 +280,37 @@ class PE(Process):
         # set stack pointer
         self.ql.nprint("[+] Initiate stack address at 0x%x " % self.ql.stack_address)
         self.ql.uc.mem_map(self.ql.stack_address, self.ql.stack_size)
-        sp = self.ql.stack_address + self.ql.stack_size
+
+        # Stack should not init at the very bottom. Will cause errors with Dlls
+        sp = self.ql.stack_address + self.ql.stack_size - 0x1000
 
         if self.ql.arch == QL_X86:
             self.ql.uc.reg_write(UC_X86_REG_ESP, sp)
             self.ql.uc.reg_write(UC_X86_REG_EBP, sp)
+
+            if self.pe.is_dll():
+                self.ql.nprint('[+] Setting up DllMain args')
+                load_addr_bytes = self.PE_IMAGE_BASE.to_bytes(length=4, byteorder='little')
+
+                self.ql.nprint('[+] Writing {:08X} (IMAGE_BASE) to [ESP+4](0x{:08X})'.format(self.PE_IMAGE_BASE, sp+0x4))
+                self.ql.uc.mem_write(sp+0x4, load_addr_bytes)
+
+                self.ql.nprint('[+] Writing 0x01 (DLL_PROCESS_ATTACH) to [ESP+8](0x{:08X})'.format(sp+0x8))
+                self.ql.uc.mem_write(sp+0x8, int(1).to_bytes(length=4, byteorder='little'))
+
         elif self.ql.arch == QL_X8664:
             self.ql.uc.reg_write(UC_X86_REG_RSP, sp)
             self.ql.uc.reg_write(UC_X86_REG_RBP, sp)
+
+            if self.pe.is_dll():
+                self.ql.nprint('[+] Setting up DllMain args')
+                load_addr_bytes = self.PE_IMAGE_BASE.to_bytes(length=8, byteorder='little')
+
+                self.ql.nprint('[+] Setting RCX (arg1) to {:16X} (IMAGE_BASE)'.format(self.PE_IMAGE_BASE))
+                self.ql.uc.reg_write(UC_X86_REG_RCX, load_addr_bytes)
+
+                self.ql.nprint('[+] Setting RDX (arg2) to 1 (DLL_PROCESS_ATTACH)')
+                self.ql.uc.reg_write(UC_X86_REG_RDX, int(1).to_bytes(length=8, byteorder='little'))
         else:
             raise QlErrorArch("[!] Unknown ql.arch")
 
@@ -296,16 +326,21 @@ class PE(Process):
 
         # parse directory entry import
         for entry in self.pe.DIRECTORY_ENTRY_IMPORT:
-            dll_name = entry.dll
-            super().load_dll(dll_name)
+            dll_name = str(entry.dll.lower(), 'utf-8', 'ignore')
+            super().load_dll(entry.dll)
             for imp in entry.imports:
                 # fix IAT
                 # self.ql.nprint(imp.name)
                 # self.ql.nprint(self.import_address_table[imp.name])
-                if self.ql.arch == QL_X86:
-                    address = self.ql.pack32(self.import_address_table[imp.name])
+                if imp.name:
+                    addr = self.import_address_table[dll_name][imp.name]
                 else:
-                    address = self.ql.pack64(self.import_address_table[imp.name])
+                    addr = self.import_address_table[dll_name][imp.ordinal]
+
+                if self.ql.arch == QL_X86:
+                    address = self.ql.pack32(addr)
+                else:
+                    address = self.ql.pack64(addr)
                 self.ql.uc.mem_write(imp.address, address)
 
         self.ql.nprint("[+] Done with loading %s" % self.path)

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -289,13 +289,13 @@ class PE(Process):
             self.ql.uc.reg_write(UC_X86_REG_EBP, sp)
 
             if self.pe.is_dll():
-                self.ql.nprint('[+] Setting up DllMain args')
+                self.ql.dprint('[+] Setting up DllMain args')
                 load_addr_bytes = self.PE_IMAGE_BASE.to_bytes(length=4, byteorder='little')
 
-                self.ql.nprint('[+] Writing {:08X} (IMAGE_BASE) to [ESP+4](0x{:08X})'.format(self.PE_IMAGE_BASE, sp+0x4))
+                self.ql.dprint('[+] Writing 0x%08X (IMAGE_BASE) to [ESP+4](0x%08X)' % (self.PE_IMAGE_BASE, sp+0x4))
                 self.ql.uc.mem_write(sp+0x4, load_addr_bytes)
 
-                self.ql.nprint('[+] Writing 0x01 (DLL_PROCESS_ATTACH) to [ESP+8](0x{:08X})'.format(sp+0x8))
+                self.ql.dprint('[+] Writing 0x01 (DLL_PROCESS_ATTACH) to [ESP+8](0x%08X)' % (sp+0x8))
                 self.ql.uc.mem_write(sp+0x8, int(1).to_bytes(length=4, byteorder='little'))
 
         elif self.ql.arch == QL_X8664:
@@ -303,13 +303,13 @@ class PE(Process):
             self.ql.uc.reg_write(UC_X86_REG_RBP, sp)
 
             if self.pe.is_dll():
-                self.ql.nprint('[+] Setting up DllMain args')
+                self.ql.dprint('[+] Setting up DllMain args')
                 load_addr_bytes = self.PE_IMAGE_BASE.to_bytes(length=8, byteorder='little')
 
-                self.ql.nprint('[+] Setting RCX (arg1) to {:16X} (IMAGE_BASE)'.format(self.PE_IMAGE_BASE))
+                self.ql.dprint('[+] Setting RCX (arg1) to %16X (IMAGE_BASE)' % (self.PE_IMAGE_BASE))
                 self.ql.uc.reg_write(UC_X86_REG_RCX, load_addr_bytes)
 
-                self.ql.nprint('[+] Setting RDX (arg2) to 1 (DLL_PROCESS_ATTACH)')
+                self.ql.dprint('[+] Setting RDX (arg2) to 1 (DLL_PROCESS_ATTACH)')
                 self.ql.uc.reg_write(UC_X86_REG_RDX, int(1).to_bytes(length=8, byteorder='little'))
         else:
             raise QlErrorArch("[!] Unknown ql.arch")

--- a/qiling/os/windows/x86.py
+++ b/qiling/os/windows/x86.py
@@ -39,7 +39,7 @@ def hook_winapi(ql, address, size):
     # call win32 api
     if address in ql.PE.import_symbols:
         try:
-            ql.nprint('[+] Hooking 0x{:08x}: {}'.format(address, ql.PE.import_symbols[address]))
+            ql.dprint('[+] Hooking 0x{:08x}: {}'.format(address, ql.PE.import_symbols[address]))
             globals()['hook_' + ql.PE.import_symbols[address]['name'].decode()](ql, address, {})
         except KeyError as e:
             print("[!]", e, "\t is not implemented")

--- a/qiling/os/windows/x86.py
+++ b/qiling/os/windows/x86.py
@@ -39,7 +39,8 @@ def hook_winapi(ql, address, size):
     # call win32 api
     if address in ql.PE.import_symbols:
         try:
-            globals()['hook_' + ql.PE.import_symbols[address].decode()](ql, address, {})
+            ql.nprint('[+] Hooking 0x{:08x}: {}'.format(address, ql.PE.import_symbols[address]))
+            globals()['hook_' + ql.PE.import_symbols[address]['name'].decode()](ql, address, {})
         except KeyError as e:
             print("[!]", e, "\t is not implemented")
 

--- a/qiling/os/windows/x8664.py
+++ b/qiling/os/windows/x8664.py
@@ -32,7 +32,8 @@ def set_pe64_gdt(ql):
 def hook_winapi(ql, address, size):
     if address in ql.PE.import_symbols:
         try:
-            globals()['hook_' + ql.PE.import_symbols[address].decode()](ql, address, {})
+            ql.nprint('Hooking 0x{:08x}: {}'.format(address, ql.PE.import_symbols[address]))
+            globals()['hook_' + ql.PE.import_symbols[address]['name'].decode()](ql, address, {})
         except KeyError as e:
             print("[!]", e, "\t is not implemented")
 

--- a/qiling/os/windows/x8664.py
+++ b/qiling/os/windows/x8664.py
@@ -32,7 +32,7 @@ def set_pe64_gdt(ql):
 def hook_winapi(ql, address, size):
     if address in ql.PE.import_symbols:
         try:
-            ql.nprint('Hooking 0x{:08x}: {}'.format(address, ql.PE.import_symbols[address]))
+            ql.dprint('Hooking 0x{:08x}: {}'.format(address, ql.PE.import_symbols[address]))
             globals()['hook_' + ql.PE.import_symbols[address]['name'].decode()](ql, address, {})
         except KeyError as e:
             print("[!]", e, "\t is not implemented")


### PR DESCRIPTION
Passed in dllmain args hinstDLL and fdwReason as described here: [https://docs.microsoft.com/en-us/windows/win32/dlls/dllmain](https://docs.microsoft.com/en-us/windows/win32/dlls/dllmain) I did not include any handling for lpvReserved as in my experience it is rarely used. 

I also made some changes to support imports by ordinal and to avoid collisions where two different dlls have the same api name:

pe.import_symbols now maps addr to a dict with both name and ordinal. I updated the x86.py and x8664.py loaders to use this new structure in the api hooking. 

In pe.import_address_table I separated imports out by dll name (to avoid collisions) and added two mappings per import: api_name to addr and ordinal to addr. This allows for finding the correct address when loading a new import by name or by ordinal.  This structure also allows for easily applying hooks (by name) to imports by ordinal.