### PR TITLE
fix Cs module lost when debugging in fuzzing example

### DIFF
--- a/examples/fuzzing/fuzz_x8664_linux.py
+++ b/examples/fuzzing/fuzz_x8664_linux.py
@@ -19,7 +19,7 @@ unicornafl.monkeypatch()
 import sys, os
 from binascii import hexlify
 
-from capstone.x86_const import *
+from capstone import *
 
 sys.path.append("../..")
 from qiling import *


### PR DESCRIPTION
When debugging with the -t argument,  the script fails to run, and it said that name 'Cs' is not defined.
`Traceback (most recent call last):
  File "./fuzz_x8664_linux.py", line 154, in <module>
    main(sys.argv[2], enable_trace=True)
  File "./fuzz_x8664_linux.py", line 116, in main
    md = Cs(CS_ARCH_X86, CS_MODE_64)
NameError: name 'Cs' is not defined
`
The Cs module and some others also need to be imported from the capstone,  so I change the capstone import code