### PR TITLE
Adding DLL images for PE coverage logging.

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -96,6 +96,9 @@ class Process():
         # add dll to ldr data
         self.add_ldr_data_table_entry(dll_name)
 
+        # add DLL to coverage images
+        self.images.append(self.coverage_image(dll_base, dll_base+dll_len, path))
+
         self.ql.nprint("[+] Done with loading %s" % path)
         
         return dll_base


### PR DESCRIPTION
We also want to track DLLs when tracing Portable Executables. If you need anything else added to this please let me know!