### PR TITLE
Gitee sync actions

### DIFF
--- a/.github/workflows/giteesync.yml
+++ b/.github/workflows/giteesync.yml
@@ -1,0 +1,15 @@
+name: sync to gitee
+on:
+  push:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: acefei/sync-repo-action@master
+      with:
+        ssh_private_key: ${{ secrets.GITEE_KEY }}
+        target_repo: ssh://git@gitee.com/qilingframework/qiling.git


### PR DESCRIPTION
Github action to sync to gitee. This is one way sync from Github to Gitee. Should add to both master and dev as Gitee will follow Github branch.

Important requirement:

1. Create a secret and name it as GITEE_KEY. Value will be sent offline.