### PR TITLE
Fix: ql_syscall_wait4 wstatus may be null

### DIFF
--- a/qiling/os/posix/syscall/wait.py
+++ b/qiling/os/posix/syscall/wait.py
@@ -14,7 +14,8 @@ from qiling.utils import *
 
 def ql_syscall_wait4(ql, wait4_pid, wait4_wstatus, wait4_options, wait4_rusage, *args, **kw):
     spid, status, rusage = os.wait4(wait4_pid, wait4_options)
-    ql.mem.write(wait4_wstatus, ql.pack32(status))
+    if wait4_wstatus != 0:
+        ql.mem.write(wait4_wstatus, ql.pack32(status))
     regreturn = spid
     ql.nprint("wait4(%d, %d) = %d"% (wait4_pid, wait4_options, regreturn))
     ql.os.definesyscall_return(regreturn)


### PR DESCRIPTION
man wait4:

> Similarly, the following wait4() call:
> 
>        wait4(pid, wstatus, options, rusage);
> 
> is equivalent to:
> 
>        waitpid(pid, wstatus, options);

man waitpid:
> If wstatus is not NULL, wait() and waitpid() store status information in the int to which it points.