### PR TITLE
Fix a broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Qemu usermode does similar thing to our emulator, that is to emulate whole execu
 ---
 
 #### Installation
-Please see [setup guide](https://docs.qiling.io/en/latest/getting_started/) file for how to install Qiling Framework.
+Please see [setup guide](https://docs.qiling.io/en/latest/howto/) file for how to install Qiling Framework.
 
 ---
 


### PR DESCRIPTION
I noticed that https://docs.qiling.io/en/latest/getting_started/ is broken and should be replaced with https://docs.qiling.io/en/latest/howto/