### PR TITLE
Post Report: We want every string

### DIFF
--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -47,3 +47,4 @@ class QlOs(QLOsUtils):
         # We can save every syscall called
         self.syscalls = {}
         self.syscalls_counter = 0
+        self.appeared_strings = {}

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -212,20 +212,20 @@ class QLOsUtils:
         return relative_path
 
     def post_report(self):
-        self.ql.dprint(D_INFO, "[+] Syscalls called")
+        self.ql.dprint(D_RPRT, "[+] Syscalls called")
         for key, values in self.ql.os.syscalls.items():
-            self.ql.dprint(D_INFO, "[-] %s:" % key)
+            self.ql.dprint(D_RPRT, "[-] %s:" % key)
             for value in values:
-                self.ql.dprint(D_INFO, "[-] %s " % str(dumps(value)))
-        self.ql.dprint(D_INFO, "[+] Registries accessed")
+                self.ql.dprint(D_RPRT, "[-] %s " % str(dumps(value)))
+        self.ql.dprint(D_RPRT, "[+] Registries accessed")
         for key, values in self.ql.os.registry_manager.accessed.items():
-            self.ql.dprint(D_INFO, "[-] %s:" % key)
+            self.ql.dprint(D_RPRT, "[-] %s:" % key)
             for value in values:
-                self.ql.dprint(D_INFO, "[-] %s " % str(dumps(value)))
-        self.ql.dprint(D_INFO, "[+] Strings")
+                self.ql.dprint(D_RPRT, "[-] %s " % str(dumps(value)))
+        self.ql.dprint(D_RPRT, "[+] Strings")
         for key, values in self.ql.os.appeared_strings.items():
             val = " ".join([str(word) for word in values])
-            self.ql.dprint(D_INFO, "[-] %s: %s" % (key, val))
+            self.ql.dprint(D_RPRT, "[-] %s: %s" % (key, val))
 
 
     def exec_arbitrary(self, start, end):

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -222,6 +222,11 @@ class QLOsUtils:
             self.ql.dprint(D_INFO, "[-] %s:" % key)
             for value in values:
                 self.ql.dprint(D_INFO, "[-] %s " % str(dumps(value)))
+        self.ql.dprint(D_INFO, "[+] Strings")
+        for key, values in self.ql.os.appeared_strings.items():
+            val = " ".join([str(word) for word in values])
+            self.ql.dprint(D_INFO, "[-] %s: %s" % (key, val))
+
 
     def exec_arbitrary(self, start, end):
         old_sp = self.ql.reg.arch_sp

--- a/qiling/os/windows/dlls/kernel32/fileapi.py
+++ b/qiling/os/windows/dlls/kernel32/fileapi.py
@@ -134,6 +134,7 @@ def hook_WriteFile(ql, address, params):
     if hFile == STD_OUTPUT_HANDLE:
         s = ql.mem.read(lpBuffer, nNumberOfBytesToWrite)
         ql.os.stdout.write(s)
+        string_appearance(ql, s.decode())
         ql.mem.write(lpNumberOfBytesWritten, ql.pack(nNumberOfBytesToWrite))
     else:
         f = ql.os.handle_manager.get(hFile)
@@ -287,7 +288,7 @@ def hook_GetShortPathNameW(ql, address, params):
 #   DWORD   nFileSystemNameSize
 # );
 @winapi(cc=STDCALL, params={
-    "lpRootPathName": POINTER,
+    "lpRootPathName": WSTRING,
     "lpVolumeNameBuffer": POINTER,
     "nVolumeNameSize": DWORD,
     "lpVolumeSerialNumber": POINTER,
@@ -297,9 +298,8 @@ def hook_GetShortPathNameW(ql, address, params):
     "nFileSystemNameSize": DWORD
 })
 def hook_GetVolumeInformationW(ql, address, params):
-    root_pt = params["lpRootPathName"]
-    if root_pt != 0:
-        root = read_wstring(ql, root_pt)
+    root = params["lpRootPathName"]
+    if root != 0:
         pt_volume_name = params["lpVolumeNameBuffer"]
         if pt_volume_name != 0:
             # TODO implement
@@ -336,9 +336,8 @@ def hook_GetVolumeInformationW(ql, address, params):
     "lpRootPathName": POINTER
 })
 def hook_GetDriveTypeW(ql, address, params):
-    pointer = params["lpRootPathName"]
-    if pointer != 0:
-        path = read_wstring(ql, pointer)
+    path = params["lpRootPathName"]
+    if path != 0:
         if path == ql.os.profile["PATH"]["systemdrive"]:
             return DRIVE_FIXED
         # TODO add configuration for drives

