### PR TITLE
convert ql.heap to ql.os.heap

### DIFF
--- a/qiling/os/windows/dlls/ntdll.py
+++ b/qiling/os/windows/dlls/ntdll.py
@@ -222,7 +222,7 @@ def hook_LdrGetProcedureAddress(ql, address, params):
     "Size": SIZE_T
 })
 def hook_RtlAllocateHeap(ql, address, params):
-    ret = ql.heap.alloc(params["Size"])
+    ret = ql.os.heap.alloc(params["Size"])
     return ret
 
 

--- a/qiling/os/windows/dlls/wsock32.py
+++ b/qiling/os/windows/dlls/wsock32.py
@@ -87,7 +87,7 @@ def hook_gethostbyname(ql, address, params):
     name_ptr = params["name"]
     params["name"] = ql.os.read_cstring(name_ptr)
     hostnet = Hostent(ql, name_ptr, 0, 2, 4, ip)
-    hostnet_addr = ql.heap.alloc(hostnet.size)
+    hostnet_addr = ql.os.heap.alloc(hostnet.size)
     hostnet.write(hostnet_addr)
 
     return hostnet_addr


### PR DESCRIPTION
**gethostbyname** and **RtlAllocateHeap** were still using `ql.heap` and I changed it to `ql.os.heap`