### PR TITLE
Let Linux run with Windows!

### DIFF
--- a/qiling/os/posix/const_mapping.py
+++ b/qiling/os/posix/const_mapping.py
@@ -117,7 +117,7 @@ def ql_open_flag_mapping(ql, flags):
         'O_APPEND': 8,
         'O_ASYNC': 2, # Windows doesn't have a corresponding one, assume RW
         'O_SYNC': 2, # Windows doesn't have a corresponding one, assume RW
-        'O_NOFOLLOW': 8, # Windows doesn't have a corresponding one, assume RW
+        'O_NOFOLLOW': 2, # Windows doesn't have a corresponding one, assume RW
         'O_CREAT': 256,
         'O_TRUNC': 512,
         'O_EXCL': 1024,

--- a/qiling/os/posix/const_mapping.py
+++ b/qiling/os/posix/const_mapping.py
@@ -37,7 +37,7 @@ def ql_open_flag_mapping(ql, flags):
     def flag_mapping(flags, mapping_name, mapping_from, mapping_to):
         ret = 0
         for n in mapping_name:
-            if mapping_from[n] & (flags & mapping_from[n]) == mapping_from[n]:
+            if  (flags & mapping_from[n]) == mapping_from[n]:
                 ret = ret | mapping_to[n]
         return ret
 

--- a/qiling/os/posix/const_mapping.py
+++ b/qiling/os/posix/const_mapping.py
@@ -37,7 +37,7 @@ def ql_open_flag_mapping(ql, flags):
     def flag_mapping(flags, mapping_name, mapping_from, mapping_to):
         ret = 0
         for n in mapping_name:
-            if mapping_from[n] & flags == mapping_from[n]:
+            if mapping_from[n] & (flags & mapping_from[n]) == mapping_from[n]:
                 ret = ret | mapping_to[n]
         return ret
 
@@ -55,6 +55,7 @@ def ql_open_flag_mapping(ql, flags):
         "O_EXCL",
         "O_NOCTTY",
         "O_DIRECTORY",
+        "O_BINARY"
     ]
 
     mac_open_flags = {
@@ -70,7 +71,8 @@ def ql_open_flag_mapping(ql, flags):
         "O_TRUNC": 0x0400,
         "O_EXCL": 0x0800,
         "O_NOCTTY": 0x20000,
-        "O_DIRECTORY": 0x100000
+        "O_DIRECTORY": 0x100000,
+        "O_BINARY": 0
     }
 
     linux_open_flags = {
@@ -86,7 +88,8 @@ def ql_open_flag_mapping(ql, flags):
         'O_TRUNC': 512,
         'O_EXCL': 128,
         'O_NOCTTY': 256,
-        'O_DIRECTORY': 65536
+        'O_DIRECTORY': 65536,
+        'O_BINARY': 0
     }
 
     mips_open_flags = {
@@ -103,6 +106,24 @@ def ql_open_flag_mapping(ql, flags):
         'O_EXCL': 0x400,
         'O_NOCTTY': 0x800,
         'O_DIRECTORY': 0x100000,
+        'O_BINARY' : 0
+    }
+
+    windows_open_flags = {
+        'O_RDONLY': 0,
+        'O_WRONLY': 1,
+        'O_RDWR': 2,
+        'O_NONBLOCK': 2, # Windows doesn't have a corresponding one, assume RW
+        'O_APPEND': 8,
+        'O_ASYNC': 2, # Windows doesn't have a corresponding one, assume RW
+        'O_SYNC': 2, # Windows doesn't have a corresponding one, assume RW
+        'O_NOFOLLOW': 8, # Windows doesn't have a corresponding one, assume RW
+        'O_CREAT': 256,
+        'O_TRUNC': 512,
+        'O_EXCL': 1024,
+        'O_NOCTTY': 2,
+        'O_DIRECTORY': 2, # Windows doesn't have a corresponding one, assume RW
+        'O_BINARY': 32768
     }
 
     f = {}
@@ -111,11 +132,17 @@ def ql_open_flag_mapping(ql, flags):
     if ql.archtype != QL_ARCH.MIPS:
         if ql.platform == None or ql.platform == ql.ostype:
             return flags