--- a/qiling/os/windows/dlls/kernel32/winbase.py
+++ b/qiling/os/windows/dlls/kernel32/winbase.py
@@ -223,14 +223,14 @@ def hook_lstrcpyA(ql, address, params):
 #   LPCSTR lpString2
 # );
 @winapi(cc=STDCALL, params={
-    "lpString1": POINTER,
+    "lpString1": STRING_ADDR,
     "lpString2": STRING,
 })
 def hook_lstrcatA(ql, address, params):
     # Copy String2 into String
     src = params["lpString2"]
-    pointer = params["lpString1"]
-    string_base = read_cstring(ql, pointer)
+    pointer = params["lpString1"][0]
+    string_base = params["lpString1"][1]
     result = string_base + src + "\x00"
     ql.mem.write(pointer, bytes(result, encoding="utf-16le"))
     return pointer
@@ -241,14 +241,14 @@ def hook_lstrcatA(ql, address, params):
 #   LPCWSTR lpString2
 # );
 @winapi(cc=STDCALL, params={
-    "lpString1": POINTER,
+    "lpString1": WSTRING_ADDR,
     "lpString2": WSTRING,
 })
 def hook_lstrcatW(ql, address, params):
     # Copy String2 into String
     src = params["lpString2"]
-    pointer = params["lpString1"]
-    string_base = read_wstring(ql, pointer)
+    pointer = params["lpString1"][0]
+    string_base = params["lpString1"][1]
     result = string_base + src + "\x00"
     ql.mem.write(pointer, bytes(result, encoding="utf-16le"))
     return pointer

--- a/qiling/os/windows/dlls/user32.py
+++ b/qiling/os/windows/dlls/user32.py
@@ -464,13 +464,12 @@ def hook_DefWindowProcA(ql, address, params):
 #   LPCWSTR lpsz
 # );
 @winapi(cc=STDCALL, params={
-    "lpsz": POINTER
+    "lpsz": WSTRING_ADDR
 })
 def hook_CharNextW(ql, address, params):
     # Return next char if is different from \x00
-    point = params["lpsz"]
-    string = read_wstring(ql, point)
-    ql.dprint(D_INFO, string)
+    point = params["lpsz"][0]
+    string = params["lpsz"][1]
     if len(string) == 0:
         return point
     else:
@@ -482,13 +481,13 @@ def hook_CharNextW(ql, address, params):
 #   LPCWSTR lpszCurrent
 # );
 @winapi(cc=STDCALL, params={
-    "lpszStart": POINTER,
+    "lpszStart": WSTRING_ADDR,
     "lpszCurrent": POINTER
 })
 def hook_CharPrevW(ql, address, params):
     # Return next char if is different from \x00
     current = params["lpszCurrent"]
-    start = params["lpszStart"]
+    start = params["lpszStart"][0]
     if start == current:
         return start
     return current - 1

--- a/qiling/os/windows/fncc.py
+++ b/qiling/os/windows/fncc.py
@@ -4,7 +4,6 @@
 # Built on top of Unicorn emulator (www.unicorn-engine.org) 
 
 import struct
-from unicorn.x86_const import *
 from functools import wraps
 
 from qiling.os.const import *
@@ -33,7 +32,7 @@ def _x86_get_params_by_index(ql, index):
 
 
 def _x8664_get_params_by_index(ql, index):
-    reg_list = [UC_X86_REG_RCX, UC_X86_REG_RDX, UC_X86_REG_R8, UC_X86_REG_R9]
+    reg_list = ["rcx", "rdx", "r8", "r9"]
     if index < 4:
         return ql.reg.read(reg_list[index])
 
@@ -61,7 +60,7 @@ def _x86_get_args(ql, number):
 
 
 def _x8664_get_args(ql, number):
-    reg_list = [UC_X86_REG_RCX, UC_X86_REG_RDX, UC_X86_REG_R8, UC_X86_REG_R9]
+    reg_list = ["rcx", "rdx", "r8", "r9"]
     arg_list = []
     reg_num = number
     if reg_num > 4:

--- a/qiling/os/windows/fncc.py
+++ b/qiling/os/windows/fncc.py
@@ -23,7 +23,8 @@ HANDLE = 3
 POINTER = 3
 STRING = 4
 WSTRING = 5
-
+STRING_ADDR = 6
+WSTRING_ADDR = 7
 
 def _x86_get_params_by_index(ql, index):
     # index starts from 0
@@ -32,7 +33,6 @@ def _x86_get_params_by_index(ql, index):
 
 
 def _x8664_get_params_by_index(ql, index):
