### PR TITLE
Fix exception in registry

### DIFF
--- a/qiling/os/windows/registry.py
+++ b/qiling/os/windows/registry.py
@@ -46,7 +46,7 @@ class RegistryManager:
             self.hive = os.path.join(ql.rootfs, "Windows", "registry")
             ql.dprint(D_INFO, "[+] Windows Registry PATH: %s" % self.hive)
             if not os.path.exists(self.hive) and not self.ql.shellcoder:
-                raise QlPrintException("Error: Registry files not found!")
+                raise QlErrorFileNotFound("Error: Registry files not found!")
 
         if not os.path.exists(self.regdiff):
             self.registry_config = {}


### PR DESCRIPTION
By default, when running the wannacry_x86_windows_hookaddress.py or any script that uses registry.py, exception is raised due to the fact that **QlPrintException** is not an exception object.

This commit fix-it by raising a **QlErrorFileNotFound**.