### PR TITLE
fix mips archtype in shellcode_run.py

### DIFF
--- a/examples/shellcode_run.py
+++ b/examples/shellcode_run.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     ql.run()
 
     print("\nLinux MIPS 32bit EL Shellcode")
-    ql = Qiling(shellcoder = MIPS32EL_LIN, archtype = "mips32el", ostype = "linux", output = "debug")
+    ql = Qiling(shellcoder = MIPS32EL_LIN, archtype = "mips32", ostype = "linux", output = "debug")
     ql.run()
 
     print("\nLinux X86 64bit Shellcode")


### PR DESCRIPTION
change archtype to `mips32`, since there is no `mips32el` anymore.
https://github.com/qilingframework/qiling/blob/617bcee20c77c8940dcd9aaf867e9b27a4054812/qiling/utils.py#L87-L98

Also, the archendian is `LE` in default.