### PR TITLE
PE loader now adds an entry for the main executable to LDR_DATA

### DIFF
--- a/examples/windows_trace.py
+++ b/examples/windows_trace.py
@@ -68,9 +68,6 @@ def spaced_hex(data):
 
 def disasm(count, ql, address, size):
     buf = ql.uc.mem_read(address, size)
-    if address == 0x0500049A:
-        print(hexlify(ql.uc.mem_read(ql.uc.reg_read(UC_X86_REG_ECX)+4, 0x04)))
-        
     try:
         for i in md.disasm(buf, address):
             return "{:08X}\t{:08X}: {:24s} {:10s} {:16s}".format(count[0], i.address, spaced_hex(buf), i.mnemonic, i.op_str)

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -324,6 +324,11 @@ class PE(Process):
         data = bytearray(self.pe.get_memory_mapped_image())
         self.ql.uc.mem_write(self.PE_IMAGE_BASE, bytes(data))
 
+        #Add main PE to ldr_data_table
+        mod_name = os.path.basename(self.path)
+        self.dlls[mod_name] = self.PE_IMAGE_BASE
+        super().add_ldr_data_table_entry(mod_name)
+        
         # parse directory entry import
         for entry in self.pe.DIRECTORY_ENTRY_IMPORT:
             dll_name = str(entry.dll.lower(), 'utf-8', 'ignore')

--- a/qiling/os/windows/dlls/user32.py
+++ b/qiling/os/windows/dlls/user32.py
@@ -116,7 +116,7 @@ def hook_SetClipboardData(ql, address, params):
     try:
         data = bytes(params['hMem'], 'ascii')
     except:
-        data = ""
+        data = b""
     return ql.clipboard.set_data(params['uFormat'], data)
 
 #HANDLE GetClipboardData(

--- a/qiling/os/windows/dlls/user32.py
+++ b/qiling/os/windows/dlls/user32.py
@@ -113,7 +113,11 @@ def hook_CloseClipboard(ql, address, params):
     "hMem": STRING
 })
 def hook_SetClipboardData(ql, address, params):
-    return ql.clipboard.set_data(params['uFormat'], bytes(params['hMem'], 'ascii'))
+    try:
+        data = bytes(params['hMem'], 'ascii')
+    except:
+        data = ""
+    return ql.clipboard.set_data(params['uFormat'], data)
 
 #HANDLE GetClipboardData(
 #  UINT uFormat


### PR DESCRIPTION
I added a few lines of code to insert a LDR_MODULE entry for the main exe being run to match the structure on Windows. Prior to this fix, I was getting crashes on some packers/malware that were crawling the ldr data as a method of finding PE_IMAGE_BASE.

Also made a small fix to handle null parameters to SetClipboardData and removed a couple lines of debug code that made their way into windows_trace.py