### PR TITLE
修复keystone包安装时错误

### DIFF
--- a/keystone_patch.sh
+++ b/keystone_patch.sh
@@ -1,0 +1,8 @@
+# Solve the error when install Keystone-engine
+# error: Setup script exited with error: 
+#    can't copy 'src\build\llvm\lib\libkeystone.so': 
+#       doesn't exist or not a regular file
+
+git clone https://github.com/keystone-engine/keystone.git
+cd keystone/bindings/python/
+python3 setup.py install    # python3 can be changed to another python path even venv

--- a/keystone_patch.sh
+++ b/keystone_patch.sh
@@ -4,5 +4,12 @@
 #       doesn't exist or not a regular file
 
 git clone https://github.com/keystone-engine/keystone.git
-cd keystone/bindings/python/
+cd keystone
+mkdir build
+cd build
+../make-share.sh
+sudo make install
+sudo ldconfig
+cd ../bindings/python/
+
 python3 setup.py install    # python3 can be changed to another python path even venv


### PR DESCRIPTION
Fix errors that may have occurred while installing keystone
keystone包目前版本过老，使用pip安装时可能会发生以下错误
error: Setup script exited with error: can't copy 'src\build\llvm\lib\libkeystone.so': doesn't exist or not a regular file
该脚本通过源码安装,可修复此问题