-        if ql.platform == QL_OS.MACOS and ql.ostype == QL_OS.LINUX:
+        if ql.ostype == QL_OS.LINUX:
             f = linux_open_flags
-            t = mac_open_flags
-        elif ql.platform == QL_OS.LINUX and ql.ostype == QL_OS.MACOS:
+        elif ql.ostype == QL_OS.MACOS:
             f = mac_open_flags
+        elif ql.ostype == QL_OS.WINDOWS:
+            f = windows_open_flags
+        if ql.platform == QL_OS.WINDOWS:
+            t = windows_open_flags
+        elif ql.platform == QL_OS.MACOS:
+            t = mac_open_flags
+        elif ql.platform == QL_OS.LINUX:
             t = linux_open_flags
     elif ql.archtype == QL_ARCH.MIPS and ql.platform == QL_OS.LINUX:
         f = mips_open_flags

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -92,7 +92,7 @@ class QLOsUtils:
             full_relative_path = path
         else:
             full_relative_path = cur_path + "/" + path
-        relative_path = str((Path(rootfs) / path[1:]).relative_to(Path(rootfs)))
+        relative_path = str((Path(rootfs) / full_relative_path[1:]).relative_to(Path(rootfs)))
 
         from_path = None
         to_path = None

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -9,7 +9,7 @@ This module is intended for general purpose functions that are only used in qili
 
 import os, struct, uuid
 from json import dumps
-
+from pathlib import Path
 from unicorn import *
 from unicorn.arm_const import *
 from unicorn.x86_const import *
@@ -79,6 +79,8 @@ class QLOsUtils:
     def transform_to_real_path(self, path):
         from types import FunctionType
 
+        # FIXME: Need a FULL refactor!!!
+
         if self.ql.multithread:
             cur_path = self.ql.os.thread_management.cur_thread.get_current_path()
         else:
@@ -87,9 +89,10 @@ class QLOsUtils:
         rootfs = self.ql.rootfs
 
         if path[0] == '/':
-            relative_path = os.path.abspath(path)
+            full_relative_path = path
         else:
-            relative_path = os.path.abspath(cur_path + '/' + path)
+            full_relative_path = cur_path + "/" + path
+        relative_path = str((Path(rootfs) / path[1:]).relative_to(Path(rootfs)))
 
         from_path = None
         to_path = None
@@ -117,7 +120,7 @@ class QLOsUtils:
         else:
             if rootfs is None:
                 rootfs = ""
-            real_path = os.path.abspath(rootfs + '/' + relative_path)
+            real_path = os.path.abspath(Path(rootfs) /  relative_path)
 
             if os.path.islink(real_path):
                 link_path = os.readlink(real_path)

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -92,7 +92,11 @@ class QLOsUtils:
             full_relative_path = path
         else:
             full_relative_path = cur_path + "/" + path
-        relative_path = str((Path(rootfs) / full_relative_path[1:]).relative_to(Path(rootfs)))
+        
+        if full_relative_path.startswith("//"):
+            relative_path = str((Path(rootfs) / full_relative_path[2:]).relative_to(Path(rootfs)))
+        else:    
+            relative_path = str((Path(rootfs) / full_relative_path[1:]).relative_to(Path(rootfs)))
 
         from_path = None
         to_path = None

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -93,8 +93,11 @@ class QLOsUtils:
         else:
             full_relative_path = cur_path + "/" + path
         
-        if full_relative_path.startswith("//"):
+        # Temporary work around till we got a new path transformer
+        if full_relative_path.startswith("//") and not full_relative_path.count("PHYSICALDRIVE"):
             relative_path = str((Path(rootfs) / full_relative_path[2:]).relative_to(Path(rootfs)))
+        elif full_relative_path.count("PHYSICALDRIVE") and self.ql.ostype == QL_OS.WINDOWS:
+            relative_path = str((Path(rootfs) / full_relative_path[7:]).relative_to(Path(rootfs)))
         else:    
             relative_path = str((Path(rootfs) / full_relative_path[1:]).relative_to(Path(rootfs)))
 


### PR DESCRIPTION
Two bugs are fixed in order to make Linux run on Windows.

1. The transformation between emulated path and real path is a mess

2. open() flags mapping left out Windows

Some refactors need to be done for `transform_to_real_path` and `transform_to_link_path`.