### PR TITLE
OS Improvements

### DIFF
--- a/examples/sality.py
+++ b/examples/sality.py
@@ -29,7 +29,7 @@ def init_unseen_symbols(ql, address, name, ordinal, dll_name):
 #   LPDWORD                 lpThreadId
 # );
 @winsdkapi(cc=STDCALL, dllname='kernel32_dll')
-def sality_CreateThread(ql, address, params):
+def hook_CreateThread(ql, address, params):
     # set thread handle
     return 1
 
@@ -51,7 +51,7 @@ def sality_CreateThread(ql, address, params):
     "dwFlagsAndAttributes": DWORD,
     "hTemplateFile": HANDLE
 })
-def sality_CreateFileA(ql, address, params):
+def hook_CreateFileA(ql, address, params):
     lpFileName = params["lpFileName"]
     if lpFileName.startswith("\\\\.\\"):
         if ql.amsint32_driver:
@@ -94,7 +94,7 @@ def _WriteFile(ql, address, params):
     "lpNumberOfBytesWritten": POINTER,
     "lpOverlapped": POINTER
 })
-def sality_WriteFile(ql, address, params):
+def hook_WriteFile(ql, address, params):
     hFile = params["hFile"]
     lpBuffer = params["lpBuffer"]
     nNumberOfBytesToWrite = params["nNumberOfBytesToWrite"]
@@ -121,8 +121,7 @@ def sality_WriteFile(ql, address, params):
 #   DWORD     dwNumServiceArgs,
 #   LPCSTR    *lpServiceArgVectors
 # );
-@winsdkapi(cc=STDCALL, dllname='kernel32_dll')
-def sality_StartServiceA(ql, address, params):
+def hook_StartServiceA(ql, address, params):
     try:
         hService = params["hService"]
         service_handle = ql.os.handle_manager.get(hService)
@@ -160,10 +159,10 @@ if __name__ == "__main__":
     # for this module 
     ql.amsint32_driver = None
     # emulate some Windows API
-    ql.set_api("CreateThread", sality_CreateThread)
-    ql.set_api("CreateFileA", sality_CreateFileA)
-    ql.set_api("WriteFile", sality_WriteFile)
-    ql.set_api("StartServiceA", sality_StartServiceA)
+    ql.set_api("CreateThread", hook_CreateThread)
+    ql.set_api("CreateFileA", hook_CreateFileA)
+    ql.set_api("WriteFile", hook_WriteFile)
+    ql.set_api("StartServiceA", hook_StartServiceA)
     #init sality
     ql.hook_address(hook_stop_address, 0x40EFFB)
     ql.run()

--- a/examples/sality.py
+++ b/examples/sality.py
@@ -121,6 +121,7 @@ def hook_WriteFile(ql, address, params):
 #   DWORD     dwNumServiceArgs,
 #   LPCSTR    *lpServiceArgVectors
 # );
+@winsdkapi(cc=STDCALL, dllname='advapi32_dll')
 def hook_StartServiceA(ql, address, params):
     try:
         hService = params["hService"]

--- a/examples/sality.py
+++ b/examples/sality.py
@@ -3,14 +3,16 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import struct, sys, logging
+import sys, logging
+
+from unicorn import UcError
 
 sys.path.append("..")
-from qiling import *
-from qiling.os.windows.fncc import *
+from qiling import Qiling
+from qiling.os.const import STDCALL, POINTER, DWORD, STRING, HANDLE
+from qiling.os.windows.fncc import winsdkapi
+from qiling.os.windows.utils import canonical_path, string_appearance
 from qiling.os.windows.dlls.kernel32.fileapi import _CreateFile
-from qiling.os.windows.utils import canonical_path
-from qiling.loader.utils import ql_pe_check_archtype
 
 
 def init_unseen_symbols(ql, address, name, ordinal, dll_name):
@@ -68,7 +70,8 @@ def _WriteFile(ql, address, params):
     lpBuffer = params["lpBuffer"]
     nNumberOfBytesToWrite = params["nNumberOfBytesToWrite"]
     lpNumberOfBytesWritten = params["lpNumberOfBytesWritten"]
-    lpOverlapped = params["lpOverlapped"]
+    #lpOverlapped = params["lpOverlapped"]
+
     if hFile == 0xfffffff5:
         s = ql.mem.read(lpBuffer, nNumberOfBytesToWrite)
         ql.os.stdout.write(s)
@@ -173,7 +176,7 @@ if __name__ == "__main__":
     ql.run(0x4053B2)
     logging.info("[+] test kill thread")
     if ql.amsint32_driver:
-        ql.amsint32_driver.os.io_Write(struct.pack("<I", 0xdeadbeef))
+        ql.amsint32_driver.os.io_Write(ql.pack32(0xdeadbeef))
         ql.amsint32_driver.hook_address(hook_stop_address, 0x10423)
         ql.amsint32_driver.set_function_args([0])
         ql.amsint32_driver.run(0x102D0)

