### PR TITLE
Refactor fs mapping

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ This file details the changelog of Qiling Framework.
 - Added Qiling Debugger - Currently only works with MIPS
 - Add experimental 8086 and DOS support.
 - Fix path transformation on Windows when running Linux.
+- Refactor ql.fs_mapper (now ql.os.fs_mapper).
 
 
 ------------------------------------

--- a/examples/hello_x86_linux_fake_urandom.py
+++ b/examples/hello_x86_linux_fake_urandom.py
@@ -4,8 +4,8 @@
 # Built on top of Unicorn emulator (www.unicorn-engine.org) 
 
 from qiling import *
-
-class Fake_urandom:
+from qiling.os.mapper import FsMappedObject
+class Fake_urandom(FsMappedObject):
 
     def read(self, size):
         return b"\x01" # fixed value for reading /dev/urandom

--- a/examples/hello_x86_linux_fake_urandom.py
+++ b/examples/hello_x86_linux_fake_urandom.py
@@ -4,8 +4,8 @@
 # Built on top of Unicorn emulator (www.unicorn-engine.org) 
 
 from qiling import *
-from qiling.os.mapper import FsMappedObject
-class Fake_urandom(FsMappedObject):
+from qiling.os.mapper import QlFsMappedObject
+class Fake_urandom(QlFsMappedObject):
 
     def read(self, size):
         return b"\x01" # fixed value for reading /dev/urandom

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -18,6 +18,7 @@ from .core_struct import QLCoreStructs
 from .core_hooks import QLCoreHooks
 from .core_utils import QLCoreUtils
 from .debugger import ql_debugger_init
+from .os.mapper import FsMapper
 from .__version__ import __version__
 
 class Qiling(QLCoreStructs, QLCoreHooks, QLCoreUtils):    
@@ -73,7 +74,7 @@ class Qiling(QLCoreStructs, QLCoreHooks, QLCoreUtils):
         self.patch_lib = []
         self.patched_lib = []
         self.log_file_fd = None
-        self.fs_mapper = []
+        self.fs_mapper = FsMapper(self)
         self.debug_stop = False
         self.internal_exception = None
         self.platform = platform.system()

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -18,7 +18,6 @@ from .core_struct import QLCoreStructs
 from .core_hooks import QLCoreHooks
 from .core_utils import QLCoreUtils
 from .debugger import ql_debugger_init
-from .os.mapper import FsMapper
 from .__version__ import __version__
 
 class Qiling(QLCoreStructs, QLCoreHooks, QLCoreUtils):    

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -74,7 +74,6 @@ class Qiling(QLCoreStructs, QLCoreHooks, QLCoreUtils):
         self.patch_lib = []
         self.patched_lib = []
         self.log_file_fd = None
-        self.fs_mapper = FsMapper(self)
         self.debug_stop = False
         self.internal_exception = None
         self.platform = platform.system()

--- a/qiling/core_utils.py
+++ b/qiling/core_utils.py
@@ -94,7 +94,7 @@ class QLCoreUtils(object):
 
 
     def add_fs_mapper(self, ql_path, real_dest):
-        self.fs_mapper.add_fs_mapping(ql_path, real_dest)
+        self.os.fs_mapper.add_fs_mapping(ql_path, real_dest)
 
 
     # push to stack bottom, and update stack register

--- a/qiling/core_utils.py
+++ b/qiling/core_utils.py
@@ -94,7 +94,7 @@ class QLCoreUtils(object):
 
 
     def add_fs_mapper(self, ql_path, real_dest):
-        self.fs_mapper.append([ql_path, real_dest])
+        self.fs_mapper.add_fs_mapping(ql_path, real_dest)
 
 
     # push to stack bottom, and update stack register

--- a/qiling/os/filestruct.py
+++ b/qiling/os/filestruct.py
@@ -25,15 +25,11 @@ class ql_file:
     def open(self, open_path, open_flags, open_mode):
         open_mode &= 0x7fffffff
 
