### PR TITLE
Unicorn engine should be initialized as part of constructing QlOsUefi.

### DIFF
--- a/qiling/loader/pe_uefi.py
+++ b/qiling/loader/pe_uefi.py
@@ -85,7 +85,6 @@ class QlLoaderPE_UEFI(QlLoader):
         initiate UC needs to be in loader, or else it will kill execve
         Note: This is EFI, but for the sake of same with others OS
         """
-        self.ql.uc = self.ql.arch.init_uc
 
         if self.ql.archtype == QL_ARCH.X8664:
             self.stack_address = int(self.profile.get("OS64", "stack_address"),16)

--- a/qiling/os/uefi/uefi.py
+++ b/qiling/os/uefi/uefi.py
@@ -18,7 +18,7 @@ class QlOsUefi(QlOs):
         self.entry_point = 0
         self.user_defined_api = {}
         self.notify_immediately = False
-
+        self.ql.uc = self.ql.arch.init_uc
 
     def run(self):
         self.setup_output()


### PR DESCRIPTION
Otherwise the Unicorn instance will be undefined when trying to install hooks:
```
Traceback (most recent call last):
  File "./fuzz_uefi_nvram.py", line 113, in <module>
    main(sys.argv[1])
  File "./fuzz_uefi_nvram.py", line 89, in main
    ql.hook_address(callback=start_afl, address=main_addr)
  File "../../qiling/core_hooks.py", line 305, in hook_address
    self._addr_hook_fuc[address] = self._ql_hook_addr_internal(self._hook_addr_cb, address, address)
  File "../../qiling/core_hooks.py", line 208, in _ql_hook_addr_internal
    return self.uc.hook_add(UC_HOOK_CODE, _callback, (self, user_data), address, address)
AttributeError: 'NoneType' object has no attribute 'hook_add'
```