### PR TITLE
Implement futex bitset && Check library initialization

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ This file details the changelog of Qiling Framework.
 ------------------------------------
 [Version 1.2]: October [SOMETHING], 2020
 - Demigod finally arrived, more information about [Demigod](https://groundx.io/demigod/)
+- Linux: Implement futex bitset && Check library initialization
 
 
 ------------------------------------

--- a/qiling/os/linux/futex.py
+++ b/qiling/os/linux/futex.py
@@ -6,26 +6,39 @@
 class QlLinuxFutexManagement:
     def __init__(self):
         self.wait_list = {}
+
+    FUTEX_BITSET_MATCH_ANY = 0xffffffff
     
-    def futex_wait(self, uaddr, t):
+    def futex_wait(self, ql, uaddr, t, val, bitset=FUTEX_BITSET_MATCH_ANY):
         # self.wait_list.append(uaddr, t)
+        if ql.unpack32(ql.mem.read(uaddr, 4)) != val:
+            return -1
+        ql.emu_stop()
         if uaddr not in self.wait_list.keys():
             self.wait_list[uaddr] = []
-        self.wait_list[uaddr].append(t)
+        self.wait_list[uaddr].append({'bitset': bitset, 'thread': t})
         t.blocking()
         t.set_blocking_condition(None, None)
+        return 0
     
-    def futex_wake(self, uaddr, number):
+    def futex_wake(self, uaddr, number, bitset=FUTEX_BITSET_MATCH_ANY):
         if uaddr not in self.wait_list.keys():
-            return -1
+            return 0
         
         if number > len(self.wait_list[uaddr]):
             number = len(self.wait_list[uaddr])
 
-        for i in range(number):
-            self.wait_list[uaddr][i].running()
-            
-        self.wait_list[uaddr] = self.wait_list[uaddr][number : ]
+        wake_list = []
+        for ind, t in enumerate(self.wait_list[uaddr]):
+            if t['bitset'] & bitset:
+                t['thread'].running()
+                wake_list.append(ind)
+            if len(wake_list) >= number:
+                break
+        # remove waked thread
+        while wake_list:
+            self.wait_list[uaddr].pop(wake_list.pop())
 
         if self.wait_list[uaddr] == []:
             del self.wait_list[uaddr]
+        return number

--- a/qiling/os/linux/linux.py
+++ b/qiling/os/linux/linux.py
@@ -100,6 +100,8 @@ class QlOsLinux(QlOsPosix):
                     if self.ql.loader.elf_entry != self.ql.loader.entry_point:
                         main_thread.set_exit_point(self.ql.loader.elf_entry)
                         thread_management.run()
+                        if main_thread.ql.arch.get_pc() != self.ql.loader.elf_entry:
+                            raise QlErrorExecutionStop('Dynamic library .init() failed!')
                         self.ql.enable_lib_patch()
                         self.run_function_after_load()
 

--- a/qiling/os/posix/syscall/futex.py
+++ b/qiling/os/posix/syscall/futex.py
@@ -47,7 +47,7 @@ def ql_syscall_futex(ql, futex_uaddr, futex_op, futex_val, futex_timeout, futex_
                                             ql.os.thread_management.cur_thread,
                                             futex_val)
         ql.nprint("futex(%x, %d, %d, %x) = %d" % (futex_uaddr, futex_op, futex_val, futex_timeout, regreturn))
-    if futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAIT_BITSET:
+    elif futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAIT_BITSET:
         regreturn = ql.os.futexm.futex_wait(ql, futex_uaddr,
                                             ql.os.thread_management.cur_thread,
                                             futex_val,

--- a/qiling/os/posix/syscall/futex.py
+++ b/qiling/os/posix/syscall/futex.py
@@ -43,16 +43,26 @@ def ql_syscall_futex(ql, futex_uaddr, futex_op, futex_val, futex_timeout, futex_
         #         return False
         #     else:
         #         return True
-        if ql.unpack32(ql.mem.read(futex_uaddr, 4)) == futex_val:
-            ql.emu_stop()
-            regreturn = 0
-            ql.os.futexm.futex_wait(futex_uaddr, ql.os.thread_management.cur_thread)
-        else:
-            regreturn = -1
+        regreturn = ql.os.futexm.futex_wait(ql, futex_uaddr,
+                                            ql.os.thread_management.cur_thread,
+                                            futex_val)
         ql.nprint("futex(%x, %d, %d, %x) = %d" % (futex_uaddr, futex_op, futex_val, futex_timeout, regreturn))
+    if futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAIT_BITSET:
+        regreturn = ql.os.futexm.futex_wait(ql, futex_uaddr,
+                                            ql.os.thread_management.cur_thread,
+                                            futex_val,
+                                            futex_val3)
+        ql.nprint("futex(%x, %d, %d, %x, %x, %x) = %d" % (futex_uaddr,
+                                                          futex_op, futex_val,
+                                                          futex_timeout,
+                                                          futex_uaddr2,
+                                                          futex_val3,
+                                                          regreturn))
     elif futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAKE:
-        regreturn = 0
-        ql.os.futexm.futex_wake(futex_uaddr, futex_val)
+        regreturn = ql.os.futexm.futex_wake(futex_uaddr, futex_val)
+        ql.nprint("futex(%x, %d, %d) = %d" % (futex_uaddr, futex_op, futex_val, regreturn))
+    elif futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAKE_BITSET:
+        regreturn = ql.os.futexm.futex_wake(futex_uaddr, futex_val, futex_val3)
         ql.nprint("futex(%x, %d, %d) = %d" % (futex_uaddr, futex_op, futex_val, regreturn))
     else:
         ql.nprint("futex(%x, %d, %d) = ?" % (futex_uaddr, futex_op, futex_val))


### PR DESCRIPTION
- Implement FUTEX_WAIT_BITSET and FUTEX_WAKE_BITSET flag of futex syscall.
- Check library init successfully or not.
    - futex syscall still has some features not implemented. It will `ql.emu_stop()` at [here](https://github.com/JackGrence/qiling/blob/futex_bitset/qiling/os/posix/syscall/futex.py#L69). If a library's `.init()` (like libpthread) use the unimplemented feature, emulator will stop in `.init()` function and start from elf's entry point. Will cause some unexpected status.