-    #self.ql = ql
     reg_list = [UC_X86_REG_RCX, UC_X86_REG_RDX, UC_X86_REG_R8, UC_X86_REG_R9]
     if index < 4:
         return ql.reg.read(reg_list[index])
@@ -43,9 +43,9 @@ def _x8664_get_params_by_index(ql, index):
 
 
 def _get_param_by_index(ql, index):
-    if ql.archtype== QL_ARCH.X86:
+    if ql.archtype == QL_ARCH.X86:
         return _x86_get_params_by_index(ql, index)
-    elif ql.archtype== QL_ARCH.X8664:
+    elif ql.archtype == QL_ARCH.X8664:
         return _x8664_get_params_by_index(ql, index)
 
 
@@ -84,48 +84,57 @@ def set_function_params(ql, in_params, out_params):
         if in_params[each] == DWORD or in_params[each] == POINTER:
             out_params[each] = _get_param_by_index(ql, index)
         elif in_params[each] == ULONGLONG:
-            if ql.archtype== QL_ARCH.X86:
+            if ql.archtype == QL_ARCH.X86:
                 low = _get_param_by_index(ql, index)
                 index += 1
                 high = _get_param_by_index(ql, index)
                 out_params[each] = high << 32 + low
             else:
                 out_params[each] = _get_param_by_index(ql, index)
-        elif in_params[each] == STRING:
+        elif in_params[each] == STRING or in_params[each] == STRING_ADDR:
             ptr = _get_param_by_index(ql, index)
             if ptr == 0:
                 out_params[each] = 0
             else:
-                out_params[each] = read_cstring(ql, ptr)
-        elif in_params[each] == WSTRING:
+                content = read_cstring(ql, ptr)
+                if in_params[each] == STRING_ADDR:
+                    out_params[each] = (ptr, content)
+                else:
+                    out_params[each] = content
+        elif in_params[each] == WSTRING or in_params[each] == WSTRING_ADDR:
             ptr = _get_param_by_index(ql, index)
             if ptr == 0:
                 out_params[each] = 0
             else:
-                out_params[each] = read_wstring(ql, ptr)
+                content = read_wstring(ql, ptr)
+                if in_params[each] == WSTRING_ADDR:
+                    out_params[each] = (ptr, content)
+                else:
+                    out_params[each] = content
         index += 1
     return index
 
 
 def get_function_param(ql, number):
-    if ql.archtype== QL_ARCH.X86:
+    if ql.archtype == QL_ARCH.X86:
         return _x86_get_args(ql, number)
-    elif ql.archtype== QL_ARCH.X8664:
+    elif ql.archtype == QL_ARCH.X8664:
         return _x8664_get_args(ql, number)
 
 
 def set_return_value(ql, ret):
-    if ql.archtype== QL_ARCH.X86:
+    if ql.archtype == QL_ARCH.X86:
         ql.reg.eax = ret
-    elif ql.archtype== QL_ARCH.X8664:
+    elif ql.archtype == QL_ARCH.X8664:
         ql.reg.rax = ret
 
 
 def get_return_value(ql):
-    if ql.archtype== QL_ARCH.X86:
+    if ql.archtype == QL_ARCH.X86:
         return ql.reg.eax
-    elif ql.archtype== QL_ARCH.X8664:
+    elif ql.archtype == QL_ARCH.X8664:
         return ql.reg.rax
+
 
 #
 # stdcall cdecl fastcall cc
@@ -137,7 +146,6 @@ def __x86_cc(ql, param_num, params, func, args, kwargs):
         param_num = set_function_params(ql, params, args[2])
     # call function
     result = func(*args, **kwargs)
-
 
     # set return value
     if result is not None:
@@ -156,14 +164,15 @@ def _call_api(ql, name, params, result, address, return_address):
         if params is not None:
             set_function_params(ql, params, params_with_values)
     ql.os.syscalls.setdefault(name, []).append({
-            "params": params_with_values,
-            "result": result,
-            "address": address,
-            "return_address": return_address,
-            "position": ql.os.syscalls_counter
-        })
+        "params": params_with_values,
+        "result": result,
+        "address": address,
+        "return_address": return_address,
+        "position": ql.os.syscalls_counter
+    })
 
     ql.os.syscalls_counter += 1
+
 
 def x86_stdcall(ql, param_num, params, func, args, kwargs):
     # if we check ret_addr before the call, we can't modify the ret_addr from inside the hook
@@ -193,11 +202,10 @@ def x86_cdecl(ql, param_num, params, func, args, kwargs):
     if ql.os.PE_RUN:
         ql.reg.arch_pc = ql.stack_pop()
 
-
     return result
 
 
