### PR TITLE
Some EFI_HANDLE related fixes for the UEFI emulation environment.

### DIFF
--- a/qiling/loader/pe_uefi.py
+++ b/qiling/loader/pe_uefi.py
@@ -158,7 +158,7 @@ class QlLoaderPE_UEFI(QlLoader):
         path, self.entry_point, pe = self.modules.pop(0)
         # workaround, the debugger sets the breakpoint before the module is loaded.
         if hasattr(self.ql.remotedebugsession ,'gdb'):
-                self.ql.remotedebugsession.gdb.bp_insert(self.entry_point)
+            self.ql.remotedebugsession.gdb.bp_insert(self.entry_point)
         self.ql.stack_push(self.end_of_execution_ptr)
         self.ql.reg.rdx = self.system_table_ptr
         self.ql.os.entry_point = self.entry_point

--- a/qiling/loader/pe_uefi.py
+++ b/qiling/loader/pe_uefi.py
@@ -50,7 +50,7 @@ class QlLoaderPE_UEFI(QlLoader):
                     # Setting entrypoint to the first loaded module entrypoint, so the debugger can break.
                     self.entry_point = entry_point
                 self.ql.nprint("[+] PE entry point at 0x%x" % entry_point)
-                self.modules.append((path, entry_point, pe))
+                self.modules.append((path, IMAGE_BASE, entry_point, pe))
                 return True
             else:
                 IMAGE_BASE += 0x10000
@@ -155,11 +155,12 @@ class QlLoaderPE_UEFI(QlLoader):
         self.notify_ptr = system_table_heap_ptr
         system_table_heap_ptr += pointer_size
 
-        path, self.entry_point, pe = self.modules.pop(0)
+        path, image_base, self.entry_point, pe = self.modules.pop(0)
         # workaround, the debugger sets the breakpoint before the module is loaded.
         if hasattr(self.ql.remotedebugsession ,'gdb'):
             self.ql.remotedebugsession.gdb.bp_insert(self.entry_point)
         self.ql.stack_push(self.end_of_execution_ptr)
+        self.ql.reg.rcx = image_base
         self.ql.reg.rdx = self.system_table_ptr
         self.ql.os.entry_point = self.entry_point
         self.ql.nprint(f'[+] Running from 0x{self.entry_point:x} of {path}')

--- a/qiling/os/uefi/bootup.py
+++ b/qiling/os/uefi/bootup.py
@@ -155,7 +155,7 @@ def hook_CheckEvent(ql, address, params):
 })
 def hook_InstallProtocolInterface(ql, address, params):
     dic = {}
-    handle = params["Handle"]
+    handle = read_int64(ql, params["Handle"])
     if handle in ql.loader.handle_dict:
         dic = ql.loader.handle_dict[handle]
     dic[params["Protocol"]] = params["Interface"]
@@ -433,7 +433,7 @@ def hook_LocateProtocol(ql, address, params):
 @dxeapi(params={
     "Handle": POINTER})
 def hook_InstallMultipleProtocolInterfaces(ql, address, params):
-    handle = params["Handle"]
+    handle = read_int64(ql, params["Handle"])
     ql.nprint(f'hook_InstallMultipleProtocolInterfaces {handle:x}')
     dic = {}
     if handle in ql.loader.handle_dict:

--- a/qiling/os/uefi/bootup.py
+++ b/qiling/os/uefi/bootup.py
@@ -156,11 +156,14 @@ def hook_CheckEvent(ql, address, params):
 def hook_InstallProtocolInterface(ql, address, params):
     dic = {}
     handle = read_int64(ql, params["Handle"])
+    if handle == 0:
+        handle = ql.loader.heap.alloc(1)
     if handle in ql.loader.handle_dict:
         dic = ql.loader.handle_dict[handle]
     dic[params["Protocol"]] = params["Interface"]
     ql.loader.handle_dict[handle] = dic
     check_and_notify_protocols(ql)
+    write_int64(ql, params["Handle"], handle)
     return EFI_SUCCESS
 
 @dxeapi(params={
@@ -434,6 +437,8 @@ def hook_LocateProtocol(ql, address, params):
     "Handle": POINTER})
 def hook_InstallMultipleProtocolInterfaces(ql, address, params):
     handle = read_int64(ql, params["Handle"])
+    if handle == 0:
+        handle = ql.loader.heap.alloc(1)
     ql.nprint(f'hook_InstallMultipleProtocolInterfaces {handle:x}')
     dic = {}
     if handle in ql.loader.handle_dict:
@@ -449,6 +454,7 @@ def hook_InstallMultipleProtocolInterfaces(ql, address, params):
         index +=2
     ql.loader.handle_dict[handle] = dic
     check_and_notify_protocols(ql)
+    write_int64(ql, params["Handle"], handle)
     return EFI_SUCCESS
 
 @dxeapi(params={

--- a/qiling/os/uefi/shutdown.py
+++ b/qiling/os/uefi/shutdown.py
@@ -12,8 +12,9 @@ def hook_EndOfExecution(ql):
         ql.nprint(f'No more modules to run')
         ql.emu_stop()
     else:
-        path, entry_point, pe = ql.loader.modules.pop(0)
+        path, image_base, entry_point, pe = ql.loader.modules.pop(0)
         ql.stack_push(ql.loader.end_of_execution_ptr)
+        ql.reg.rcx = image_base
         ql.reg.rdx = ql.loader.system_table_ptr
         ql.nprint(f'Running {path} module entrypoint: 0x{entry_point:x}')
         ql.reg.arch_pc = entry_point


### PR DESCRIPTION
- Dereference the `Handle` parameter passed to `Install(Multiple)ProtocolInterface(s)`.
- Pass a valid `EFI_HANDLE` to the module's initialization routine.
- Make sure no module will occupy the NULL page.
- Correctly handle the case where the `EFI_HANDLE` passed to Install(Multiple)ProtocolInterface(s) is NULL.