### PR TITLE
fix workaround for MIPS32EL argv[0] problem

### DIFF
--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -520,7 +520,8 @@ class ELFLoader(ELFParse):
         # Set AUX
         # This part of the code is a myth for MIPS32_EL
         if ql.arch == QL_MIPS32EL:
-            new_stack = new_stack - 4
+            if len(ql.argv[0]) % 8 // 4 == 0:
+                new_stack = new_stack - 4
         
         # ql.uc.mem_write(int(new_stack) - 4, ql.pack32(0x11111111))
         # new_stack = new_stack - 4


### PR DESCRIPTION
the length of argv[0] will cause "got interrupt 0xd ???" , looks like something "access invalid memory" issue (I guess).

### Debug steps

1. `cp ../examples/rootfs/mips32el_linux/bin/mips32el_hello ./A`
2. cat testing.py

```python
import os

for i in range(2, 100):
    os.system('mv {} {}'.format('A'*(i-1), 'A'*i))

    res = os.popen('../qltool run -f {} --rootfs ../examples/rootfs/mips32el_linux'.format('A'*i)).read()

    if 'got interrupt' in res:
        print('fail on ', i)

    elif 'Hello' in res:
        print('good on ', i)
```
I run the test for several length of argv[0] and saw a pattern below
```
good on  2
good on  3
fail on  4
fail on  5
fail on  6
fail on  7
good on  8
good on  9
good on  10
good on  11
fail on  12
fail on  13
fail on  14
fail on  15
good on  16
good on  17
good on  18
good on  19
fail on  20
fail on  21
fail on  22
fail on  23
good on  24
good on  25
good on  26
good on  27
fail on  28
fail on  29
fail on  30
fail on  31
good on  32
good on  33
good on  34
good on  35
fail on  36
fail on  37
fail on  38
fail on  39
good on  40
good on  41
good on  42
good on  43
fail on  44
fail on  45
fail on  46
fail on  47
good on  48
good on  49
good on  50
good on  51
fail on  52
fail on  53
fail on  54
fail on  55
good on  56
good on  57
good on  58
good on  59
fail on  60
fail on  61
fail on  62
fail on  63
good on  64
good on  65
good on  66
good on  67
fail on  68
fail on  69
fail on  70
fail on  71
good on  72
good on  73
good on  74
good on  75
fail on  76
fail on  77
fail on  78
fail on  79
good on  80
good on  81
good on  82
good on  83
fail on  84
fail on  85
fail on  86
fail on  87
good on  88
good on  89
good on  90
good on  91
fail on  92
fail on  93
fail on  94
fail on  95
good on  96
good on  97
good on  98
good on  99
```

This looks like a workaround to me

https://github.com/qilingframework/qiling/blob/33eac300b95d50f652f160a0a230b7cb62f01a51/qiling/loader/elf.py#L522-L523

so I did a bit adjustment , it should fits all cases

maybe not the root cause but work fine.