### PR TITLE
Fix GDB Truncated register 59 in remote 'g' packet (Close #388)

### DIFF
--- a/qiling/extensions/debugger/gdbserver/gdbserver.py
+++ b/qiling/extensions/debugger/gdbserver/gdbserver.py
@@ -172,7 +172,7 @@ class GDBSERVERsession(object):
                 elif self.ql.archtype == QL_ARCH.ARM:
                     mode = self.ql.arch.check_thumb()
                     
-                    for reg in self.tables[QL_ARCH.ARM]:
+                    for reg in self.tables[QL_ARCH.ARM][:17]:
                         r = self.ql.reg.read(reg)
                         if mode == UC_MODE_THUMB and reg == "pc":
                             r += 1
@@ -181,13 +181,13 @@ class GDBSERVERsession(object):
                         s += tmp
 
                 elif self.ql.archtype== QL_ARCH.ARM64:
-                    for reg in self.tables[QL_ARCH.ARM64]:
+                    for reg in self.tables[QL_ARCH.ARM64][:33]:
                         r = self.ql.reg.read(reg)
                         tmp = self.ql.arch.addr_to_str(r)
                         s += tmp
 
                 elif self.ql.archtype== QL_ARCH.MIPS:
-                    for reg in self.tables[QL_ARCH.MIPS]:
+                    for reg in self.tables[QL_ARCH.MIPS][:38]:
                         r = self.ql.reg.read(reg)
                         if self.ql.archendian == QL_ENDIAN.EB:
                             tmp = self.ql.arch.addr_to_str(r, endian ="little")


### PR DESCRIPTION
This modification works for me (debugging arm binaries) but arm64 and mips are untested, I added things according to 4a05e020a90265f238db9ef77abed0352a9f463a but I'm not familiar with the internals... 😅 it just works..

Fix #388 