### PR TITLE
Fix GetLocalTime implementation.

### DIFF
--- a/qiling/os/windows/dlls/kernel32/sysinfoapi.py
+++ b/qiling/os/windows/dlls/kernel32/sysinfoapi.py
@@ -65,7 +65,7 @@ def hook_GetLocalTime(ql, address, params):
     ptr = params['lpSystemTime']
     d = datetime.datetime.now()
     system_time = SystemTime(ql, d.year, d.month, d.isoweekday(), d.day, d.hour, d.minute, d.second,
-                             d.microsecond * 1000)
+                             d.microsecond // 1000)
     system_time.write(ptr)
     return 0
 


### PR DESCRIPTION
There was an incorrect calculation done on `d.microsecond` (converting to nanoseconds instead of milliseconds, i.e. multiplication instead of division), which led to an OverflowError in [`val.to_bytes`](https://github.com/qilingframework/qiling/blob/7f27ec31f236b61d9fa2f5a6afe02b000be2d28c/qiling/os/windows/structs.py#L302), since it would attempt to write a 30-bit value into a 16-bit location.