### PR TITLE
Adding abstractmethod to Arch

### DIFF
--- a/qiling/arch/arch.py
+++ b/qiling/arch/arch.py
@@ -3,9 +3,10 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 # Built on top of Unicorn emulator (www.unicorn-engine.org) 
 
+from abc import ABC, abstractmethod
 import struct
 
-class QlArch:
+class QlArch(ABC):
     def __init__(self, ql):
         self.ql = ql
 
@@ -16,66 +17,79 @@ class QlArch:
 
 
     # push value to stack
+    @abstractmethod
     def stack_push(self, value):
         pass
 
 
     # pop value to stack
+    @abstractmethod
     def stack_pop(self):
         pass
 
 
     # write stack value
+    @abstractmethod
     def stack_write(self, value, data):
         pass
 
 
     #  read stack value
+    @abstractmethod
     def stack_read(self, value):
         pass
 
 
     # set PC
+    @abstractmethod
     def set_pc(self, value):
         pass
 
 
     # get PC
+    @abstractmethod
     def get_pc(self):
         pass
 
 
     # set stack pointer
+    @abstractmethod
     def set_sp(self, value):
         pass
 
 
     # get stack pointer
+    @abstractmethod
     def get_sp(self):
         pass
 
 
     # get stack pointer register
+    @abstractmethod
     def get_name_sp(self):
         pass
 
 
     # get PC register
+    @abstractmethod
     def get_name_pc(self):
         pass
 
 
     # get PC register
+    @abstractmethod
     def get_reg_table(self):
         pass
 
 
     # get register name
+    @abstractmethod
     def get_reg_name_str(self):
         pass
 
 
     # set register name
+    @abstractmethod
     def set_reg_name_str(self, uc_reg):
         pass
    
@@ -98,4 +112,4 @@ class QlArch:
 
     # Unicorn's CPU state restore method
     def context_restore(self, saved_context):
-        self.ql.uc.context_restore(saved_context)        
+        self.ql.uc.context_restore(saved_context)


### PR DESCRIPTION
Arch is an inherited class, some default methods need to be implemented by the deriving architecture, those methods are now labeled with @abstractmethod decorator.