-        if isinstance(open_path, str):
-            try:
-                fd = os.open(open_path, open_flags, open_mode)
-            except OSError as e:
-                raise QlSyscallError(e.errno, e.args[1] + ' : ' + e.filename)
-            return self(open_path, fd)
-
-        elif not isinstance(open_path, str):
-            return open_path
+        try:
+            fd = os.open(open_path, open_flags, open_mode)
+        except OSError as e:
+            raise QlSyscallError(e.errno, e.args[1] + ' : ' + e.filename)
+        return self(open_path, fd)
 
     def read(self, read_len):
         return os.read(self.__fd, read_len)

--- a/qiling/os/macos/syscall.py
+++ b/qiling/os/macos/syscall.py
@@ -535,7 +535,7 @@ def ql_syscall_open_nocancel(ql, filename, flags, mode, *args, **kw):
             if ql.archtype== QL_ARCH.ARM:
                 mode = 0
 
-            ql.os.fd[idx] = ql.fs_mapper.open_ql_file(path, flags, mode)
+            ql.os.fd[idx] = ql.os.fs_mapper.open_ql_file(path, flags, mode)
             regreturn = idx
         except:
             regreturn = -1

--- a/qiling/os/macos/syscall.py
+++ b/qiling/os/macos/syscall.py
@@ -518,7 +518,6 @@ def ql_syscall_thread_selfid(ql, *args, **kw):
 # 0x18e
 def ql_syscall_open_nocancel(ql, filename, flags, mode, *args, **kw):
     path = ql.mem.string(filename)
-    real_path = ql.os.transform_to_real_path(path)
     relative_path = ql.os.transform_to_relative_path(path)
 
     flags = flags & 0xffffffff
@@ -536,8 +535,7 @@ def ql_syscall_open_nocancel(ql, filename, flags, mode, *args, **kw):
             if ql.archtype== QL_ARCH.ARM:
                 mode = 0
 
-            flags = open_flags_mapping(flags, ql.archtype)
-            ql.os.fd[idx] = ql_file.open(real_path, flags, mode)
+            ql.os.fd[idx] = ql.fs_mapper.open_ql_file(path, flags, mode)
             regreturn = idx
         except:
             regreturn = -1

--- a/qiling/os/mapper.py
+++ b/qiling/os/mapper.py
@@ -48,7 +48,7 @@ class QlFsMappedObject:
     def name(self):
         raise NotImplementedError("QlFsMappedObject property not implemented: name")
 
-class FsMapper:
+class QlFsMapper:
     
     def __init__(self, ql):
         self._mapping = {}

--- a/qiling/os/mapper.py
+++ b/qiling/os/mapper.py
@@ -58,22 +58,22 @@ class QlFsMapper:
     def ql(self):
         return self._ql
 
-    def _open_mapping_ql_file(self, fm, openflags, openmode):
-        to = self._mapping[fm]
-        if not isinstance(to, str): # We have opened this mapping or it is implemented by user.
-            return to
+    def _open_mapping_ql_file(self, ql_path, openflags, openmode):
+        real_dest = self._mapping[ql_path]
+        if not isinstance(real_dest, str): # We have opened this mapping or it is implemented by user.
+            return real_dest
         else:
-            qlfile = ql_file.open(to, openflags, openmode) # open the path and replace the destination now.
-            self._mapping[fm] = qlfile
+            qlfile = ql_file.open(real_dest, openflags, openmode) # open the path and replace the destination now.
+            self._mapping[ql_path] = qlfile
             return qlfile
     
-    def _open_mapping(self, fm, openmode):
-        to = self._mapping[fm]
-        if not isinstance(to, str):
-            return to
+    def _open_mapping(self, ql_path, openmode):
+        real_dest = self._mapping[ql_path]
+        if not isinstance(real_dest, str):
+            return real_dest
         else:
-            f = open(to, openmode)
-            self._mapping[fm] = f
+            f = open(real_dest, openmode)
+            self._mapping[ql_path] = f
             return f
 
     def has_mapping(self, fm):
@@ -95,13 +95,13 @@ class QlFsMapper:
             real_path = self.ql.os.transform_to_real_path(path)
             return open(real_path, openmode)
 
-    def add_fs_mapping(self, fm, to):
+    def add_fs_mapping(self, ql_path, real_dest):
         # For os.PathLike
         # fm should be always objects which can be converted to a string.
