### PR TITLE
Fixed memory writes from GDB

### DIFF
--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -331,7 +331,7 @@ class QlGdb(QlDebugger, object):
                 addr, data = subcmd.split(',')
                 size, data = data.split(':')
                 addr = int(addr, 16)
-                data = int(data, 16)
+                data = bytes.fromhex(data)
                 try:
                     self.ql.mem.write(addr, data)
                     self.send('OK')


### PR DESCRIPTION
Small bugfix. Memory writes from gdb don't currently work, because the server tries to interpret the address AND the data as an integer. This is fixed by converting the data (a hexadecimal string) into bytes.