### PR TITLE
Updated Dockerfile to be faster to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,19 @@ MAINTAINER "Kevin Foo <chbsd64@gmail.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+
 RUN apt-get update \
   && apt-get -y upgrade \
-  && apt-get install -y python3-pip git cmake
+  && apt-get install -y python3-pip git cmake\
+  && apt-get install -y vim
 
-WORKDIR /
+COPY ./requirements.txt ./qiling/requirements.txt
+RUN pip3 install -r /qiling/requirements.txt
 
-RUN git clone https://github.com/qilingframework/qiling
 
-RUN cd /qiling \
-  && pip3 install -r requirements.txt \
-  && python3 setup.py install
 
 RUN pysite1=$(python3 -c "import site; print(site.getsitepackages()[0])"); \
-  pysite2=$(python3 -c "import site; print(site.getsitepackages()[1])") \
+  pysite2=$(python3 -c "import site; print(site.getsitepackages()[1])")\
   && cp ${pysite1}${pysite2}/keystone/libkeystone.so $pysite1/keystone/
 
 RUN apt-get clean \

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Qemu usermode does similar thing to our emulator, that is to emulate whole execu
 
 #### Install
 
+##### Local
 If you are NOT using pyenv, run the command shown below to install Qiling (Python3 is required).
 
 ```
@@ -67,6 +68,24 @@ If you are using pyenv, run the command shown below (or use docker).
 mv $(dirname $(which python))/python2.7 $(dirname $(which python))/python2.7.bak
 pip install -r ./requirements.txt
 python setup.py install
+```
+
+##### Docker
+You can build a docker container with
+```
+# docker build -t quiling .
+```
+
+And connect to it mounting your mock filesystem with
+
+```
+# docker run -it -v $PWD:/qiling -v /your/path/to/mock/fs:/qiling/examples/roots/WINOS/Windows/SysWOW64 qiling bash
+```
+
+After that 
+
+```
+python3 /qiling/setup.py install
 ```
 
 ---


### PR DESCRIPTION
Changed build operations order, now is not necessary to build every time something is modified inside qiling. I didn't think that the clone was really necessary, we can just copy the local folder inside the container (a lot faster) and link the mock filesystem, samples and tests.

Modified Readme to reflect the changes.