### PR TITLE
NoneType checking of ql.thread.management

### DIFF
--- a/qiling/os/posix/syscall/sched.py
+++ b/qiling/os/posix/syscall/sched.py
@@ -67,7 +67,8 @@ def ql_syscall_clone(ql, clone_flags, clone_child_stack, clone_parent_tidptr, cl
     if ql.archtype== QL_MIPS32:
         clone_child_tidptr = ql.unpack32(ql.mem.read(clone_child_tidptr, 4))
 
-
+    if ql.thread_management == None:
+        return
     f_th = ql.thread_management.cur_thread	
     newtls = None
     set_child_tid_addr = None


### PR DESCRIPTION
Avoid this error: 
  File "/usr/local/lib/python3.6/dist-packages/qiling-0.9-py3.6.egg/qiling/os/posix/syscall/sched.py", line 71, in ql_syscall_clone
    f_th = ql.thread_management.cur_thread	
AttributeError: 'NoneType' object has no attribute 'cur_thread'