### PR TITLE
Print warnings after loading a dll

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -69,6 +69,11 @@ class Process():
         else:
             dll = pefile.PE(path, fast_load=True)
             dll.parse_data_directories()
+            warnings = dll.get_warnings()
+            if warnings:
+                logging.warn(f'Warnings while loading {path}:')
+                for warning in warnings:
+                    logging.warn(f' - {warning}')
             data = bytearray(dll.get_memory_mapped_image())
             cmdlines = []
 


### PR DESCRIPTION
`pefile` has a builtin method to retrieve warnings,
so when there are warnings display those.