### PR TITLE
Fix logging initialization

### DIFF
--- a/qiling/core.py
+++ b/qiling/core.py
@@ -154,7 +154,7 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         #####################
         # Profile & Logging #
         #####################
-        self._profile = profile_setup(self.ostype, self.profile, self)
+        self._profile, debugmsg = profile_setup(self.ostype, self.profile, self)
         if self._append == None:
             self._append = self._profile["MISC"]["append"]
         if self._log_dir == None:
@@ -178,7 +178,10 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         self._log_file_fd = logging.getLogger()
         
         ql_resolve_logger_level(self._output, self._verbose)
-        
+
+        # Now that the logger is configured, we can log profile debug msg:
+        logging.debug(debugmsg)
+
         ########################
         # Archbit & Endianness #
         ########################

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -485,7 +485,7 @@ def os_setup(archtype, ostype, ql):
 
 
 def profile_setup(ostype, profile, ql):
-    logging.debug("Customized profile: %s" % profile)
+    debugmsg = "Customized profile: %s" % profile
 
     os_profile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "profiles", ostype_convert_str(ostype) + ".ql")
 
@@ -496,7 +496,7 @@ def profile_setup(ostype, profile, ql):
 
     config = configparser.ConfigParser()
     config.read(profiles)
-    return config
+    return config, debugmsg
 
 def ql_resolve_logger_level(output, verbose):
     level = logging.INFO
@@ -522,8 +522,6 @@ def ql_setup_logger(ql, log_dir, log_filename, log_split, console, filter, multi
 
     # Clear all handlers and filters.
     lger = logging.getLogger()
-    lger.handlers = []
-    lger.filters = []
 
     # Do we have console output?
     if console:


### PR DESCRIPTION
When initializing logger before logging, there is no need to clear the default loggers.
This allows other applications that integrating Qiling to register logger handlers before starting qiling