### PR TITLE
posix.wait4 syscall now handles invalid pids correctly

### DIFF
--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -246,3 +246,5 @@ arm_open_flags = {
     'O_NOFOLLOW' : 0x20000,
     'O_SYNC'     : 0x101000,
 }
+
+ECHILD = -10

--- a/qiling/os/posix/syscall/wait.py
+++ b/qiling/os/posix/syscall/wait.py
@@ -12,11 +12,18 @@ from qiling.os.filestruct import *
 from qiling.os.posix.const_mapping import *
 from qiling.exception import *
 from qiling.utils import *
+from qiling.os.posix.const import ECHILD
+
 
 def ql_syscall_wait4(ql, wait4_pid, wait4_wstatus, wait4_options, wait4_rusage, *args, **kw):
-    spid, status, rusage = os.wait4(wait4_pid, wait4_options)
-    if wait4_wstatus != 0:
-        ql.mem.write(wait4_wstatus, ql.pack32(status))
-    regreturn = spid
+    wait4_pid = ql.unpacks(ql.pack(wait4_pid))  # convert to signed
+    try:
+        spid, status, rusage = os.wait4(wait4_pid, wait4_options)
+        if wait4_wstatus != 0:
+            ql.mem.write(wait4_wstatus, ql.pack32(status))
+        regreturn = spid
+    except ChildProcessError:
+        regreturn = -ECHILD
     logging.info("wait4(%d, %d) = %d"% (wait4_pid, wait4_options, regreturn))
-    return regreturn
+    ql.os.definesyscall_return(regreturn)
+

--- a/qiling/os/posix/syscall/wait.py
+++ b/qiling/os/posix/syscall/wait.py
@@ -25,5 +25,5 @@ def ql_syscall_wait4(ql, wait4_pid, wait4_wstatus, wait4_options, wait4_rusage, 
     except ChildProcessError:
         regreturn = -ECHILD
     logging.info("wait4(%d, %d) = %d"% (wait4_pid, wait4_options, regreturn))
-    ql.os.definesyscall_return(regreturn)
+    return regreturn
 


### PR DESCRIPTION
The posix wait4 syscall hands parameters to os.wait4, but there is no Exception handling. It now handles the exception if the PID does not exist or is not a childs PID.