### PR TITLE
Add support for fcntl64 F_SETFL and non-blocking sockets

### DIFF
--- a/qiling/os/posix/filestruct.py
+++ b/qiling/os/posix/filestruct.py
@@ -52,6 +52,12 @@ class ql_socket:
     def close(self):
         return os.close(self.__fd)
     
+    def fcntl(self, fcntl_cmd, fcntl_arg):
+        try:
+            return fcntl.fcntl(self.__fd, fcntl_cmd, fcntl_arg)
+        except Exception:
+            pass
+
     def ioctl(self, ioctl_cmd, ioctl_arg):
         try:
             return fcntl.ioctl(self.__fd, ioctl_cmd, ioctl_arg)
@@ -82,8 +88,12 @@ class ql_socket:
         return self.__socket.getpeername()
     
     def accept(self):
-        con, addr = self.__socket.accept()
-        new_ql_socket = ql_socket(con)
+        try:
+            con, addr = self.__socket.accept()
+            new_ql_socket = ql_socket(con)
+        except BlockingIOError:
+            # For support non-blocking sockets
+            return None, None
         return new_ql_socket, addr
     
     def recv(self, recv_len, recv_flags):
@@ -132,6 +142,12 @@ class ql_pipe:
     def close(self):
         return os.close(self.__fd)
     
+    def fcntl(self, fcntl_cmd, fcntl_arg):
+        try:
+            return fcntl.fcntl(self.__fd, fcntl_cmd, fcntl_arg)
+        except Exception:
+            pass
+
     def ioctl(self, ioctl_cmd, ioctl_arg):
         try:
             return fcntl.ioctl(self.__fd, ioctl_cmd, ioctl_arg)

--- a/qiling/os/posix/syscall/fcntl.py
+++ b/qiling/os/posix/syscall/fcntl.py
@@ -117,6 +117,7 @@ def ql_syscall_fcntl64(ql, fcntl_fd, fcntl_cmd, fcntl_arg, null1, null2, null3):
     if fcntl_cmd == F_GETFL:
         regreturn = 2
     elif fcntl_cmd == F_SETFL:
+        ql.os.fd[fcntl_fd].fcntl(fcntl_cmd, fcntl_arg)
         regreturn = 0
     elif fcntl_cmd == F_GETFD:
         regreturn = 2

--- a/qiling/os/posix/syscall/socket.py
+++ b/qiling/os/posix/syscall/socket.py
@@ -220,6 +220,10 @@ def ql_syscall_accept(ql, accept_sockfd, accept_addr, accept_addrlen, *args, **k
         return ret
     try:
         conn, address = ql.os.fd[accept_sockfd].accept()
+        if conn == None:
+            ql.os.definesyscall_return(-1)
+            return
+
         idx = -1
         for i in range(256):
             if ql.os.fd[i] == 0:


### PR DESCRIPTION
This commit adds support for fcntl64 F_SETFL to Qiling. It also allows accept() to support non-blocking sockets.