### PR TITLE
Fix unpack size in RegQueryValue

### DIFF
--- a/qiling/os/windows/dlls/advapi32.py
+++ b/qiling/os/windows/dlls/advapi32.py
@@ -55,7 +55,7 @@ def RegQueryValue(ql, address, params):
     params["hKey"] = s_hKey
     # read reg_type
     if lpType != 0:
-        reg_type = ql.unpack(ql.mem.read(lpType, 4))
+        reg_type = ql.unpack32(ql.mem.read(lpType, 4))
     else:
         reg_type = Registry.RegNone
     try:


### PR DESCRIPTION
Hello,

There is an issue in the function `ReqQueryValue` at line 58.

https://github.com/qilingframework/qiling/blob/078996ce2dbe61c3da0b9b352634876d0e38be0f/qiling/os/windows/dlls/advapi32.py#L58

Basically, when I emulate a 64-bit PE, the function at this specific line tries to unpack a 64-bit value although there is an hardcoded size set to 4 bytes.

I fixed it by replacing the `unpack` function with `unpack32`.