### PR TITLE
Allow enabling disassembly output at runtime

### DIFF
--- a/CREDITS.TXT
+++ b/CREDITS.TXT
@@ -49,7 +49,7 @@ iamyeh
 alfink
 bambu
 bkerler (viperbjk)
-learn-more
+Mark Jansen (learn-more)
 cq674350529
 
 Alpha testers (in no particular order, named by github id)

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -553,6 +553,7 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         else:
             self._output = op
         ql_resolve_logger_level(self._output, self._verbose)
+        self.os.setup_output()
 
     @property
     def verbose(self):
@@ -575,6 +576,7 @@ class Qiling(QlCoreHooks, QlCoreStructs):
     def verbose(self, v):
         self._verbose = v
         ql_resolve_logger_level(self._output, self._verbose)
+        self.os.setup_output()
     
     @property
     def patch_bin(self) -> list:


### PR DESCRIPTION
This allows the user to turn disassembly output on/off whenever they want, instead of only being able to configure this for the entire session.

For example, loading a dll could be done on 'info',
and then before a second call to `run` (to call an export for example) the output level can be set to `disasm`