### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine
 
-MAINTAINER "Kevin Foo <chbsd64@gmail.com>"
+LABEL Author="Kevin Foo <chbsd64@gmail.com>"
 
 ENV PIP_NO_CACHE_DIR=1
 


### PR DESCRIPTION
Set the Author field of the generated images. This instruction has been deprecated in favor of LABEL.