### PR TITLE
Bugfix/newselect: the timeout parameter is not properly dereferenced

### DIFF
--- a/qiling/os/posix/syscall/select.py
+++ b/qiling/os/posix/syscall/select.py
@@ -42,12 +42,15 @@ def ql_syscall__newselect(ql, _newselect_nfds, _newselect_readfds, _newselect_wr
     tmp_e_fd, tmp_e_map = parse_fd_set(ql, _newselect_nfds, _newselect_exceptfds)
 
     if _newselect_timeout != 0:
-        timeout = ql.unpack32(ql.mem.read(_newselect_timeout, 4))
+        timeout_p = ql.unpack(ql.mem.read(_newselect_timeout, 4))
+        sec = ql.unpack(ql.mem.read(timeout_p, 4))
+        usec = ql.unpack(ql.mem.read(timeout_p+4, 4))
+        timeout_total = sec + float(usec)/1000000
     else:
-        timeout = None
+        timeout_total = None
 
     try:
-        ans = select.select(tmp_r_fd, tmp_w_fd, tmp_e_fd, timeout)
+        ans = select.select(tmp_r_fd, tmp_w_fd, tmp_e_fd, timeout_total)
         regreturn = len(ans[0]) + len(ans[1]) + len(ans[2])
 
         if _newselect_readfds != 0:

--- a/qiling/os/posix/syscall/select.py
+++ b/qiling/os/posix/syscall/select.py
@@ -44,9 +44,9 @@ def ql_syscall__newselect(ql, _newselect_nfds, _newselect_readfds, _newselect_wr
     n = ql.archbit // 8 # 4 for 32-bit , 8 for 64-bit
 
     if _newselect_timeout != 0:
-        timeout_p = ql.unpack(ql.mem.read(_newselect_timeout, n))
-        sec = ql.unpack(ql.mem.read(timeout_p, n))
-        usec = ql.unpack(ql.mem.read(timeout_p + n, n))
+        timeout_ptr = ql.unpack(ql.mem.read(_newselect_timeout, n))
+        sec = ql.unpack(ql.mem.read(timeout_ptr, n))
+        usec = ql.unpack(ql.mem.read(timeout_ptr + n, n))
         timeout_total = sec + float(usec)/1000000
     else:
         timeout_total = None

--- a/qiling/os/posix/syscall/select.py
+++ b/qiling/os/posix/syscall/select.py
@@ -41,10 +41,12 @@ def ql_syscall__newselect(ql, _newselect_nfds, _newselect_readfds, _newselect_wr
     tmp_w_fd, tmp_w_map = parse_fd_set(ql, _newselect_nfds, _newselect_writefds)
     tmp_e_fd, tmp_e_map = parse_fd_set(ql, _newselect_nfds, _newselect_exceptfds)
 
+    n = ql.archbit // 8 # 4 for 32-bit , 8 for 64-bit
+
     if _newselect_timeout != 0:
-        timeout_p = ql.unpack(ql.mem.read(_newselect_timeout, 4))
-        sec = ql.unpack(ql.mem.read(timeout_p, 4))
-        usec = ql.unpack(ql.mem.read(timeout_p+4, 4))
+        timeout_p = ql.unpack(ql.mem.read(_newselect_timeout, n))
+        sec = ql.unpack(ql.mem.read(timeout_p, n))
+        usec = ql.unpack(ql.mem.read(timeout_p + n, n))
         timeout_total = sec + float(usec)/1000000
     else:
         timeout_total = None


### PR DESCRIPTION
Hello,

I found the newselect syscall emulation misses dereferencing the last parameter. The address of the stack is passed to ql_syscall_newselect, while the timeout should be dereferenced from the pointer stored on the stack rather than from the stack directly. The PR should fix it. Please review. Thanks.