### PR TITLE
Fix #513 Shellcoder don't have filepath

### DIFF
--- a/qiling/os/windows/dlls/kernel32/libloaderapi.py
+++ b/qiling/os/windows/dlls/kernel32/libloaderapi.py
@@ -158,7 +158,7 @@ def hook_GetProcAddress(ql, address, params):
 @winsdkapi(cc=STDCALL, dllname=dllname)
 def hook_LoadLibraryA(ql, address, params):
     lpLibFileName = params["lpLibFileName"]
-    if lpLibFileName == ql.loader.filepath.decode():
+    if not ql.shellcoder and lpLibFileName == ql.loader.filepath.decode():
         # Loading self
         return ql.loader.pe_image_address
     dll_base = ql.loader.load_dll(lpLibFileName.encode())

--- a/qiling/os/windows/dlls/kernel32/libloaderapi.py
+++ b/qiling/os/windows/dlls/kernel32/libloaderapi.py
@@ -74,7 +74,7 @@ def hook_GetModuleFileNameA(ql, address, params):
 
     # GetModuleHandle can return pe_image_address as handle, and GetModuleFileName will try to retrieve it.
     # Pretty much 0 and pe_image_address value should do the same operations
-    if hModule == 0 or hModule == ql.loader.pe_image_address:
+    if not ql.shellcoder and (hModule == 0 or hModule == ql.loader.pe_image_address):
         filename = ql.loader.filepath
         filename_len = len(filename)
         if filename_len > nSize - 1:
@@ -102,7 +102,7 @@ def hook_GetModuleFileNameW(ql, address, params):
     nSize = params["nSize"]
     # GetModuleHandle can return pe_image_address as handle, and GetModuleFileName will try to retrieve it.
     # Pretty much 0 and pe_image_address value should do the same operations
-    if hModule == 0 or hModule == ql.loader.pe_image_address:
+    if not ql.shellcoder and (hModule == 0 or hModule == ql.loader.pe_image_address):
         filename = ql.loader.filepath.decode('ascii').encode('utf-16le')
         filename_len = len(filename)
         if filename_len > nSize - 1:


### PR DESCRIPTION
There is no need for a shellcode to initialize the cmdline, there are 2 solutions for this, It could be resolved with a dummy cmdline name or add another check if pe is a shellcode in every use of ql.loader.filepath in libloaderapi.py. I don't think a dummy cmdline is good for a generic solution.

