### PR TITLE
Added missing fncc import. Fixed x64 param parsing

### DIFF
--- a/qiling/os/windows/dlls/advapi32.py
+++ b/qiling/os/windows/dlls/advapi32.py
@@ -4,6 +4,7 @@
 # Built on top of Unicorn emulator (www.unicorn-engine.org) 
 import struct
 from qiling.os.windows.fncc import *
+from qiling.os.fncc import *
 from qiling.os.windows.utils import *
 from qiling.os.windows.handle import *
 from qiling.os.windows.const import *

--- a/qiling/os/windows/dlls/kernel32.py
+++ b/qiling/os/windows/dlls/kernel32.py
@@ -6,6 +6,7 @@
 import struct
 import time
 from qiling.os.windows.const import *
+from qiling.os.fncc import *
 from qiling.os.windows.fncc import *
 from qiling.os.windows.utils import *
 from qiling.os.windows.memory import align
@@ -1027,7 +1028,7 @@ def hook_LoadLibraryExA(ql, address, params):
     "lpLibFileName": WSTRING
 })
 def hook_LoadLibraryW(ql, address, params):
-    lpLibFileName = bytes(params["lpLibFileName"], 'ascii')
+    lpLibFileName = bytes(bytes(params["lpLibFileName"], 'ascii').deocde('utf-16le'), 'ascii')
     dll_base = ql.PE.load_dll(lpLibFileName)
     return dll_base
 
@@ -1043,7 +1044,7 @@ def hook_LoadLibraryW(ql, address, params):
     "dwFlags": DWORD
 })
 def hook_LoadLibraryExW(ql, address, params):
-    lpLibFileName = bytes(params["lpLibFileName"], 'ascii')
+    lpLibFileName = bytes(bytes(params["lpLibFileName"], "ascii").decode('utf-16le'), 'ascii')
     dll_base = ql.PE.load_dll(lpLibFileName)
     return dll_base
 
@@ -1058,7 +1059,6 @@ def hook_LoadLibraryExW(ql, address, params):
 })
 def hook_GetProcAddress(ql, address, params):
     lpProcName = bytes(params["lpProcName"], 'ascii')
-
     #Check if dll is loaded
     try:
         dll_name = [key for key, value in ql.PE.dlls.items() if value == params['hModule']][0]
@@ -1069,7 +1069,7 @@ def hook_GetProcAddress(ql, address, params):
     if lpProcName in ql.PE.import_address_table[dll_name]:
         return ql.PE.import_address_table[dll_name][lpProcName]
 
-    return 0
+    return 1
 
 #LPVOID GlobalLock(
 #  HGLOBAL hMem

--- a/qiling/os/windows/dlls/msi.py
+++ b/qiling/os/windows/dlls/msi.py
@@ -6,6 +6,7 @@
 import struct
 from qiling.os.windows.const import *
 from qiling.os.windows.fncc import *
+from qiling.os.fncc import *
 from qiling.os.windows.utils import *
 from qiling.os.windows.memory import align
 from qiling.os.windows.thread import *

--- a/qiling/os/windows/dlls/msvcrt.py
+++ b/qiling/os/windows/dlls/msvcrt.py
@@ -4,6 +4,7 @@
 # Built on top of Unicorn emulator (www.unicorn-engine.org) 
 import struct
 from qiling.os.windows.fncc import *
+from qiling.os.fncc import *
 
 
 # void __set_app_type (

--- a/qiling/os/windows/dlls/ntdll.py
+++ b/qiling/os/windows/dlls/ntdll.py
@@ -6,6 +6,7 @@
 import struct
 from qiling.os.windows.const import *
 from qiling.os.windows.fncc import *
+from qiling.os.fncc import *
 from qiling.os.windows.utils import *
 from qiling.os.windows.memory import align
 from qiling.os.windows.thread import *

--- a/qiling/os/windows/dlls/user32.py
+++ b/qiling/os/windows/dlls/user32.py
@@ -5,6 +5,7 @@
 
 import struct
 from qiling.os.windows.fncc import *
+from qiling.os.fncc import *
 from qiling.os.windows.utils import *
 
 

--- a/qiling/os/windows/dlls/wininet.py
+++ b/qiling/os/windows/dlls/wininet.py
@@ -5,6 +5,7 @@
 
 import struct
 from qiling.os.windows.fncc import *
+from qiling.os.fncc import *
 from qiling.os.windows.utils import *
 
 

--- a/qiling/os/windows/fncc.py
+++ b/qiling/os/windows/fncc.py
@@ -5,6 +5,7 @@
 import struct
 from unicorn.x86_const import *
 from qiling.os.utils import *
+from qiling.os.fncc import *
 from qiling.os.windows.utils import *
 from qiling.arch.filetype import *
 

--- a/qiling/os/windows/fncc.py
+++ b/qiling/os/windows/fncc.py
@@ -6,7 +6,6 @@ import struct
 from unicorn.x86_const import *
 from qiling.os.utils import *
 from qiling.os.windows.utils import *
-from qiling.os.fncc import *
 from qiling.arch.filetype import *
 
 
@@ -35,7 +34,7 @@ def _x8664_get_params_by_index(ql, index):
 
     index -= 4
     # skip ret_addr
-    return ql.stack_read((index + 1) * 8)
+    return ql.stack_read((index + 5) * 8)
 
 
 def _get_param_by_index(ql, index):


### PR DESCRIPTION
fncc.py was refactored recently and now the windows hook modules need to import both qiling.os.windows.fncc and qiling.os.fncc. I updated the dlls to import both as needed.

Additionally, I fixed _x8664_get_params_by_index to take into account the home space / shadow stack. I described this in a previous pull request: https://github.com/qilingframework/qiling/pull/47#issuecomment-562439953