-def x8664_fastcall(ql,  param_num, params, func, args, kwargs):
+def x8664_fastcall(ql, param_num, params, func, args, kwargs):
     result, param_num = __x86_cc(ql, param_num, params, func, args, kwargs)
     old_pc = ql.reg.arch_pc
     # append syscall to list
@@ -205,8 +213,6 @@ def x8664_fastcall(ql,  param_num, params, func, args, kwargs):
 
     if ql.os.PE_RUN:
         ql.reg.arch_pc = ql.stack_pop()
-
-
 
     return result
 
@@ -223,12 +229,12 @@ def winapi(cc, param_num=None, params=None):
         @wraps(func)
         def wrapper(*args, **kwargs):
             ql = args[0]
-            if ql.archtype== QL_ARCH.X86:
+            if ql.archtype == QL_ARCH.X86:
                 if cc == STDCALL:
                     return x86_stdcall(ql, param_num, params, func, args, kwargs)
                 elif cc == CDECL:
                     return x86_cdecl(ql, param_num, params, func, args, kwargs)
-            elif ql.archtype== QL_ARCH.X8664:
+            elif ql.archtype == QL_ARCH.X8664:
                 return x8664_fastcall(ql, param_num, params, func, args, kwargs)
             else:
                 raise QlErrorArch("[!] Unknown self.ql.arch")

--- a/qiling/os/windows/utils.py
+++ b/qiling/os/windows/utils.py
@@ -17,19 +17,23 @@ def ql_x86_windows_hook_mem_error(ql, access, addr, size, value):
     ql.dprint(D_INFO, "[+] ERROR: unmapped memory access at 0x%x" % addr)
     return False
 
+
 def string_unpack(string):
     return string.decode().split("\x00")[0]
 
 
 def print_function(ql, address, function_name, params, ret):
     function_name = function_name.replace('hook_', '')
-    if function_name in ("__stdio_common_vfprintf","__stdio_common_vfwprintf", "printf", "wsprintfW", "sprintf"):
+    if function_name in ("__stdio_common_vfprintf", "__stdio_common_vfwprintf", "printf", "wsprintfW", "sprintf"):
         return
     log = '0x%0.2x: %s(' % (address, function_name)
     for each in params:
         value = params[each]
-        if type(value) == str or type(value) == bytearray:
+        if isinstance(value, str) or type(value) == bytearray:
             log += '%s = "%s", ' % (each, value)
+        elif isinstance(value, tuple):
+            # we just need the string, not the address in the log
+            log += '%s = "%s", ' % (each, value[1])
         else:
             log += '%s = 0x%x, ' % (each, value)
     log = log.strip(", ")
@@ -52,7 +56,9 @@ def read_wstring(ql, address):
         result += char.decode(errors="ignore")
         char = ql.mem.read(address, 2)
     # We need to remove \x00 inside the string. Compares do not work otherwise
-    return result.replace("\x00", "")
+    result = result.replace("\x00", "")
+    string_appearance(ql, result)
+    return result
 
 
 def read_cstring(ql, address):
@@ -62,6 +68,7 @@ def read_cstring(ql, address):
         address += 1
         result += char.decode(errors="ignore")
         char = ql.mem.read(address, 1)
+    string_appearance(ql, result)
     return result
 
 
@@ -89,7 +96,15 @@ def string_to_hex(string):
     return ":".join("{:02x}".format(ord(c)) for c in string)
 
 
-def printf(ql, address, fmt, params_addr, name, wstring=False, double_pointer = False):
+def string_appearance(ql, string):
+    strings = string.split(" ")
+    for string in strings:
+        val = ql.os.appeared_strings.get(string, set())
+        val.add(ql.os.syscalls_counter)
+        ql.os.appeared_strings[string] = val
+
+
+def printf(ql, address, fmt, params_addr, name, wstring=False, double_pointer=False):
     count = fmt.count("%")
     params = []
     if count > 0:
@@ -129,9 +144,5 @@ def printf(ql, address, fmt, params_addr, name, wstring=False, double_pointer = 
         output = '%s(format = %s) = 0x%x' % (name, repr(fmt), len(fmt))
         stdout = fmt
     ql.nprint(output)
-    ql.os.stdout.write(bytes(stdout , 'utf-8'))
+    ql.os.stdout.write(bytes(stdout, 'utf-8'))
     return len(stdout), stdout
-
-
-
-


### PR DESCRIPTION
Is possible to retrieve both the CSTRING or WSTRING and their addres thank to the parameter in the decorator STRING_ADDR and WSTRING_ADDR.

We are now saving every string that is used inside an api, that is moved in the memory, in ql.os.appeared_strings.
Is not necessary anymore to parse the result file, is possible to use qiling as a framework, as intended