--- a/qiling/os/const.py
+++ b/qiling/os/const.py
@@ -122,6 +122,7 @@ reptypedict = {
             "REFCLSID": "POINTER",
             "REFIID": "POINTER",
             "REGSAM": "POINTER",
+            "SC_HANDLE": "HANDLE",
             "SHELLEXECUTEINFOA": "POINTER",
             "SHELLEXECUTEINFOW": "POINTER",
             "SHFILEINFOW": "POINTER",

--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -3,15 +3,16 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+import sys, logging
 import logging, os, sys, types
 
-from .utils import QlOsUtils
 from .const import *
 from .filestruct import ql_file
 from .mapper import QlFsMapper
+from .utils import QlOsUtils
 
-from qiling.const import *
-
+from qiling.const import QL_ARCH, QL_OS, QL_INTERCEPT, QL_OS_POSIX
+from qiling.exception import QlErrorArch
 from unicorn.x86_const import *
 
 class QlOs(QlOsUtils):

--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -246,8 +246,11 @@ class QlOs(QlOsUtils):
 
             return deref(ptr) if ptr else 0
 
-        def __handle_POINTER(idx: int):
+        def __handle_default(idx: int):
             return self.get_param_by_index(idx), 1
+
+        def __handle_POINTER(idx: int):
+            return __handle_default(idx)
 
         def __handle_ULONGLONG_32(idx: int):
             lo = self.get_param_by_index(idx)
@@ -265,7 +268,6 @@ class QlOs(QlOsUtils):
             return __nullptr_or_deref(idx, lambda p: str(self.read_guid(p))), 1
 
         param_handlers = {
-            DWORD    : __handle_POINTER,
             ULONGLONG: __handle_POINTER if self.ql.archbit == 64 else __handle_ULONGLONG_32,
             POINTER  : __handle_POINTER,
             STRING   : __handle_STRING,
@@ -275,7 +277,8 @@ class QlOs(QlOsUtils):
 
         i = 0
         for pname, ptype in in_params.items():
-            out_params[pname], consumed = param_handlers[ptype](i)
+            handler = param_handlers.get(ptype, __handle_default)
+            out_params[pname], consumed = handler(i)
             i += consumed
 
         return i

--- a/tests/test_pe_sality.py
+++ b/tests/test_pe_sality.py
@@ -130,6 +130,7 @@ class PETest(unittest.TestCase):
         #   DWORD     dwNumServiceArgs,
         #   LPCSTR    *lpServiceArgVectors
         # );
+        @winsdkapi(cc=STDCALL, dllname='advapi32_dll')
         def hook_StartServiceA(ql, address, params):
             try:
                 hService = params["hService"]

--- a/tests/test_pe_sality.py
+++ b/tests/test_pe_sality.py
@@ -39,7 +39,7 @@ class PETest(unittest.TestCase):
         #   LPDWORD                 lpThreadId
         # );
         @winsdkapi(cc=STDCALL, dllname='kernel32_dll')
-        def sality_CreateThread(ql, address, params):
+        def hook_CreateThread(ql, address, params):
             # set thread handle
             return 1
 
@@ -61,7 +61,7 @@ class PETest(unittest.TestCase):
             "dwFlagsAndAttributes": DWORD,
             "hTemplateFile": HANDLE
         })
-        def sality_CreateFileA(ql, address, params):
+        def hook_CreateFileA(ql, address, params):
             lpFileName = params["lpFileName"]
             if lpFileName.startswith("\\\\.\\"):
                 if ql.amsint32_driver:
@@ -104,7 +104,7 @@ class PETest(unittest.TestCase):
             "lpNumberOfBytesWritten": POINTER,
             "lpOverlapped": POINTER
         })
-        def sality_WriteFile(ql, address, params):
+        def hook_WriteFile(ql, address, params):
             hFile = params["hFile"]
             lpBuffer = params["lpBuffer"]
             nNumberOfBytesToWrite = params["nNumberOfBytesToWrite"]
@@ -130,8 +130,7 @@ class PETest(unittest.TestCase):
         #   DWORD     dwNumServiceArgs,
         #   LPCSTR    *lpServiceArgVectors
         # );
-        @winsdkapi(cc=STDCALL, dllname='kernel32_dll')
-        def sality_StartServiceA(ql, address, params):
+        def hook_StartServiceA(ql, address, params):
             try:
                 hService = params["hService"]
                 service_handle = ql.os.handle_manager.get(hService)
@@ -167,10 +166,10 @@ class PETest(unittest.TestCase):
         # for this module 
         ql.amsint32_driver = None
         # emulate some Windows API
-        ql.set_api("CreateThread", sality_CreateThread)
-        ql.set_api("CreateFileA", sality_CreateFileA)
-        ql.set_api("WriteFile", sality_WriteFile)
-        ql.set_api("StartServiceA", sality_StartServiceA)
+        ql.set_api("CreateThread", hook_CreateThread)
+        ql.set_api("CreateFileA", hook_CreateFileA)
+        ql.set_api("WriteFile", hook_WriteFile)
+        ql.set_api("StartServiceA", hook_StartServiceA)
         #init sality
         ql.hook_address(hook_stop_address, 0x40EFFB)
         ql.run()


### PR DESCRIPTION
[Resubmitting #639 with additional fixes]

Some improvements to the OS module:
- New and improved function arguments handling
  - Selects between `amd64`, `cdecl` and `ms` calling conventions instead of just 32 vs 64 bits
  - Uses a unified generic handling instead of re-selecting appropriate handling every single time
  - Supports up to 16 function call arguments in each cc
- Code cleanup and tidy-up
- Documentation

Fixes to Sality (both test and example):
- BUGFIX: `os.windows.fncc` could not find DLL functions hooked by sality and assign them with parameters, as it expects a name prefix of 5 chars (maybe `"hook_"` ? https://github.com/qilingframework/qiling/blob/5ddb8d68cc9ea518902d4c9fccf9d49a57c186b3/qiling/os/windows/fncc.py#L42)
- BUGFIX: `StartServiceA` is defined in `advapi32.dll` and not in `kernel32.dll`
- BUGFIX: Added support for `HC_HANDLE` parameters type needed for `StartServiceA`
- Reduced namespace pollution
- Code cleanup