### PR TITLE
Fix Fstat error on test using Debug

### DIFF
--- a/qiling/os/posix/syscall/stat.py
+++ b/qiling/os/posix/syscall/stat.py
@@ -213,7 +213,7 @@ def ql_syscall_fstat64(ql, fstat64_fd, fstat64_add, *args, **kw):
 
 def ql_syscall_fstat(ql, fstat_fd, fstat_add, *args, **kw):
 
-    if fstat_fd < 256 and ql.os.fd[fstat_fd] != 0 and "fstat" in dir(ql.os.fd[fstat_fd]):
+    if fstat_fd < 256 and ql.os.fd[fstat_fd] != 0 and hasattr(ql.os.fd[fstat_fd], "fstat"):
         user_fileno = fstat_fd
         fstat_info = ql.os.fd[user_fileno].fstat()
 

--- a/qiling/os/posix/syscall/stat.py
+++ b/qiling/os/posix/syscall/stat.py
@@ -213,7 +213,7 @@ def ql_syscall_fstat64(ql, fstat64_fd, fstat64_add, *args, **kw):
 
 def ql_syscall_fstat(ql, fstat_fd, fstat_add, *args, **kw):
 
-    if fstat_fd < 256 and ql.os.fd[fstat_fd] != 0 and ql.os.fd[fstat_fd].fstat:
+    if fstat_fd < 256 and ql.os.fd[fstat_fd] != 0 and "fstat" in dir(ql.os.fd[fstat_fd]):
         user_fileno = fstat_fd
         fstat_info = ql.os.fd[user_fileno].fstat()
 

--- a/qiling/os/posix/syscall/stat.py
+++ b/qiling/os/posix/syscall/stat.py
@@ -213,7 +213,7 @@ def ql_syscall_fstat64(ql, fstat64_fd, fstat64_add, *args, **kw):
 
 def ql_syscall_fstat(ql, fstat_fd, fstat_add, *args, **kw):
 
-    if fstat_fd < 256 and ql.os.fd[fstat_fd] != 0:
+    if fstat_fd < 256 and ql.os.fd[fstat_fd] != 0 and ql.os.fd[fstat_fd].fstat:
         user_fileno = fstat_fd
         fstat_info = ql.os.fd[user_fileno].fstat()
 


### PR DESCRIPTION
This addresses the nasty : 

"AttributeError: '_io.FileIO' object has no attribute 'fstat'"

error when running qiling Test in Debug mode.