-        fm = str(fm)
-        if '__fspath__' in dir(to): # to is a os.PathLike object.
-            to = to.__fspath__()
-            if isinstance(to, bytes): # os.PathLike.__fspath__ may return bytes.
-                to = to.decode("utf-8")
-        self._mapping[fm] = to
+        ql_path = str(ql_path)
+        if '__fspath__' in dir(real_dest): # real_dest is a os.PathLike object.
+            real_dest = real_dest.__fspath__()
+            if isinstance(real_dest, bytes): # os.PathLike.__fspath__ may return bytes.
+                real_dest = real_dest.decode("utf-8")
+        self._mapping[ql_path] = real_dest
         

--- a/qiling/os/mapper.py
+++ b/qiling/os/mapper.py
@@ -1,0 +1,107 @@
+from .filestruct import ql_file
+from .utils import QLOsUtils
+
+# All mapped object should inherit this class.
+# Note this object is compatible with ql_file
+# Q: Why not derive from ql_file directly?
+# A: ql_file assumes that it holds a path with corresponding fd, but
+#    a FsMappedObejct doesn't have to be associated with a path or fd
+#    and thus the default implementation may cause unexpected behavior.
+#    Simply let it crash if the method is not implemented.
+#
+#    A quick way to create a FsMappedObject is `ql_file.open` or `open`.
+class FsMappedObject:
+    def __init__(self):
+        pass
+    
+    def read(self, expected_len):
+        raise NotImplementedError("FsMappedObject method not implemented: read")
+    
+    def write(self, buffer):
+        raise NotImplementedError("FsMappedObject method not implemented: write")
+    
+    def fileno(self):
+        raise NotImplementedError("FsMappedObject method not implemented: fileno")
+    
+    def lseek(self, lseek_offset, lseek_origin):
+        raise NotImplementedError("FsMappedObject method not implemented: lseek")
+    
+    def close(self):
+        raise NotImplementedError("FsMappedObject method not implemented: close")
+    
+    def fstat(self):
+        raise NotImplementedError("FsMappedObject method not implemented: fstat")
+    
+    def ioctl(self, ioctl_cmd, ioctl_arg):
+        raise NotImplementedError("FsMappedObject method not implemented: ioctl")
+
+    def tell(self):
+        raise NotImplementedError("FsMappedObject method not implemented: tell")
+    
+    def dup(self):
+        raise NotImplementedError("FsMappedObject method not implemented: dup")
+    
+    def readline(self, end = b'\n'):
+        raise NotImplementedError("FsMappedObject method not implemented: readline")
+
+    @property
+    def name(self):
+        raise NotImplementedError("FsMappedObject property not implemented: name")
+
+class FsMapper:
+    
+    def __init__(self, ql):
+        self._mapping = {}
+        self._ql = ql
+    
+    @property
+    def ql(self):
+        return self._ql
+
+    def _open_mapping_ql_file(self, fm, openflags, openmode):
+        to = self._mapping[fm]
+        if not isinstance(to, str): # We have opened this mapping or it is implemented by user.
+            return to
+        else:
+            qlfile = ql_file.open(to, openflags, openmode) # open the path and replace the destination now.
+            self._mapping[fm] = qlfile
+            return qlfile
+    
+    def _open_mapping(self, fm, openmode):
+        to = self._mapping[fm]
+        if not isinstance(to, str):
+            return to
+        else:
+            f = open(to, openmode)
+            self._mapping[fm] = f
+            return f
+
+    def has_mapping(self, fm):
+        return fm in self._mapping
+
+    def open_ql_file(self, path, openflags, openmode):
+        if self.has_mapping(path):
+            self.ql.nrpint(f"mapping {path}")
+            return self._open_mapping_ql_file(path, openflags, openmode)
+        else:
+            real_path = self.ql.os.transform_to_real_path(path)
+            return ql_file.open(real_path, openflags, openmode)
+
+    def open(self, path, openmode):
+        if self.has_mapping(path):
+            self.ql.nrpint(f"mapping {path}")
+            return self._open_mapping(path, openmode)
+        else:
+            real_path = self.ql.os.transform_to_real_path(path)
+            return open(real_path, openmode)
+
+    def add_fs_mapping(self, fm, to):
+        # For os.PathLike
+        # fm should be always objects which can be converted to a string.
+        fm = str(fm)
+        if '__fspath__' in dir(to): # to is a os.PathLike object.
+            to = to.__fspath__()
+            if isinstance(to, bytes): # os.PathLike.__fspath__ may return bytes.
+                to = to.decode("utf-8")
+        self._mapping[fm] = to
+        

