### PR TITLE
gdbserver: fix read file length

### DIFF
--- a/qiling/debugger/gdbserver/gdbserver.py
+++ b/qiling/debugger/gdbserver/gdbserver.py
@@ -624,7 +624,7 @@ class GDBSERVERsession(object):
                                 self.send('F1;\x00')
 
                         elif count > 1:
-                            self.send(b'F' + (str(hex(count)[2:]).encode()) + b';' + (read_offset))
+                            self.send(("F%x;" % len(read_offset)).encode() + (read_offset))
 
                         else:
                             self.send("F0;")


### PR DESCRIPTION
According to [GDB protocol](https://sourceware.org/gdb/current/onlinedocs/gdb/Host-I_002fO-Packets.html), the `vFile:pread` command should return the data length. Now Qiling return the buffer length from gdb client request. It will crash the client in some cases.

Test case：

```sh
qltool run -f examples/rootfs/arm_linux/bin/arm_hello_static \
  --rootfs examples/rootfs/arm_linux --gdb 127.0.0.1:9999
```

Attach from another terminal:

```
$ gdb-multiarch examples/rootfs/arm_linux/bin/arm_hello_static

> target remote :9999
> remote get /bin/arm_hello_static test
Read returned 16661, but 16383 bytes.
```
