### PR TITLE
New and fixed API hooks

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -257,7 +257,7 @@ class Process(QlLoader):
                 self.import_address_table[dll_name][entry.ordinal] = self.PE_IMAGE_BASE + entry.address
         except:
             import traceback
-            self.ql.nprint('Failed to load exports for %s:\n%s' % (self.name, traceback.format_exc()))
+            self.ql.nprint('Failed to load exports for %s:\n%s' % (self.ql.filename, traceback.format_exc()))
 
 
 class QlLoaderPE(Process, QlLoader):

--- a/qiling/os/windows/dlls/kernel32/libloaderapi.py
+++ b/qiling/os/windows/dlls/kernel32/libloaderapi.py
@@ -272,3 +272,12 @@ def hook_LoadResource(ql, address, params):
 def hook_LockResource(ql, address, params):
     pointer = params["hResData"]
     return pointer
+
+#BOOL DisableThreadLibraryCalls(
+#  HMODULE hLibModule
+#);
+@winapi(cc=STDCALL, params={
+    "hLibModule": POINTER
+})
+def hook_DisableThreadLibraryCalls(ql, address, params):
+    return 1

--- a/qiling/os/windows/dlls/kernel32/processthreadsapi.py
+++ b/qiling/os/windows/dlls/kernel32/processthreadsapi.py
@@ -48,7 +48,7 @@ def hook_ExitProcess(ql, address, params):
 # } STARTUPINFO, *LPSTARTUPINFO;
 def GetStartupInfo(ql, address, params):
     startup_info = {
-        "cb": 0x44.to_bytes(length=4, byteorder='little'),
+        "cb": (0x34 + 4*ql.pointersize).to_bytes(length=4, byteorder='little'),
         "lpReserved": 0x0.to_bytes(length=ql.pointersize, byteorder='little'),
         "lpDesktop": 0xc3c930.to_bytes(length=ql.pointersize, byteorder='little'),
         "lpTitle": 0x0.to_bytes(length=ql.pointersize, byteorder='little'),

--- a/qiling/os/windows/dlls/kernel32/synchapi.py
+++ b/qiling/os/windows/dlls/kernel32/synchapi.py
@@ -183,10 +183,16 @@ def hook_WaitForMultipleObjects(ql, address, params):
     "lpName": WSTRING
 })
 def hook_OpenMutexW(ql, address, params):
-    type, name = params["lpName"].split("\\")
     # The name can have a "Global" or "Local" prefix to explicitly open an object in the global or session namespace.
+    # It can also have no prefix
+    try:
+        _type, name = params["lpName"].split("\\")
+    except:
+        name = params["lpName"]
+        _type = ""
+
     handle = ql.os.handle_manager.search(name)
-    if type == "Global":
+    if _type == "Global":
         # if is global is a Windows lock. We always return a valid handle because we have no way to emulate them
         # example sample: Gandcrab e42431d37561cc695de03b85e8e99c9e31321742
         if handle is None:
@@ -204,6 +210,19 @@ def hook_OpenMutexW(ql, address, params):
             return 0
         else:
             raise QlErrorNotImplemented("[!] API not implemented")
+
+# HANDLE OpenMutexA(
+#   DWORD   dwDesiredAccess,
+#   BOOL    bInheritHandle,
+#   LPCSTR lpName
+# );
+@winapi(cc=STDCALL, params={
+    "dwDesiredAccess": DWORD,
+    "bInheritHandle": BOOL,
+    "lpName": STRING
+})
+def hook_OpenMutexA(ql, address, params):
+    return hook_OpenMutexW.__wrapped__(ql, address, params)
 
 
 # HANDLE CreateMutexW(
@@ -237,6 +256,20 @@ def hook_CreateMutexW(ql, address, params):
 
     return handle.ID
 
+# HANDLE CreateMutexA(
+#   LPSECURITY_ATTRIBUTES lpMutexAttributes,
+#   BOOL                  bInitialOwner,
+#   LPCSTR               lpName
+# );
+@winapi(cc=STDCALL, params={
+    "lpMutexAttributes": POINTER,
+    "bInitialOwner": BOOL,
+    "lpName": STRING
+})
+def hook_CreateMutexA(ql, address, params):
+    return hook_CreateMutexW.__wrapped__(ql, address, params)
+
+
 #HANDLE CreateEventA(
 #  LPSECURITY_ATTRIBUTES lpEventAttributes,
 #  BOOL                  bManualReset,
