### PR TITLE
Fix debug print for negative hex values in posix

### DIFF
--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -173,7 +173,7 @@ class QlOsPosix(QlOs):
                         # each name has a list of calls, we want the last one and we want to update the return value
                         self.syscalls[self.syscall_name][-1]["result"] = ret
                         ret = self.set_syscall_return(ret)
-                        self.ql.log.debug("%s() = 0x%x" % (self.syscall_map.__name__[11:], ret))
+                        self.ql.log.debug("%s() = %s" % (self.syscall_map.__name__[11:], hex(ret)))
 
                 if self.syscall_onExit is not None:
                     self.syscall_onExit(self.ql, self.get_func_arg()[0], self.get_func_arg()[1], self.get_func_arg()[2], self.get_func_arg()[3], self.get_func_arg()[4], self.get_func_arg()[5])


### PR DESCRIPTION
Before you could receive values like "0x-17", which makes no sense.
With this fix it now prints as "-0x17"


## Checklist

### Which kind of PR do you create?

- [X] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [X] The imports are arranged properly.
- [X] Essential comments are added.
- [X] The reference of the new code is pointed out.

### Extra tests?

- [X] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [X] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
