### PR TITLE
Added hooks for: WSAStartup,WSASocketA,Connect

### DIFF
--- a/qiling/os/windows/dlls/__init__.py
+++ b/qiling/os/windows/dlls/__init__.py
@@ -10,3 +10,4 @@ from .wininet import *
 from .msi import *
 from .ntdll import *
 from .ucrtbased import *
+from .wsock32 import *

--- a/qiling/os/windows/dlls/wsock32.py
+++ b/qiling/os/windows/dlls/wsock32.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+# Cross Platform and Multi Architecture Advanced Binary Emulation Framework
+# Built on top of Unicorn emulator (www.unicorn-engine.org)
+
+import struct
+from qiling.os.windows.const import *
+from qiling.os.windows.fncc import *
+from qiling.os.fncc import *
+from qiling.os.windows.utils import *
+from qiling.os.memory import align
+from qiling.os.windows.thread import *
+from qiling.os.windows.handle import *
+from qiling.exception import *
+
+# int WSAStartup(
+#  WORD      wVersionRequired,
+#  LPWSADATA lpWSAData
+# );
+@winapi(cc=STDCALL, params={"wVersionRequired": DWORD, "LPWSADATA": STRING})
+def hook_WSAStartup(ql, address, params):
+    return 0
+
+
+# SOCKET WSAAPI WSASocketA(
+#  int                 af,
+#  int                 type,
+#  int                 protocol,
+#  LPWSAPROTOCOL_INFOA lpProtocolInfo,
+#  GROUP               g,
+#  DWORD               dwFlags
+# );
+@winapi(
+    STDCALL,
+    params={
+        "af": INT,
+        "type": INT,
+        "protocol": INT,
+        "lpProtocolInfo": POINTER,
+        "g": INT,
+        "dwFlags": INT,
+    },
+)
+def hook_WSASocketA(ql, address, params):
+    return 0
+
+
+# int WSAAPI connect(
+#  SOCKET         s,
+#  const sockaddr *name,
+#  int            namelen
+# );
+@winapi(cc=STDCALL, params={"s": INT, "name": POINTER, "namelen": INT})
+def hook_connect(ql, address, params):
+    sin_family = ql.mem_read(params["name"], 1)[0]
+    sin_port = int.from_bytes(ql.mem_read(params["name"] + 2, 2), byteorder="big")
+    if sin_family == 0x17:  # IPv6
+        segments = list(map("{:02x}".format, ql.mem_read(params["name"] + 8, 16)))
+        sin_addr = ":".join(["".join(x) for x in zip(segments[0::2], segments[1::2])])
+    elif sin_family == 0x2:  # IPv4
+        sin_addr = ".".join(
+            [str(octet) for octet in ql.mem_read(params["name"] + 4, 4)]
+        )
+    else:
+        print("[!] sockaddr sin_family unhandled variant")
+        return 0
+    print(
+        f"0x{params['name']:08x}: sockaddr_in{6 if sin_family == 0x17 else ''}",
+        f"{{sin_family=0x{sin_family:02x}, sin_port={sin_port}, sin_addr={sin_addr}}}",
+        sep="",
+    )
+    return 0


### PR DESCRIPTION
Added hook for WSAStartup,WSASocketA,Connect and added basic parsing of the sockaddr_in and sockaddr_in6 structure to parse out destination address and port.

Output will look like the below for IPv4:

```
[+] Loading /home/XXX/CC/qiling/msfhere2 to 0x400000
[+] PE entry point at 0x40b187
[+] Initiate stack address at 0xfffdd000 
[+] TEB addr is 0x6000
[+] PEB addr is 0x6044
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/msvcrt.dll to 0x10000000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/msvcrt.dll
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/kernel32.dll to 0x100bf000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/kernel32.dll
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/advapi32.dll to 0x10194000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/advapi32.dll
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/wsock32.dll to 0x1020d000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/wsock32.dll
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/ws2_32.dll to 0x10215000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/ws2_32.dll
[+] Done with loading /home/XXX/CC/qiling/msfhere2
0x100d4ed0: VirtualAlloc(lpAddress = 0x0, dwSize = 0x155, flAllocationType = 0x1000, flProtect = 0x40) = 0x5024bec
0x100e1990: LoadLibraryA(lpLibFileName = "ws2_32") = 0x10215000
0x1021dce0: WSAStartup(wVersionRequired = 0x190, LPWSADATA = "") = 0x0
0x1022bbd0: WSASocketA(af = 0x2, type = 0x1, protocol = 0x0, lpProtocolInfo = 0x0, g = 0x0, dwFlags = 0x0) = 0x0
0xffffce4c: sockaddr_in{sin_family=0x02, sin_port=1234, sin_addr=111.222.111.11}
0x10229de0: connect(s = 0x0, name = 0xffffce4c, namelen = 0x10) = 0x0
```
Output will look like the below for IPv6:

```
[+] Loading /home/XXX/CC/qiling/msfhere to 0x400000
[+] PE entry point at 0x40ba77
[+] Initiate stack address at 0xfffdd000 
[+] TEB addr is 0x6000
[+] PEB addr is 0x6044
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/msvcrt.dll to 0x10000000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/msvcrt.dll
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/kernel32.dll to 0x100bf000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/kernel32.dll
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/advapi32.dll to 0x10194000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/advapi32.dll
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/wsock32.dll to 0x1020d000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/wsock32.dll
[+] Loading examples/rootfs/x86_windows/Windows/SysWOW64/ws2_32.dll to 0x10215000
[+] Done with loading examples/rootfs/x86_windows/Windows/SysWOW64/ws2_32.dll
[+] Done with loading /home/XXX/CC/qiling/msfhere
0x100d4ed0: VirtualAlloc(lpAddress = 0x0, dwSize = 0x121, flAllocationType = 0x1000, flProtect = 0x40) = 0x5024be4
0x100e1990: LoadLibraryA(lpLibFileName = "ws2_32") = 0x10215000
0x1021dce0: WSAStartup(wVersionRequired = 0x202, LPWSADATA = "") = 0x0
0x1022bbd0: WSASocketA(af = 0x17, type = 0x1, protocol = 0x6, lpProtocolInfo = 0x0, g = 0x0, dwFlags = 0x0) = 0x0
0x05024caa: sockaddr_in6{sin_family=0x17, sin_port=1234, sin_addr=2001:4860:4860:0000:0000:0000:0000:8888}
0x10229de0: connect(s = 0x0, name = 0x5024caa, namelen = 0x1c) = 0x0
```

I've tried to keep the formatting for the struct parsing consistent with the rest of the output from the program.