--- a/qiling/os/mapper.py
+++ b/qiling/os/mapper.py
@@ -81,7 +81,7 @@ class FsMapper:
 
     def open_ql_file(self, path, openflags, openmode):
         if self.has_mapping(path):
-            self.ql.nrpint(f"mapping {path}")
+            self.ql.nprint(f"mapping {path}")
             return self._open_mapping_ql_file(path, openflags, openmode)
         else:
             real_path = self.ql.os.transform_to_real_path(path)

--- a/qiling/os/mapper.py
+++ b/qiling/os/mapper.py
@@ -1,12 +1,12 @@
 from .filestruct import ql_file
 from .utils import QLOsUtils
 
-# All mapped object should inherit this class.
-# Note this object is compatible with ql_file
+# All mapped objects should inherit this class.
+# Note this object is compatible with ql_file.
 # Q: Why not derive from ql_file directly?
-# A: ql_file assumes that it holds a path with corresponding fd, but
-#    a FsMappedObejct doesn't have to be associated with a path or fd
-#    and thus the default implementation may cause unexpected behavior.
+# A: ql_file assumes that it holds a path with a corresponding fd, but
+#    a QlFsMappedObject doesn't have to be associated with a path or fd
+#    and thus the default implementation may cause unexpected behaviors.
 #    Simply let it crash if the method is not implemented.
 #
 #    A quick way to create a QlFsMappedObject is `ql_file.open` or `open`.

--- a/qiling/os/mapper.py
+++ b/qiling/os/mapper.py
@@ -9,44 +9,44 @@ from .utils import QLOsUtils
 #    and thus the default implementation may cause unexpected behavior.
 #    Simply let it crash if the method is not implemented.
 #
-#    A quick way to create a FsMappedObject is `ql_file.open` or `open`.
-class FsMappedObject:
+#    A quick way to create a QlFsMappedObject is `ql_file.open` or `open`.
+class QlFsMappedObject:
     def __init__(self):
         pass
     
     def read(self, expected_len):
-        raise NotImplementedError("FsMappedObject method not implemented: read")
+        raise NotImplementedError("QlFsMappedObject method not implemented: read")
     
     def write(self, buffer):
-        raise NotImplementedError("FsMappedObject method not implemented: write")
+        raise NotImplementedError("QlFsMappedObject method not implemented: write")
     
     def fileno(self):
-        raise NotImplementedError("FsMappedObject method not implemented: fileno")
+        raise NotImplementedError("QlFsMappedObject method not implemented: fileno")
     
     def lseek(self, lseek_offset, lseek_origin):
-        raise NotImplementedError("FsMappedObject method not implemented: lseek")
+        raise NotImplementedError("QlFsMappedObject method not implemented: lseek")
     
     def close(self):
-        raise NotImplementedError("FsMappedObject method not implemented: close")
+        raise NotImplementedError("QlFsMappedObject method not implemented: close")
     
     def fstat(self):
-        raise NotImplementedError("FsMappedObject method not implemented: fstat")
+        raise NotImplementedError("QlFsMappedObject method not implemented: fstat")
     
     def ioctl(self, ioctl_cmd, ioctl_arg):
-        raise NotImplementedError("FsMappedObject method not implemented: ioctl")
+        raise NotImplementedError("QlFsMappedObject method not implemented: ioctl")
 
     def tell(self):
-        raise NotImplementedError("FsMappedObject method not implemented: tell")
+        raise NotImplementedError("QlFsMappedObject method not implemented: tell")
     
     def dup(self):
-        raise NotImplementedError("FsMappedObject method not implemented: dup")
+        raise NotImplementedError("QlFsMappedObject method not implemented: dup")
     
     def readline(self, end = b'\n'):
-        raise NotImplementedError("FsMappedObject method not implemented: readline")
+        raise NotImplementedError("QlFsMappedObject method not implemented: readline")
 
     @property
     def name(self):
