### PR TITLE
fix debug_print_stack method parameter inconsistency

### DIFF
--- a/qiling/os/windows/utils.py
+++ b/qiling/os/windows/utils.py
@@ -35,7 +35,7 @@ def debug_print_stack(ql, num, message=None):
     if message:
         ql.dprint(D_INFO, "========== %s ==========" % message)
         sp = ql.reg.arch_sp
-        ql.dprint(D_INFO, hex(sp + ql.pointersize * i) + ": " + hex(ql.stack_read(i * ql.pointersize)))
+        ql.dprint(D_INFO, hex(sp + ql.pointersize * num) + ": " + hex(ql.stack_read(num * ql.pointersize)))
 
 
 def is_file_library(string):


### PR DESCRIPTION
The original local variable i is not correct in debug_print_stack_method.