### PR TITLE
Fix socket sin_family to resolve "Operation not permitted" error

### DIFF
--- a/qiling/os/posix/syscall/socket.py
+++ b/qiling/os/posix/syscall/socket.py
@@ -115,7 +115,7 @@ def ql_syscall_bind(ql, bind_fd, bind_addr, bind_addrlen,  *args, **kw):
     else:
         data = ql.mem.read(bind_addr, bind_addrlen)
 
-    sin_family, = struct.unpack("<h", data[:2])
+    sin_family = struct.unpack("<h", data[:2])[0] or ql.os.fd[bind_fd].family
     port, host = struct.unpack(">HI", data[2:8])
     host = ql_bin_to_ip(host)
 


### PR DESCRIPTION
This fixes the following situation where `sin_family` is specified via `socket`, rather than `sockaddr_in` that is passed into `bind`.

```c
sockaddr_in addr;
addr.sin_addr = inet_addr("192.168.1.1");
addr.sin_port = 80;
sock_fd = socket(AF_INET, SOCK_STREAM, 0);
bind_fd = bind(sock_fd, &addr, sizeof(addr));  # sin_family should be AF_INET, instead of 0
```

If this isn't handled, the above will result in a "Operation not permitted" error.