### PR TITLE
Align PE image size on a 4KiB boundary

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -326,7 +326,7 @@ class QlLoaderPE(QlLoader, Process):
             self.pe = pefile.PE(self.path, fast_load=True)
             # for simplicity, no image base relocation
             self.pe_image_address = self.pe.OPTIONAL_HEADER.ImageBase
-            self.pe_image_address_size = self.ql.os.heap._align(self.pe.OPTIONAL_HEADER.SizeOfImage, 0x1000)
+            self.pe_image_address_size = self.ql.mem.align(self.pe.OPTIONAL_HEADER.SizeOfImage, 0x1000)
 
             if self.pe_image_address + self.pe_image_address_size > self.ql.os.heap_base_address:
                 # pe reloc

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -325,19 +325,18 @@ class QlLoaderPE(QlLoader, Process):
             
             self.pe = pefile.PE(self.path, fast_load=True)
             # for simplicity, no image base relocation
-            self.pe_image_address = self.pe_image_address = self.pe.OPTIONAL_HEADER.ImageBase
-            self.pe_image_address_size = self.pe_image_address_size = self.pe.OPTIONAL_HEADER.SizeOfImage
+            self.pe_image_address = self.pe.OPTIONAL_HEADER.ImageBase
+            self.pe_image_address_size = self.ql.os.heap._align(self.pe.OPTIONAL_HEADER.SizeOfImage, 0x1000)
 
             if self.pe_image_address + self.pe_image_address_size > self.ql.os.heap_base_address:
                 # pe reloc
-                self.pe_image_address = self.pe_image_address = self.image_address
+                self.pe_image_address = self.image_address
                 self.pe.relocate_image(self.image_address)
 
             self.entry_point = self.pe_entry_point = self.pe_image_address + self.pe.OPTIONAL_HEADER.AddressOfEntryPoint
             self.sizeOfStackReserve = self.pe.OPTIONAL_HEADER.SizeOfStackReserve
             self.ql.nprint("[+] Loading %s to 0x%x" % (self.path, self.pe_image_address))
             self.ql.nprint("[+] PE entry point at 0x%x" % self.entry_point)
-
 
             # Stack should not init at the very bottom. Will cause errors with Dlls
             sp = self.stack_address + self.stack_size - 0x1000


### PR DESCRIPTION
`self.pe.OPTIONAL_HEADER.SizeOfImage` might not be a multiple of the page size (which is 4096 bytes on Windows).  
This commit fixes failing calls to `uc_mem_map` that would return `UC_ERR_ARG` for some executables.  
I'm not sure that this commit has side effects but  I'll wait for the reviews.