### PR TITLE
Fix improper calls to read_cstring and argument check in _LCMapString

### DIFF
--- a/qiling/os/windows/dlls/kernel32/winbase.py
+++ b/qiling/os/windows/dlls/kernel32/winbase.py
@@ -248,7 +248,7 @@ def hook_lstrcatA(ql, address, params):
     # Copy String2 into String
     src = params["lpString2"]
     pointer = params["lpString1"]
-    string_base = read_cstring(ql, pointer)
+    string_base = ql.os.read_cstring(pointer)
     params["lpString1"] = string_base
     result = string_base + src + "\x00"
     ql.mem.write(pointer, result.encode())

--- a/qiling/os/windows/dlls/kernel32/winnls.py
+++ b/qiling/os/windows/dlls/kernel32/winnls.py
@@ -96,7 +96,7 @@ def _LCMapString(ql, address, params):
     cchDest = params["cchDest"]
     result = (params["lpSrcStr"] + "\x00").encode("utf-16le")
     dst = params["lpDestStr"]
-    if cchDest != 0:
+    if cchDest != 0 and dst != 0:
         # TODO maybe do some other check, for now is working
         ql.mem.write(dst, result)
     return len(result)

--- a/qiling/os/windows/dlls/shlwapi.py
+++ b/qiling/os/windows/dlls/shlwapi.py
@@ -51,7 +51,7 @@ def hook_PathFindExtensionW(ql, address, params):
 def hook_PathFindFileNameA(ql, address, params):
     # Must return the address of the start of the filename
     pointer = params["pszPath"]
-    pathname = read_cstring(ql, pointer)
+    pathname = ql.os.read_cstring(pointer)
     params["pszPath"] = pathname
     size_before_last_slash = len("".join(pathname.split("\\")[:-1])) + pathname.count("\\")
     pointer_start = pointer + size_before_last_slash

--- a/qiling/os/windows/dlls/user32.py
+++ b/qiling/os/windows/dlls/user32.py
@@ -563,7 +563,7 @@ def hook_CharNextW(ql, address, params):
 def hook_CharNextA(ql, address, params):
     # Return next char if is different from \x00
     point = params["lpsz"][0]
-    string = read_cstring(ql, point)
+    string = ql.os.read_cstring(point)
     params["lpsz"] = string
     if len(string) == 0:
         return point
@@ -604,9 +604,9 @@ def hook_CharPrevW(ql, address, params):
 def hook_CharPrevA(ql, address, params):
     # Return next char if is different from \x00
     current = params["lpszCurrent"]
-    strcur = read_cstring(ql, current)
+    strcur = ql.os.read_cstring(current)
     start = params["lpszStart"]
-    strstart = read_cstring(ql, start)
+    strstart = ql.os.read_cstring(start)
     params["lpszStart"] = strstart
     params["lpszCurrent"] = strcur
 


### PR DESCRIPTION
It seems some calls to `read_cstring` are made incorrectly.
I also pushed a fix for some invalid memory writes that could happen in `_LCMapString`.