### PR TITLE
fix stack setup in elf.py

### DIFF
--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -140,16 +140,8 @@ class QlLoaderELF(QlLoader, ELFParse):
         l_addr = []
         s_addr = addr
         for s in strs:
-            bs = s.encode("utf-8") + b"\x00"
+            bs = s.encode("utf-8") + b"\x00" if not isinstance(s, bytes) else s
             s_addr = s_addr - len(bs)
-            # if isinstance(i, bytes):
-            #   logging.info(type(b'\x00'))
-            #   logging.info(type(i))
-            #   logging.info(i)
-            #   logging.info(type(i.encode()))
-            #   logging.info(type(addr))
-            #   self.ql.mem.write(s_addr, i + b'\x00')
-            # else:
             self.ql.mem.write(s_addr, bs)
             l_addr.append(s_addr)
         return l_addr, s_addr


### PR DESCRIPTION
## Problem description
according to this
https://github.com/qilingframework/qiling/blob/58a73b173f5e9f48241d5cb43cad7229683438c0/qiling/loader/elf.py#L143-L153

argv will be encoded before copy to stack, its working fine while all inputs are all ASCII character.

for those non-ASCII character will be converted to UTF-8 and messed up with original input

this is an easy bof example with input `'A'*0xcc + 'B'*4`
![image](https://user-images.githubusercontent.com/10076774/103399349-a79bd380-4b7b-11eb-8218-43a4ce11066e.png)

before this commit with input `'A'*0xcc + '\xc2'*4`, you can see the input `\xc2` were converted to `\xc3\x82`
![image](https://user-images.githubusercontent.com/10076774/103399407-f9445e00-4b7b-11eb-9be6-440ba9a8ed55.png)

after this commit with input `b'A'*0xcc + b'\xc2'*4`
![image](https://user-images.githubusercontent.com/10076774/103399529-72dc4c00-4b7c-11eb-8917-4782803dcb97.png)

## conclusion

- this commit made qiling accepts bytes input