### PR TITLE
Fix buggy qdb examine output

### DIFF
--- a/qiling/debugger/qdb/frontend.py
+++ b/qiling/debugger/qdb/frontend.py
@@ -42,8 +42,8 @@ def examine_mem(ql, addr, fmt):
             offset = line * sz * 4
             print("0x{:x}:\t".format(addr+offset), end="")
 
-            idx = line * sz
-            for each in mem_read[idx:idx+(sz*4)]:
+            idx = line * 4
+            for each in mem_read[idx:idx+4]:
                 data = unpack(each, sz)
                 prefix = "0x" if ft in ("x", "a") else ""
                 pad = '0' + str(sz*2) if ft in ('x', 'a', 't') else ''


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

qdb examine output for byte type was buggy. 
Example when examine a 16-byte buffer `000102030405060708090A0B0C0D0E0F`

**Before the fix**
Word display is correct
```
(Qdb) x/4wx 0x00021030
0x21030:        0x03020100      0x07060504      0x0b0a0908      0x0f0e0d0c
```
But byte one is buggy (data is incorrect)
```
(Qdb) x/16bx 0x00021030
0x21030:        0x00    0x01    0x02    0x03
0x21034:        0x01    0x02    0x03    0x04
0x21038:        0x02    0x03    0x04    0x05
0x2103c:        0x03    0x04    0x05    0x06
```
Half-words also are incorrect 
```
(Qdb) x/8hx 0x00021030
0x21030:        0x0100  0x0302  0x0504  0x0706  0x0908  0x0b0a  0x0d0c  0x0f0e
0x21038:        0x0504  0x0706  0x0908  0x0b0a  0x0d0c  0x0f0e
```

**After the fix**
```
(Qdb) x/4wx 0x00021030
0x21030:        0x03020100      0x07060504      0x0b0a0908      0x0f0e0d0c
(Qdb) x/8hx 0x00021030
0x21030:        0x0100  0x0302  0x0504  0x0706
0x21038:        0x0908  0x0b0a  0x0d0c  0x0f0e
(Qdb) x/16bx 0x00021030
0x21030:        0x00    0x01    0x02    0x03
0x21034:        0x04    0x05    0x06    0x07
0x21038:        0x08    0x09    0x0a    0x0b
0x2103c:        0x0c    0x0d    0x0e    0x0f
```

