### PR TITLE
support for architecture-specific IoT program

### DIFF
--- a/qiling/loader/utils.py
+++ b/qiling/loader/utils.py
@@ -43,12 +43,11 @@ def ql_elf_check_archtype(path):
         osabi = ident[0x7]
         e_machine = ident[0x12:0x14]
 
-        if osabi == 0x11 or osabi == 0x03 or osabi == 0x0:
-            ostype = QL_OS.LINUX
-        elif osabi == 0x09:
+        if osabi == 0x09:
             ostype = QL_OS.FREEBSD
         else:
-            ostype = None
+        #if osabi == 0x11 or osabi == 0x03 or osabi == 0x0:
+            ostype = QL_OS.LINUX
 
         if e_machine == b"\x03\x00":
             archendian = QL_ENDIAN.EL


### PR DESCRIPTION
some malware binary built for uncommon IoT operation system (ARM+Linux) but osabi (ident[7]) might be 64 ~ 255. I face a Mirai varieties with osabi = 0x97. I think detect magic of ELF header is stable enough to assert it's a ELF file.

ref: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html#elfid