### PR TITLE
Add pread64 syscall on x86_64

### DIFF
--- a/qiling/os/linux/x8664_syscall.py
+++ b/qiling/os/linux/x8664_syscall.py
@@ -20,6 +20,7 @@ dict_x8664_linux_syscall = {
     0x0D : "ql_syscall_rt_sigaction",
     0x0E : "ql_syscall_rt_sigprocmask",
     0x10 : "ql_syscall_ioctl",
+    0x11 : "ql_syscall_pread64",
     0x14 : "ql_syscall_writev",
     0x15 : "ql_syscall_access",
     0x23 : "ql_syscall_nanosleep",

--- a/qiling/os/posix/syscall.py
+++ b/qiling/os/posix/syscall.py
@@ -1095,6 +1095,22 @@ def ql_syscall_lstat(ql, lstat_path, lstat_buf_ptr, null0, null1, null2, null3):
         ql.dprint(0,"[!] lstat() read/write fail")
     ql_definesyscall_return(ql, regreturn)
 
+def ql_syscall_pread64(ql, read_fd, read_buf, read_len, read_offt, null0, null1):
+    data = None
+    if read_fd < 256 and ql.file_des[read_fd] != 0:
+        try:
+            pos = ql.file_des[read_fd].tell()
+            ql.file_des[read_fd].lseek(read_offt)
+            data = ql.file_des[read_fd].read(read_len)
+            ql.file_des[read_fd].lseek(pos)
+            ql.uc.mem_write(read_buf, data)
+            regreturn = len(data)
+        except:
+            regreturn = -1
+    else:
+        regreturn = -1
+    ql.nprint("pread(%d, 0x%x, 0x%x, 0x%x) = 0x%x" % (read_fd, read_buf, read_len, read_offt, regreturn))
+    ql_definesyscall_return(ql, regreturn)
 
 def ql_syscall_read(ql, read_fd, read_buf, read_len, null0, null1, null2):
     data = None


### PR DESCRIPTION
Adds `ssize_t pread(int fd, void *buf, size_t count, off_t offset)` on x86_64, which seems to be used by libc 2.31 on Arch Linux.