-        raise NotImplementedError("FsMappedObject property not implemented: name")
+        raise NotImplementedError("QlFsMappedObject property not implemented: name")
 
 class FsMapper:
     

--- a/qiling/os/mapper.py
+++ b/qiling/os/mapper.py
@@ -89,7 +89,7 @@ class FsMapper:
 
     def open(self, path, openmode):
         if self.has_mapping(path):
-            self.ql.nrpint(f"mapping {path}")
+            self.ql.nprint(f"mapping {path}")
             return self._open_mapping(path, openmode)
         else:
             real_path = self.ql.os.transform_to_real_path(path)

--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -8,7 +8,7 @@ import os, sys, types
 from .utils import QLOsUtils
 from .const import *
 from .filestruct import ql_file
-from .mapper import FsMapper
+from .mapper import QlFsMapper
 
 from qiling.const import *
 
@@ -17,7 +17,7 @@ class QlOs(QLOsUtils):
         super(QlOs, self).__init__(ql)
         self.ql = ql
         self.ql.uc = self.ql.arch.init_uc
-        self.fs_mapper = FsMapper(ql)
+        self.fs_mapper = QlFsMapper(ql)
         self.child_processes = False
         self.thread_management = None
         self.current_path = '/'

--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -8,6 +8,7 @@ import os, sys, types
 from .utils import QLOsUtils
 from .const import *
 from .filestruct import ql_file
+from .mapper import FsMapper
 
 from qiling.const import *
 
@@ -16,6 +17,7 @@ class QlOs(QLOsUtils):
         super(QlOs, self).__init__(ql)
         self.ql = ql
         self.ql.uc = self.ql.arch.init_uc
+        self.fs_mapper = FsMapper(ql)
         self.child_processes = False
         self.thread_management = None
         self.current_path = '/'

--- a/qiling/os/posix/syscall/fcntl.py
+++ b/qiling/os/posix/syscall/fcntl.py
@@ -35,7 +35,7 @@ def ql_syscall_open(ql, filename, flags, mode, *args, **kw):
                 mode = 0
 
             flags = ql_open_flag_mapping(ql, flags)
-            ql.os.fd[idx] = ql.fs_mapper.open_ql_file(path, flags, mode)
+            ql.os.fd[idx] = ql.os.fs_mapper.open_ql_file(path, flags, mode)
             regreturn = idx
         except QlSyscallError as e:
             regreturn = - e.errno
@@ -75,7 +75,7 @@ def ql_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, *ar
                 mode = 0
 
             openat_flags = ql_open_flag_mapping(ql, openat_flags)
-            ql.os.fd[idx] = ql.fs_mapper.open_ql_file(openat_path, openat_flags, openat_mode)
+            ql.os.fd[idx] = ql.os.fs_mapper.open_ql_file(openat_path, openat_flags, openat_mode)
             regreturn = idx
         except:
             regreturn = -1

--- a/qiling/os/posix/syscall/fcntl.py
+++ b/qiling/os/posix/syscall/fcntl.py
@@ -35,7 +35,7 @@ def ql_syscall_open(ql, filename, flags, mode, *args, **kw):
                 mode = 0
 
             flags = ql_open_flag_mapping(ql, flags)
-            ql.os.fd[idx] = ql_file.open(real_path, flags, mode)
+            ql.os.fd[idx] = ql.fs_mapper.open_ql_file(path, flags, mode)
             regreturn = idx
         except QlSyscallError as e:
             regreturn = - e.errno
@@ -75,7 +75,7 @@ def ql_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, *ar
                 mode = 0
 
             openat_flags = ql_open_flag_mapping(ql, openat_flags)
-            ql.os.fd[idx] = ql_file.open(real_path, openat_flags, openat_mode)
+            ql.os.fd[idx] = ql.fs_mapper.open_ql_file(path, openat_flags, openat_mode)
             regreturn = idx
         except:
             regreturn = -1

--- a/qiling/os/posix/syscall/fcntl.py
+++ b/qiling/os/posix/syscall/fcntl.py
@@ -75,7 +75,7 @@ def ql_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, *ar
                 mode = 0
 
             openat_flags = ql_open_flag_mapping(ql, openat_flags)
