### PR TITLE
use space for nprint seperator as default option

### DIFF
--- a/qiling/core_utils.py
+++ b/qiling/core_utils.py
@@ -62,9 +62,9 @@ class QLCoreUtils(object):
                             each_console_handler.removeFilter(each_filter)
             
             if isinstance(args, tuple) or isinstance(args, list):
-                msg = "".join(args)
+                msg = kw.get("sep", " ").join(args)
             else:
-                msg = "".join(str(args))
+                msg = kw.get("sep", " ").join(str(args))
 
             if kw.get("end", None) != None:
                 msg += kw["end"]


### PR DESCRIPTION
as title.
so we can use ql.nprint(1, 2, 3, 4) now.