### PR TITLE
Bug fixes

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -239,6 +239,8 @@ class Process(QlLoader):
         self.ldr_list.append(ldr_table_entry)
 
     def init_exports(self):
+        if self.ql.shellcoder:
+            return
         if self.pe.OPTIONAL_HEADER.DATA_DIRECTORY[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_EXPORT']].VirtualAddress != 0:
             # Do a full load if IMAGE_DIRECTORY_ENTRY_EXPORT is present so we can load the exports
             self.pe.full_load()

--- a/qiling/os/windows/dlls/kernel32/fileapi.py
+++ b/qiling/os/windows/dlls/kernel32/fileapi.py
@@ -391,8 +391,16 @@ def hook_GetDiskFreeSpaceW(ql, address, params):
 })
 def hook_CreateDirectoryA(ql, address, params):
     try:
-        os.mkdir(os.path.join(ql.rootfs, lpPathName.replace("\\", os.sep)))
-        return 1
+        target_dir = os.path.join(ql.rootfs, lpPathName.replace("\\", os.sep))
+        print('TARGET_DIR = %s' % target_dir)
+        ql.os.transform_to_real_path(lpPathName) 
+        # Verify the directory is in ql.rootfs to ensure no path traversal has taken place
+        if os.path.commonprefix(target_dir, ql.rootfs) != ql.rootfs:
+            ql.dprint(D_INFO, 'CreateDirectoryA attempted to create dir outside of rootfs: "%s". Not creating.' % (target_dir))
+            return 0
+        else:
+            os.mkdir()
+            return 1
     except FileExistsError:
         ql.os.last_error = ERROR_ALREADY_EXISTS
         return 0

--- a/qiling/os/windows/dlls/kernel32/libloaderapi.py
+++ b/qiling/os/windows/dlls/kernel32/libloaderapi.py
@@ -166,8 +166,6 @@ def hook_GetProcAddress(ql, address, params):
 
     #Handle case where module is self
     if dll_name == os.path.basename(ql.loader.path):
-        from pprint import pprint
-        pprint(ql.loader.export_symbols)
         for addr, export in ql.loader.export_symbols.items():
             if export['name'] == lpProcName:
                 return addr

--- a/qiling/os/windows/dlls/wsock32.py
+++ b/qiling/os/windows/dlls/wsock32.py
@@ -87,7 +87,8 @@ def hook_connect(ql, address, params):
     "name": STRING
 })
 def hook_gethostbyname(ql, address, params):
-    dummy_ip = b"\x40\x30\x20\x10" #10.20.30.40
+    ip_str = ql.os.profile.getint("NETWORK", "dns_response_ip")
+    ip = bytes([int(octet) for octet in ip_str.split('.')[::-1]])
     hostnet = ql.heap.mem_alloc(ql.pointersize*3+4)
     ip_ptr = ql.heap.mem_alloc(len(params['name']))
     ql.uc.mem.write(ip_ptr, params['name'].encode('latin1'))
@@ -96,5 +97,5 @@ def hook_gethostbyname(ql, address, params):
     ql.mem.write(hostnet+ql.pointersize, (0).to_bytes(length=ql.pointersize, byteorder='little'))
     ql.mem.write(hostnet+2*ql.pointersize, (2).to_bytes(length=2, byteorder='little'))
     ql.mem.write(hostnet+2*ql.pointersize+2, (4).to_bytes(length=2, byteorder='little'))
-    ql.mem.write(hostnet+2*ql.pointersize+4, dummy_ip)
+    ql.mem.write(hostnet+2*ql.pointersize+4, ip)
     return hostnet


### PR DESCRIPTION
I managed to forget to include the changes to wsock32.py and fileapi.py in commit: https://github.com/qilingframework/qiling/commit/bff5fd4139f70ee868b11815683732d88821202c

I added those, and also included a fix in the pe loader that occurs when trying to load a dll with no imports (ntdll.dll for example)

I additionally added some code to parse exports for the main module being loaded. This allows execution of various exported functions for a dll similarly to rundll32. 

Some executables (especially malware) will have exported functions which are found and called by calling LoadLibrary against themselves, then using that handle to find the addresses of exported funtions with GetProcAddress.
Previously this would crash, but now works. I updated the GetProcAddress hook to check if hMod == self, and if so to search through the newly available exports.