### PR TITLE
Move the creation of a disassembler to a new function

### DIFF
--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -199,9 +199,8 @@ class QLOsUtils:
         # we want to rewrite the return address to the function
         self.ql.stack_write(0, start)
 
-    def disassembler(self, ql, address, size):
-        tmp = self.ql.mem.read(address, size)
 
+    def create_disassembler(self):
         if self.ql.archtype == QL_ARCH.ARM:  # QL_ARM
             reg_cpsr = self.ql.reg.cpsr
             mode = CS_MODE_ARM
@@ -237,6 +236,13 @@ class QLOsUtils:
 
         else:
             raise QlErrorArch("[!] Unknown arch defined in utils.py (debug output mode)")
+
+        return md
+
+    def disassembler(self, ql, address, size):
+        tmp = self.ql.mem.read(address, size)
+
+        md = self.create_disassembler()
 
         insn = md.disasm(tmp, address)
         opsize = int(size)


### PR DESCRIPTION
This makes it easier when using qiling to create a disassembler for the correct architecture,
without the need of having to copy that code into your own project.