-            ql.os.fd[idx] = ql.fs_mapper.open_ql_file(path, openat_flags, openat_mode)
+            ql.os.fd[idx] = ql.fs_mapper.open_ql_file(openat_path, openat_flags, openat_mode)
             regreturn = idx
         except:
             regreturn = -1

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -136,15 +136,8 @@ class QLOsUtils:
             self.ql.nprint(f"[!] Warning: cur_path doesn't start with a /")
         
         rootfs = self.ql.rootfs
-        real_path, relative_path = self.convert_path(rootfs, cur_path, path)
+        real_path, _ = self.convert_path(rootfs, cur_path, path)
 
-        for ql_path, real_dest in self.ql.fs_mapper:
-            if isinstance(real_dest, str):
-                try:
-                    remains = relative_path.relative_to(Path(real_dest))
-                    real_path = Path(ql_path) / remains
-                except ValueError:
-                    continue
         return str(real_path.absolute())
 
     def transform_to_real_path(self, path):
@@ -160,12 +153,7 @@ class QLOsUtils:
             self.ql.nprint(f"[!] Warning: cur_path must start with /")
 
         rootfs = self.ql.rootfs
-        real_path, relative_path = self.convert_path(rootfs, cur_path, path)
-
-        # TODO: A better design for fs mapping.
-        for ql_path, real_dest in self.ql.fs_mapper:
-            if ql_path == path:
-                return real_dest
+        real_path, _ = self.convert_path(rootfs, cur_path, path)
         
         if os.path.islink(real_path):
             link_path = Path(os.readlink(real_path))
@@ -179,7 +167,6 @@ class QLOsUtils:
             cur_path = self.ql.os.thread_management.cur_thread.get_current_path()
         else:
             cur_path = self.ql.os.current_path
-
 
         return str(Path(cur_path[1:]) / path)
 

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -41,7 +41,6 @@ class PathUtils:
         # cwd and path are pure paths
         cwd = PurePosixPath(cwd[1:])
 
-        # First, convert all slashes to backslashes
         result = None
         # Things are complicated here.
         # See https://docs.microsoft.com/zh-cn/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN

--- a/qiling/os/windows/dlls/kernel32/fileapi.py
+++ b/qiling/os/windows/dlls/kernel32/fileapi.py
@@ -151,7 +151,7 @@ def _CreateFile(ql, address, params, name):
 
     # create thread handle
     try:
-        f = ql.fs_mapper.open(s_lpFileName, mode)
+        f = ql.os.fs_mapper.open(s_lpFileName, mode)
     except FileNotFoundError:
         ql.os.last_error = ERROR_FILE_NOT_FOUND
         return INVALID_HANDLE_VALUE

--- a/qiling/os/windows/dlls/kernel32/fileapi.py
+++ b/qiling/os/windows/dlls/kernel32/fileapi.py
@@ -150,15 +150,8 @@ def _CreateFile(ql, address, params, name):
         mode += "r"
 
     # create thread handle
-    s_lpFileName = ql.os.transform_to_real_path(s_lpFileName)
     try:
-        # For compatibility with fs mapper.
-        # TODO: A better design for fs mapper.
-        # A real mapping layer with transparency and max compatibility.
-        if isinstance(s_lpFileName, str):
-            f = open(s_lpFileName.replace("\\", os.sep), mode)
-        else:
-            f = s_lpFileName
+        f = ql.fs_mapper.open(s_lpFileName, mode)
     except FileNotFoundError:
         ql.os.last_error = ERROR_FILE_NOT_FOUND
         return INVALID_HANDLE_VALUE

--- a/qiling/os/windows/dlls/msvcrt.py
+++ b/qiling/os/windows/dlls/msvcrt.py
@@ -421,8 +421,7 @@ def hook__wfopen_s(ql, address, params):
     dst = params["pFile"]
     filename = params["filename"]
     mode = params["mode"]
-    s_lpFileName = ql.os.transform_to_real_path(filename)
-    f = open(s_lpFileName.replace("\\", os.sep), mode)
+    f = ql.fs_mapper.open(filename, mode)
     new_handle = Handle(obj=f)
     ql.os.handle_manager.append(new_handle)
     ql.mem.write(dst, ql.pack(new_handle.id))

