### PR TITLE
Change 'file_des' to 'fd' in the example code

### DIFF
--- a/examples/hello_arm_linux_custom_syscall.py
+++ b/examples/hello_arm_linux_custom_syscall.py
@@ -15,7 +15,7 @@ def my_syscall_write(ql, write_fd, write_buf, write_count, *args, **kw):
     try:
         buf = ql.mem.read(write_buf, write_count)
         ql.nprint("\n+++++++++\nmy write(%d,%x,%i) = %d\n+++++++++" % (write_fd, write_buf, write_count, regreturn))
-        ql.os.file_des[write_fd].write(buf)
+        ql.os.fd[write_fd].write(buf)
         regreturn = write_count
     except:
         regreturn = -1

--- a/examples/netgear_6220_mips32el_linux.py
+++ b/examples/netgear_6220_mips32el_linux.py
@@ -18,7 +18,7 @@ from qiling.os.posix import syscall
 
 
 def my_syscall_write(ql, write_fd, write_buf, write_count, *rest):
-    if write_fd == 2 and ql.os.file_des[2].__class__.__name__ == 'ql_pipe':
+    if write_fd == 2 and ql.os.fd[2].__class__.__name__ == 'ql_pipe':
         ql.os.definesyscall_return(-1)
     else:
         syscall.ql_syscall_write(ql, write_fd, write_buf, write_count, *rest)


### PR DESCRIPTION
The 'file_des' member does not exist in the QlOsPosix class. The 'fd' member is incorrectly typed as 'file_des' in example codes.