### PR TITLE
Various fixes

### DIFF
--- a/qiling/core.py
+++ b/qiling/core.py
@@ -206,6 +206,14 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         # Add extra guard options when configured to do so
         self._init_stop_guard()
 
+        ###############################
+        # Properties configured later #
+        ###############################
+        self.entry_point = None
+        self.exit_point = None
+        self.timeout = None
+        self.count = None
+        self._initial_sp = None
     
     #####################
     # Qiling Components #

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -67,8 +67,9 @@ class Process():
 
         if self.libcache and os.path.exists(fcache) and \
             os.stat(fcache).st_mtime > os.stat(path).st_mtime: # pickle file cannot be outdated
-            (data, cmdlines, self.import_symbols, self.import_address_table) = \
-                pickle.load(open(fcache, "rb"))
+            with open(fcache, "rb") as fcache_file:
+                (data, cmdlines, self.import_symbols, self.import_address_table) = \
+                    pickle.load(fcache_file)
             for entry in cmdlines:
                 self.set_cmdline(entry['name'], entry['address'], data)
         else:

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -256,7 +256,11 @@ class QlOsUtils:
             temp_str += ("%02x " % i)
         log_data += temp_str.ljust(30)
 
+        first = True
         for i in insn:
+            if not first:
+                log_data += '\n> '
+            first = False
             log_data += "%s %s" % (i.mnemonic, i.op_str)
         logging.info(log_data)
 

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -254,6 +254,7 @@ def debugger_convert_str(debugger_id):
 # Call `function_name` in `module_name`.
 # e.g. map_syscall in qiling.os.linux.map_syscall
 def ql_get_module_function(module_name, function_name = None):
+    
     try:
         imp_module = importlib.import_module(module_name)
     except Exception as ex:

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -256,8 +256,8 @@ def debugger_convert_str(debugger_id):
 def ql_get_module_function(module_name, function_name = None):
     try:
         imp_module = importlib.import_module(module_name)
-    except:
-        raise QlErrorModuleNotFound("[!] Unable to import module %s" % module_name)
+    except Exception as ex:
+        raise QlErrorModuleNotFound("[!] Unable to import module %s (%s)" % (module_name, ex))
 
     try:
         module_function = getattr(imp_module, function_name)


### PR DESCRIPTION
- Include exception on module load failure
- Split out instructions over multiple lines when disassembling
- Fix a warning related to the binary cache
- Explicitly set some properties in the constructor

One commit per feature, so that it's easy to only include the ones you approve of.