--- a/qiling/os/windows/dlls/msvcrt.py
+++ b/qiling/os/windows/dlls/msvcrt.py
@@ -421,7 +421,7 @@ def hook__wfopen_s(ql, address, params):
     dst = params["pFile"]
     filename = params["filename"]
     mode = params["mode"]
-    f = ql.fs_mapper.open(filename, mode)
+    f = ql.os.fs_mapper.open(filename, mode)
     new_handle = Handle(obj=f)
     ql.os.handle_manager.append(new_handle)
     ql.mem.write(dst, ql.pack(new_handle.id))

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -9,7 +9,7 @@ from qiling import *
 from qiling.const import *
 from qiling.exception import *
 from qiling.os.posix import syscall
-from qiling.os.mapper import FsMappedObject
+from qiling.os.mapper import QlFsMappedObject
 
 class ELFTest(unittest.TestCase):
 
@@ -921,7 +921,7 @@ class ELFTest(unittest.TestCase):
 
 
     def test_x86_fake_urandom(self):
-        class Fake_urandom(FsMappedObject):
+        class Fake_urandom(QlFsMappedObject):
 
             def read(self, size):
                 return b"\x01"

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -9,6 +9,7 @@ from qiling import *
 from qiling.const import *
 from qiling.exception import *
 from qiling.os.posix import syscall
+from qiling.os.mapper import FsMappedObject
 
 class ELFTest(unittest.TestCase):
 
@@ -920,7 +921,7 @@ class ELFTest(unittest.TestCase):
 
 
     def test_x86_fake_urandom(self):
-        class Fake_urandom:
+        class Fake_urandom(FsMappedObject):
 
             def read(self, size):
                 return b"\x01"

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -14,7 +14,7 @@ from qiling.const import *
 from qiling.exception import *
 from qiling.os.windows.fncc import *
 from qiling.os.windows.utils import *
-from qiling.os.mapper import FsMappedObject
+from qiling.os.mapper import QlFsMappedObject
 from unicorn.x86_const import *
 
 class PETest(unittest.TestCase):
@@ -37,7 +37,7 @@ class PETest(unittest.TestCase):
     def test_pe_win_x86_uselessdisk(self):
         if 'QL_FAST_TEST' in os.environ:
             return
-        class Fake_Drive(FsMappedObject):
+        class Fake_Drive(QlFsMappedObject):
 
             def read(self, size):
                 return random.randint(0, 256)

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -14,6 +14,7 @@ from qiling.const import *
 from qiling.exception import *
 from qiling.os.windows.fncc import *
 from qiling.os.windows.utils import *
+from qiling.os.mapper import FsMappedObject
 from unicorn.x86_const import *
 
 class PETest(unittest.TestCase):
@@ -36,7 +37,7 @@ class PETest(unittest.TestCase):
     def test_pe_win_x86_uselessdisk(self):
         if 'QL_FAST_TEST' in os.environ:
             return
-        class Fake_Drive:
+        class Fake_Drive(FsMappedObject):
 
             def read(self, size):
                 return random.randint(0, 256)


### PR DESCRIPTION
## Motivation

In the past, fs mapping is implemented as:

1. When path conversion between emulated systems and hosts happens, we check whether the destination is in our mapper.
2. If the mapped destination is a string, we re-construct the destination path. 
3. If the mapped destination is a user-implemented object, we return the object directly.
4. `ql_file.open` will handle the new destination according to its type.

Here we have several problems:

1. As #446 points out, we return either a string or a user-defined object before, which is rather hacky and ugly.
2. When defining a self-defined mapped object, we never know the exact methods we should implement.
3. The fs mapping doesn't support Windows since it doesn't use `ql_file` internally.

All these problems call for a new, transparent, and universal implementation for fs mapping.

## Implementation

1. Add a `FsMappedObject` so it is clear which interface is required to map a path.
2. Implement a `Fsmapper` to handle all paths we are going to open so we have a chance to check user-defined mappings.
3. Provide a similar trick for Windows `CreateFile`.
4. Remove the code handling fs mapping in `ql_file` since `ql_file` shouldn't be aware of fs mapping details.

The implementation is somewhat experimental since I'm not sure whether it will cause other side-effects.