@@ -268,3 +301,18 @@ def hook_CreateEventA(ql, address, params):
         handle = Handle(obj=mutex, name=name)
         ql.os.handle_manager.append(handle)
     return handle.ID
+
+#HANDLE CreateEventW(
+#  LPSECURITY_ATTRIBUTES lpEventAttributes,
+#  BOOL                  bManualReset,
+#  BOOL                  bInitialState,
+#  LPCWSTR               lpName
+#);
+@winapi(cc=STDCALL, params={
+    "lpEventAttributes": POINTER, 
+    "bManualReset": BOOL,
+    "bInitialState": BOOL,
+    "lpName": WSTRING 
+})
+def hook_CreateEventW(ql, address, params):
+    return hook_CreateEventA.__wrapped__(ql, address, params)

--- a/qiling/os/windows/dlls/kernel32/winnt.py
+++ b/qiling/os/windows/dlls/kernel32/winnt.py
@@ -29,9 +29,23 @@ def hook_InterlockedExchange(ql, address, params):
     "Target": POINTER
 })
 def hook_InterlockedIncrement(ql, address, params):
-    val = int.from_bytes(ql.mem.read(params['Target'], ql.pointersize), byteorder='little')
-    val += 1 & (2 ** ql.pointersize * 8)  # increment and overflow back to 0 if applicable
-    ql.mem.write(params['Target'], val.to_bytes(length=ql.pointersize, byteorder='little'))
+    val = int.from_bytes(ql.mem.read(params['Target'], 4), byteorder='little')
+    val += 1 & (2 ** 32)  # increment and overflow back to 0 if applicable
+    ql.mem.write(params['Target'], val.to_bytes(length=4, byteorder='little'))
+    return val
+
+# LONG InterlockedDecrement(
+#  LONG volatile *Target,
+# );
+@winapi(cc=STDCALL, params={
+    "Target": POINTER
+})
+def hook_InterlockedDecrement(ql, address, params):
+    val = int.from_bytes(ql.mem.read(params['Target'], 4), byteorder='little')
+    val -= 1
+    if val == -1:
+        val = 0xFFFFFFFF
+    ql.mem.write(params['Target'], val.to_bytes(length=4, byteorder='little'))
     return val
 
 

--- a/qiling/os/windows/fncc.py
+++ b/qiling/os/windows/fncc.py
@@ -5,6 +5,7 @@
 
 import struct
 from unicorn.x86_const import *
+from functools import wraps
 
 from qiling.os.const import *
 from .utils import *
@@ -219,6 +220,7 @@ def winapi(cc, param_num=None, params=None):
     """
 
     def decorator(func):
+        @wraps(func)
         def wrapper(*args, **kwargs):
             ql = args[0]
             if ql.archtype== QL_ARCH.X86:

--- a/qiling/os/windows/utils.py
+++ b/qiling/os/windows/utils.py
@@ -13,8 +13,8 @@ from .handle import HandleManager, Handle
 from .thread import QlWindowsThreadManagement, QlWindowsThread
 
 
-def ql_x86_windows_hook_mem_error(ql, addr, size, value):
-    #ql.dprint(D_INFO, "[+] ERROR: unmapped memory access at 0x%x" % addr)
+def ql_x86_windows_hook_mem_error(ql, access, addr, size, value):
+    ql.dprint(D_INFO, "[+] ERROR: unmapped memory access at 0x%x" % addr)
     return False
 
 def string_unpack(string):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ unicorn>=1.0.2rc3
 pefile>=2019.4.18
 python-registry>=1.3.1
 keystone-engine>=0.9.1.post3
+decorator=4.2.1


### PR DESCRIPTION
Added some new api hooks, fixed some others. 

Decorated winapi with https://github.com/micheles/decorator.
Most Windows APIs come in two versions, one with a W suffix for widestrings and one with A suffix for ascii. Due to this, many of the api hooks are just duplicates or in some cases only one version exists. With this decorator, it's possible to access the undecorated version of the hook, so rather than copy pasting the entire function for the second version, the second version can often be implemented like this:

def hook_CreateEventW(ql, address, params):                                                                                                                                                                                                                                                                                                                                                                        
    return hook_CreateEventA.__wrapped__(ql, address, params)

In my opinion this is a lot cleaner and allows for less unanticipated divergences between the two versions. This just happened to be the cleanest way I could find to do this, but if there is a better way, let me know. 

At some point the parameter list for ql.hook_mem_unmapped was changed, but ql_x86_windows_hook_mem_error in qiling/os/windows/utils.py was not updated accordingly. I added the new access parameter so it would stop throwing errors.