### PR TITLE
Ignore mode in open syscall if not O_CREAT

### DIFF
--- a/qiling/os/posix/filestruct.py
+++ b/qiling/os/posix/filestruct.py
@@ -16,6 +16,9 @@ class ql_file:
 
     @classmethod
     def open(self, open_path, open_flags, open_mode):
+        if (open_flags & os.O_CREAT) == 0:
+            open_mode = 0
+
         fd = os.open(open_path, open_flags, open_mode)
         return self(open_path, fd)
 

--- a/qiling/os/posix/syscall.py
+++ b/qiling/os/posix/syscall.py
@@ -232,9 +232,6 @@ def ql_syscall_open(ql, filename, flags, mode, null0, null1, null2):
                 mode = 0
 
             flags = open_flag_mapping(flags, ql)
-            if (flags & os.O_CREAT) == 0:
-                mode = 0
-
             ql.file_des[idx] = ql_file.open(real_path, flags, mode)
             regreturn = idx
         except:
@@ -267,9 +264,6 @@ def ql_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, nul
             regreturn = -1
         else:
             openat_flags = open_flag_mapping(openat_flags, ql)
-            if (openat_flags & os.O_CREAT) == 0:
-                openat_mode = 0
-
             ql.file_des[idx] = ql_file.open(real_path, openat_flags, openat_mode)
             regreturn = (idx)
     ql.nprint("\nopenat(%d, %s, 0x%x, 0x%x) = %d" % (openat_fd, relative_path, openat_flags, openat_mode, regreturn))

--- a/qiling/os/posix/syscall.py
+++ b/qiling/os/posix/syscall.py
@@ -232,6 +232,9 @@ def ql_syscall_open(ql, filename, flags, mode, null0, null1, null2):
                 mode = 0
 
             flags = open_flag_mapping(flags, ql)
+            if (flags & os.O_CREAT) == 0:
+                mode = 0
+
             ql.file_des[idx] = ql_file.open(real_path, flags, mode)
             regreturn = idx
         except:
@@ -263,6 +266,10 @@ def ql_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, nul
         if idx == -1:
             regreturn = -1
         else:
+            openat_flags = open_flag_mapping(openat_flags, ql)
+            if (openat_flags & os.O_CREAT) == 0:
+                openat_mode = 0
+
             ql.file_des[idx] = ql_file.open(real_path, openat_flags, openat_mode)
             regreturn = (idx)
     ql.nprint("\nopenat(%d, %s, 0x%x, 0x%x) = %d" % (openat_fd, relative_path, openat_flags, openat_mode, regreturn))


### PR DESCRIPTION
Per both linux and macos man page, mode should only be used when the O_CREAT flag is passed. On macOS at least, the call to `ql_gfile.open()` will fail if the emulated program has data in the `mode` argument and it does not have the O_CREAT flag. 