### PR TITLE
drcov_exact: coverage collection at instruction granularity

### DIFF
--- a/qiling/extensions/coverage/formats/__init__.py
+++ b/qiling/extensions/coverage/formats/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["base", "drcov"]
+__all__ = ["base", "drcov", "drcov_exact"]

--- a/qiling/extensions/coverage/formats/drcov_exact.py
+++ b/qiling/extensions/coverage/formats/drcov_exact.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# 
+# Cross Platform and Multi Architecture Advanced Binary Emulation Framework
+# Built on top of Unicorn emulator (www.unicorn-engine.org) 
+
+from .drcov import QlDrCoverage
+
+class QlDrCoverageExact(QlDrCoverage):
+    """
+    Collects emulated code coverage and formats it in accordance with the DynamoRIO based
+    tool drcov: https://dynamorio.org/dynamorio_docs/page_drcov.html
+
+    The resulting output file can later be imported by coverage visualization tools such
+    as Lighthouse: https://github.com/gaasedelen/lighthouse
+    """
+
+    FORMAT_NAME = "drcov_exact"
+
+    def __init__(self, ql):
+        super().__init__(ql)
+
+    def activate(self):
+        # We treat every instruction as a block on its own.
+        self.bb_callback = self.ql.hook_code(self.block_callback, user_data=self)
+        

--- a/qiling/extensions/coverage/utils.py
+++ b/qiling/extensions/coverage/utils.py
@@ -6,9 +6,19 @@
 from .formats import *
 from contextlib import contextmanager
 
+# Returns subclasses recursively.
+def get_all_subclasses(cls):
+    all_subclasses = []
+
+    for subclass in cls.__subclasses__():
+        all_subclasses.append(subclass)
+        all_subclasses.extend(get_all_subclasses(subclass))
+
+    return all_subclasses
+
 class CoverageFactory():
     def __init__(self):
-        self.coverage_collectors = {subcls.FORMAT_NAME:subcls for subcls in base.QlBaseCoverage.__subclasses__()}
+        self.coverage_collectors = {subcls.FORMAT_NAME:subcls for subcls in get_all_subclasses(base.QlBaseCoverage)}
 
     @property
     def formats(self):


### PR DESCRIPTION
Sometimes, when an exception is generated in the middle of a basic block, block-level coverage might "paint" instructions which weren't really executed.

![image](https://user-images.githubusercontent.com/8438963/94098502-6a63cf00-fe31-11ea-8111-b9cb478222a9.png)

This PR introduces a coverage collector which works at instruction granularity, hence it is more accurate:

![image](https://user-images.githubusercontent.com/8438963/94098651-c890b200-fe31-11ea-9326-6941cc363801.png)

