### PR TITLE
Improve ELF memory mapping

### DIFF
--- a/CREDITS.TXT
+++ b/CREDITS.TXT
@@ -48,6 +48,7 @@ danielhenrymantilla
 iamyeh
 alfink
 bambu
+bkerler (viperbjk)
 
 Alpha testers (in no particular order, named by github id)
 ==========================================================

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,8 @@ This file details the changelog of Qiling Framework.
 - De-flattern with IDA plugin now supports ARM && ARM64 with experimental IDA mircocode API.
 - Snapshot mechanism allows saving and restoring of OS and Loader information.
 - Welcome Lazymio and Kabeor to the team
-
+- Improve register handling (uppercase/lowercase) and add LR register support to arm64
+- Fix ELF Memory mapping issues
 
 ------------------------------------
 [Version 1.1.3]: September 30, 2020


### PR DESCRIPTION
This will address several ELF memory mapping issues : 

1. The memory addresses do now always increase sequentially, means if the first program segment has the address 
    of 0x800000 and the next has the offset of 0x143000, memory mapping would have failed.
    Therefore the maps are now being sorted before they are used for analysis.

2. A mapped memory region might differ in size vs the actual memory usage : 
    Means : The data section size is smaller than the physical size. If the emulated code does use regions outside
    the data section size, it will have an exception saying that the memory is unmapped.
    Example: p_vaddr 0x800000, p_offset 0x300, p_filesz 0x50, p_memsz 0x500
                    Memory should be mapped at 0x800000 for a length of 0x500 (p_memsz)
                    Data should only be written at 0x800000 for a length of 0x50 (p_filesz), which is smaller than p_memsz
                    Any access higher than 0x800050 would fail due to a mapping error

3. Permission masks may be higher than just 8 bits, thus it won't be recognized correctly by unicorn. Adding a 0xFF mask 
    will help. Example: Permission 0x1C000001 will fail, whereas permission 0x1 is fine.