### PR TITLE
move mips ccall

### DIFF
--- a/qiling/os/linux/fncc.py
+++ b/qiling/os/linux/fncc.py
@@ -238,9 +238,7 @@ def linux_kernel_api(param_num=None, params=None):
             elif ql.archtype == QL_ARCH.X8664:
                 return ql.os.x8664_fastcall(param_num, params, func, args, kwargs)
             elif ql.archtype == QL_ARCH.MIPS:
-                # TODO: FIxing
-                #return ql.os.mips_call(param_num, params, func, args, kwargs)
-                return mips_call(ql, param_num, params, func, args, kwargs)
+                return ql.os.mips_o32_call(param_num, params, func, args, kwargs)
             else:
                 raise QlErrorArch("Unknown ql.archtype")
         return wrapper


### PR DESCRIPTION
move mips o32 call convention into os/fncc.py

> Currently only add o32 call convention, since it's most ubuquitious. There is another conventions, such as o64, n32/n64, maybe added later.
> MIPS Call Convention Reference: https://en.wikipedia.org/wiki/Calling_convention#MIPS