### PR TITLE
Refactor of stat64/fstat64 stat/fstat/lstat and added lstat64

### DIFF
--- a/qiling/os/posix/syscall/stat.py
+++ b/qiling/os/posix/syscall/stat.py
@@ -13,6 +13,223 @@ from qiling.os.posix.const_mapping import *
 from qiling.exception import *
 from qiling.os.stat import *
 
+
+def create_stat_struct(ql, info):
+    if ql.archtype == QL_ARCH.MIPS:
+        # pack fstatinfo
+        stat_buf = ql.pack32(info.st_dev)
+        stat_buf += ql.pack32(0) * 3
+        stat_buf += ql.pack32(info.st_ino)
+        stat_buf += ql.pack32(info.st_mode)
+        stat_buf += ql.pack32(info.st_nlink)
+        stat_buf += ql.pack32(info.st_uid)
+        stat_buf += ql.pack32(info.st_gid)
+        stat_buf += ql.pack32(info.st_rdev)
+        stat_buf += ql.pack32(0) * 2
+        stat_buf += ql.pack32(info.st_size)
+        stat_buf += ql.pack32(0)
+        stat_buf += ql.pack32(int(info.st_atime))
+        stat_buf += ql.pack32(0)
+        stat_buf += ql.pack32(int(info.st_mtime))
+        stat_buf += ql.pack32(0)
+        stat_buf += ql.pack32(int(info.st_ctime))
+        stat_buf += ql.pack32(0)
+        stat_buf += ql.pack32(info.st_blksize)
+        stat_buf += ql.pack32(info.st_blocks)
+        stat_buf = stat_buf.ljust(0x90, b'\x00')
+    elif ql.archtype == QL_ARCH.X8664:
+        if ql.platform == QL_OS.MACOS:
+            stat_buf = ql.pack64s(info.st_dev)
+        else:
+            stat_buf = ql.pack64(info.st_dev)
+        stat_buf += ql.pack(info.st_ino)
+        stat_buf += ql.pack64(info.st_nlink)
+        stat_buf += ql.pack32(info.st_mode)
+        stat_buf += ql.pack32(info.st_uid)
+        stat_buf += ql.pack32(info.st_gid)
+        stat_buf += ql.pack32(0)
+        stat_buf += ql.pack64(info.st_rdev)
+        stat_buf += ql.pack64(info.st_size)
+        stat_buf += ql.pack64(info.st_blksize)
+        stat_buf += ql.pack64(info.st_blocks)
+        stat_buf += ql.pack64(int(info.st_atime))
+        stat_buf += ql.pack64(0)
+        stat_buf += ql.pack64(int(info.st_mtime))
+        stat_buf += ql.pack64(0)
+        stat_buf += ql.pack64(int(info.st_ctime))
+        stat_buf += ql.pack64(0)
+    elif ql.archtype == QL_ARCH.ARM64:
+        # struct stat is : 80 addr is : 0x4000811bc8
+        # buf.st_dev offest 0 8 0
+        # buf.st_ino offest 8 8 0
+        # buf.st_mode offest 10 4 0
+        # buf.st_nlink offest 14 4 0
+        # buf.st_uid offest 18 4 0
+        # buf.st_gid offest 1c 4 0
+        # buf.st_rdev offest 20 8 0
+        # buf.st_size offest 30 8 274886889936
+        # buf.st_blksize offest 38 4 8461328
+        # buf.st_blocks offest 40 8 274877909532
+        # buf.st_atime offest 48 8 274886368336
+        # buf.st_mtime offest 58 8 274877909472
+        # buf.st_ctime offest 68 8 274886368336
+        # buf.__glibc_reserved offest 78 8
+        if ql.platform == QL_OS.MACOS:
+            stat_buf = ql.pack64s(info.st_dev)
+        else:
+            stat_buf = ql.pack64(info.st_dev)
+        stat_buf += ql.pack64(info.st_ino)
+        stat_buf += ql.pack32(info.st_mode)
+        stat_buf += ql.pack32(info.st_nlink)
+        stat_buf += ql.pack32(ql.os.uid)
+        stat_buf += ql.pack32(ql.os.gid)
+        stat_buf += ql.pack64(info.st_rdev)
+        stat_buf += ql.pack64(0)
+        stat_buf += ql.pack64(info.st_size)
+        stat_buf += ql.pack32(info.st_blksize)
+        stat_buf += ql.pack32(0)
+        stat_buf += ql.pack64(info.st_blocks)
+        stat_buf += ql.pack64(int(info.st_atime))
+        stat_buf += ql.pack64(0)
+        stat_buf += ql.pack64(int(info.st_mtime))
+        stat_buf += ql.pack64(0)
+        stat_buf += ql.pack64(int(info.st_ctime))
+        stat_buf += ql.pack64(0)
+    else:
+        # pack fstatinfo
+        stat_buf = ql.pack32(info.st_dev)
+        stat_buf += ql.pack(info.st_ino)
+        stat_buf += ql.pack32(info.st_mode)
+        stat_buf += ql.pack32(info.st_nlink)
+        stat_buf += ql.pack32(info.st_uid)
+        stat_buf += ql.pack32(info.st_gid)
+        stat_buf += ql.pack32(info.st_rdev)
+        stat_buf += ql.pack32(info.st_size)
+        stat_buf += ql.pack32(info.st_blksize)
+        stat_buf += ql.pack32(info.st_blocks)
+        stat_buf += ql.pack32(int(info.st_atime))
+        stat_buf += ql.pack32(int(info.st_mtime))
+        stat_buf += ql.pack32(int(info.st_ctime))
+    return stat_buf
+
+
+def create_stat64_struct(ql, info):
+    if ql.archtype == QL_ARCH.ARM64:
+        # struct stat is : 80 addr is : 0x4000811bc8
+        # buf.st_dev offest 0 8 0
+        # buf.st_ino offest 8 8 0
+        # buf.st_mode offest 10 4 0
+        # buf.st_nlink offest 14 4 0
+        # buf.st_uid offest 18 4 0
+        # buf.st_gid offest 1c 4 0
+        # buf.st_rdev offest 20 8 0
+        # buf.st_size offest 30 8 274886889936
+        # buf.st_blksize offest 38 4 8461328
+        # buf.st_blocks offest 40 8 274877909532
+        # buf.st_atime offest 48 8 274886368336
+        # buf.st_mtime offest 58 8 274877909472
+        # buf.st_ctime offest 68 8 274886368336
+        # buf.__glibc_reserved offest 78 8
+        fstat64_buf = ql.pack64(info.st_dev)  # 8
+        fstat64_buf += ql.pack64(info.st_ino)  # 16
+        fstat64_buf += ql.pack32(info.st_mode)  # 20
+        fstat64_buf += ql.pack32(info.st_nlink)  # 24
+        fstat64_buf += ql.pack32(ql.os.uid)  # 28
+        fstat64_buf += ql.pack32(ql.os.gid)  # 32
+        fstat64_buf += ql.pack64(info.st_rdev)  # 40
+        fstat64_buf += ql.pack64(0)  # 48
+        fstat64_buf += ql.pack64(info.st_size)  # 56
+        fstat64_buf += ql.pack32(info.st_blksize)  # 60
+        fstat64_buf += ql.pack32(0)  # 64
+        fstat64_buf += ql.pack64(info.st_blocks)  # 72
+        fstat64_buf += ql.pack64(int(info.st_atime))  # 80
+        fstat64_buf += ql.pack64(0)  # 88
+        fstat64_buf += ql.pack64(int(info.st_mtime))  # 96
+        fstat64_buf += ql.pack64(0)  # 104
+        fstat64_buf += ql.pack64(int(info.st_ctime))  # 114
+        fstat64_buf += ql.pack64(0)  # 120
+    elif ql.archtype == QL_ARCH.MIPS:
+        # struct stat is : a0 addr is : 0x7fffedc0
+        # buf.st_dev offest 0 4 2049
+        # buf.st_ino offest 10 8 2400362
+        # buf.st_mode offest 18 4 16893
+        # buf.st_nlink offest 1c 4 5
+        # buf.st_uid offest 20 4 1000
+        # buf.st_gid offest 24 4 1000
+        # buf.st_rdev offest 28 4 0
+        # buf.st_size offest 38 8 0
+        # buf.st_blksize offest 58 4 4096
+        # buf.st_blocks offest 60 8 136
+        # buf.st_atime offest 40 4 1586616689
+        # buf.st_mtime offest 48 4 1586616689
+        # buf.st_ctime offest 50 4 1586616689
+        if ql.platform == QL_OS.MACOS:
+            fstat64_buf = ql.pack32s(info.st_dev)
+        else:
+            fstat64_buf = ql.pack32(info.st_dev)  # 4
+        fstat64_buf += b'\x00' * 12  # 16
+        fstat64_buf += ql.pack64(info.st_ino)  # 24
+        fstat64_buf += ql.pack32(info.st_mode)
+        fstat64_buf += ql.pack32(info.st_nlink)
+        fstat64_buf += ql.pack32(ql.os.uid)
+        fstat64_buf += ql.pack32(ql.os.gid)
+        fstat64_buf += ql.pack32(info.st_rdev)
+        fstat64_buf += b'\x00' * 12
+        fstat64_buf += ql.pack64(info.st_size)
+        fstat64_buf += ql.pack64(int(info.st_atime))
+        fstat64_buf += ql.pack64(0)
+        fstat64_buf += ql.pack64(int(info.st_mtime))
+        fstat64_buf += ql.pack64(0)
+        fstat64_buf += ql.pack64(int(info.st_ctime))
+        fstat64_buf += ql.pack64(0)
+        fstat64_buf += ql.pack32(info.st_blksize)
+        fstat64_buf += ql.pack32(0)
+        fstat64_buf += ql.pack64(info.st_blocks)
+    elif ql.archtype == QL_ARCH.ARM:
+        # pack fstatinfo
+        if ql.platform == QL_OS.MACOS:
+            fstat64_buf = ql.pack64s(info.st_dev)
+        else:
+            fstat64_buf = ql.pack64(info.st_dev)
+        fstat64_buf += ql.pack32(0)
+        fstat64_buf += ql.pack32(info.st_ino)
+        fstat64_buf += ql.pack32(info.st_mode)
+        fstat64_buf += ql.pack32(info.st_nlink)
+        fstat64_buf += ql.pack32(info.st_uid)
+        fstat64_buf += ql.pack32(info.st_gid)
+        fstat64_buf += ql.pack64(info.st_rdev)  # ?? fstat_info.st_rdev
+        fstat64_buf += ql.pack64(0)
+        fstat64_buf += ql.pack64(info.st_size)
+        fstat64_buf += ql.pack64(info.st_blksize)  # ?? fstat_info.st_blksize
+        fstat64_buf += ql.pack64(info.st_blocks)  # ?? fstat_info.st_blocks
+        fstat64_buf += ql.pack64(int(info.st_atime))
+        fstat64_buf += ql.pack64(int(info.st_mtime))
+        fstat64_buf += ql.pack64(int(info.st_ctime))
+        fstat64_buf += ql.pack64(info.st_ino)
+
+    else:
+        # pack fstatinfo
+        if ql.platform == QL_OS.MACOS:
+            fstat64_buf = ql.pack64s(info.st_dev)
+        else:
+            fstat64_buf = ql.pack64(info.st_dev)
+        fstat64_buf += ql.pack64(0x0000000300c30000)
+        fstat64_buf += ql.pack32(info.st_mode)
+        fstat64_buf += ql.pack32(info.st_nlink)
+        fstat64_buf += ql.pack32(info.st_uid)
+        fstat64_buf += ql.pack32(info.st_gid)
+        fstat64_buf += ql.pack64(0x0000000000008800)  # ?? fstat_info.st_rdev
+        fstat64_buf += ql.pack32(0xffffd257)
+        fstat64_buf += ql.pack64(info.st_size)
+        fstat64_buf += ql.pack32(0x00000400)  # ?? fstat_info.st_blksize
+        fstat64_buf += ql.pack64(0x0000000000000000)  # ?? fstat_info.st_blocks
+        fstat64_buf += ql.pack64(int(info.st_atime))
+        fstat64_buf += ql.pack64(int(info.st_mtime))
+        fstat64_buf += ql.pack64(int(info.st_ctime))
+        fstat64_buf += ql.pack64(info.st_ino)
+    return fstat64_buf
+
+
 def ql_syscall_chmod(ql, filename, mode, null1, null2, null3, null4):
     regreturn = 0
     filename = ql.mem.string(filename)
@@ -63,7 +280,7 @@ def ql_syscall_fstatat64(ql, fstatat64_fd, fstatat64_fname, fstatat64_buf, fstat
         fstat64_buf += ql.pack64(0)
         fstat64_buf += ql.pack64(int(fstat64_info.st_ctime))
         fstat64_buf += ql.pack64(0)
-        ql.mem.write(fstatat64_buf,fstat64_buf)
+        ql.mem.write(fstatat64_buf, fstat64_buf)
         regreturn = 0
 
     if regreturn == 0:
@@ -82,121 +299,7 @@ def ql_syscall_fstat64(ql, fstat64_fd, fstat64_add, *args, **kw):
     elif fstat64_fd < 256 and ql.os.fd[fstat64_fd] != 0:
         user_fileno = fstat64_fd
         fstat64_info = ql.os.fd[user_fileno].fstat()
-
-        if ql.archtype== QL_ARCH.ARM64:
-            # struct stat is : 80 addr is : 0x4000811bc8
-            # buf.st_dev offest 0 8 0
-            # buf.st_ino offest 8 8 0
-            # buf.st_mode offest 10 4 0
-            # buf.st_nlink offest 14 4 0
-            # buf.st_uid offest 18 4 0
-            # buf.st_gid offest 1c 4 0
-            # buf.st_rdev offest 20 8 0
-            # buf.st_size offest 30 8 274886889936
-            # buf.st_blksize offest 38 4 8461328
-            # buf.st_blocks offest 40 8 274877909532
-            # buf.st_atime offest 48 8 274886368336
-            # buf.st_mtime offest 58 8 274877909472
-            # buf.st_ctime offest 68 8 274886368336
-            # buf.__glibc_reserved offest 78 8
-            fstat64_buf = ql.pack64(fstat64_info.st_dev)
-            fstat64_buf += ql.pack64(fstat64_info.st_ino)
-            fstat64_buf += ql.pack32(fstat64_info.st_mode)
-            fstat64_buf += ql.pack32(fstat64_info.st_nlink)
-            fstat64_buf += ql.pack32(ql.os.uid)
-            fstat64_buf += ql.pack32(ql.os.gid)
-            fstat64_buf += ql.pack64(fstat64_info.st_rdev)
-            fstat64_buf += ql.pack64(0)
-            fstat64_buf += ql.pack64(fstat64_info.st_size)
-            fstat64_buf += ql.pack32(fstat64_info.st_blksize)
-            fstat64_buf += ql.pack32(0)
-            fstat64_buf += ql.pack64(fstat64_info.st_blocks)
-            fstat64_buf += ql.pack64(int(fstat64_info.st_atime))
-            fstat64_buf += ql.pack64(0)
-            fstat64_buf += ql.pack64(int(fstat64_info.st_mtime))
-            fstat64_buf += ql.pack64(0)
-            fstat64_buf += ql.pack64(int(fstat64_info.st_ctime))
-            fstat64_buf += ql.pack64(0)
-        elif ql.archtype == QL_ARCH.MIPS:
-            # struct stat is : a0 addr is : 0x7fffedc0
-            # buf.st_dev offest 0 4 2049
-            # buf.st_ino offest 10 8 2400362
-            # buf.st_mode offest 18 4 16893
-            # buf.st_nlink offest 1c 4 5
-            # buf.st_uid offest 20 4 1000
-            # buf.st_gid offest 24 4 1000
-            # buf.st_rdev offest 28 4 0
-            # buf.st_size offest 38 8 0
-            # buf.st_blksize offest 58 4 4096
-            # buf.st_blocks offest 60 8 136
-            # buf.st_atime offest 40 4 1586616689
-            # buf.st_mtime offest 48 4 1586616689
-            # buf.st_ctime offest 50 4 1586616689
-            if ql.platform == QL_OS.MACOS:
-                fstat64_buf = ql.pack32s(fstat64_info.st_dev)
-            else:
-                fstat64_buf = ql.pack32(fstat64_info.st_dev)
-            fstat64_buf += b'\x00' * 12
-            fstat64_buf += ql.pack64(fstat64_info.st_ino)
-            fstat64_buf += ql.pack32(fstat64_info.st_mode)
-            fstat64_buf += ql.pack32(fstat64_info.st_nlink)
-            fstat64_buf += ql.pack32(ql.os.uid)
-            fstat64_buf += ql.pack32(ql.os.gid)
-            fstat64_buf += ql.pack32(fstat64_info.st_rdev)
-            fstat64_buf += b'\x00' * 12
-            fstat64_buf += ql.pack64(fstat64_info.st_size)
-            fstat64_buf += ql.pack64(int(fstat64_info.st_atime))
-            fstat64_buf += ql.pack64(0)
-            fstat64_buf += ql.pack64(int(fstat64_info.st_mtime))
-            fstat64_buf += ql.pack64(0)
-            fstat64_buf += ql.pack64(int(fstat64_info.st_ctime))
-            fstat64_buf += ql.pack64(0)
-            fstat64_buf += ql.pack32(fstat64_info.st_blksize)
-            fstat64_buf += ql.pack32(0)
-            fstat64_buf += ql.pack64(fstat64_info.st_blocks)        
-        elif ql.archtype == QL_ARCH.ARM:
-            # pack fstatinfo
-            if ql.platform == QL_OS.MACOS:
-                fstat64_buf = ql.pack64s(fstat64_info.st_dev)
-            else:
-                fstat64_buf = ql.pack64(fstat64_info.st_dev)
-            fstat64_buf += ql.pack32(0)
-            fstat64_buf += ql.pack32(fstat64_info.st_ino)
-            fstat64_buf += ql.pack32(fstat64_info.st_mode)
-            fstat64_buf += ql.pack32(fstat64_info.st_nlink)
-            fstat64_buf += ql.pack32(fstat64_info.st_uid)
-            fstat64_buf += ql.pack32(fstat64_info.st_gid)
-            fstat64_buf += ql.pack64(fstat64_info.st_rdev) #?? fstat_info.st_rdev
-            fstat64_buf += ql.pack64(0) 
-            fstat64_buf += ql.pack64(fstat64_info.st_size)
-            fstat64_buf += ql.pack64(fstat64_info.st_blksize) #?? fstat_info.st_blksize
-            fstat64_buf += ql.pack64(fstat64_info.st_blocks) #?? fstat_info.st_blocks
-            fstat64_buf += ql.pack64(int(fstat64_info.st_atime))
-            fstat64_buf += ql.pack64(int(fstat64_info.st_mtime))
-            fstat64_buf += ql.pack64(int(fstat64_info.st_ctime))
-            fstat64_buf += ql.pack64(fstat64_info.st_ino)
-
-        else:
-            # pack fstatinfo
-            if ql.platform == QL_OS.MACOS:
-                fstat64_buf = ql.pack64s(fstat64_info.st_dev)
-            else:
-                fstat64_buf = ql.pack64(fstat64_info.st_dev)
-            fstat64_buf += ql.pack64(0x0000000300c30000)
-            fstat64_buf += ql.pack32(fstat64_info.st_mode)
-            fstat64_buf += ql.pack32(fstat64_info.st_nlink)
-            fstat64_buf += ql.pack32(fstat64_info.st_uid)
-            fstat64_buf += ql.pack32(fstat64_info.st_gid)
-            fstat64_buf += ql.pack64(0x0000000000008800) #?? fstat_info.st_rdev
-            fstat64_buf += ql.pack32(0xffffd257)
-            fstat64_buf += ql.pack64(fstat64_info.st_size)
-            fstat64_buf += ql.pack32(0x00000400) #?? fstat_info.st_blksize
-            fstat64_buf += ql.pack64(0x0000000000000000) #?? fstat_info.st_blocks
-            fstat64_buf += ql.pack64(int(fstat64_info.st_atime))
-            fstat64_buf += ql.pack64(int(fstat64_info.st_mtime))
-            fstat64_buf += ql.pack64(int(fstat64_info.st_ctime))
-            fstat64_buf += ql.pack64(fstat64_info.st_ino)
-
+        fstat64_buf = create_stat64_struct(ql, fstat64_info)
         ql.mem.write(fstat64_add, fstat64_buf)
         regreturn = 0
     else:
@@ -210,107 +313,10 @@ def ql_syscall_fstat64(ql, fstat64_fd, fstat64_add, *args, **kw):
 
 
 def ql_syscall_fstat(ql, fstat_fd, fstat_add, *args, **kw):
-
     if fstat_fd < 256 and ql.os.fd[fstat_fd] != 0 and hasattr(ql.os.fd[fstat_fd], "fstat"):
         user_fileno = fstat_fd
         fstat_info = ql.os.fd[user_fileno].fstat()
-
-        if ql.archtype== QL_ARCH.MIPS:
-            # pack fstatinfo
-            fstat_buf = ql.pack32(fstat_info.st_dev)
-            fstat_buf += ql.pack32(0) * 3
-            fstat_buf += ql.pack32(fstat_info.st_ino)
-            fstat_buf += ql.pack32(fstat_info.st_mode)
-            fstat_buf += ql.pack32(fstat_info.st_nlink)
-            fstat_buf += ql.pack32(fstat_info.st_uid)
-            fstat_buf += ql.pack32(fstat_info.st_gid)
-            fstat_buf += ql.pack32(fstat_info.st_rdev)
-            fstat_buf += ql.pack32(0) * 2
-            fstat_buf += ql.pack32(fstat_info.st_size)
-            fstat_buf += ql.pack32(0)
-            fstat_buf += ql.pack32(int(fstat_info.st_atime))
-            fstat_buf += ql.pack32(0)
-            fstat_buf += ql.pack32(int(fstat_info.st_mtime))
-            fstat_buf += ql.pack32(0)
-            fstat_buf += ql.pack32(int(fstat_info.st_ctime))
-            fstat_buf += ql.pack32(0)
-            fstat_buf += ql.pack32(fstat_info.st_blksize)
-            fstat_buf += ql.pack32(fstat_info.st_blocks)
-            fstat_buf = fstat_buf.ljust(0x90, b'\x00')
-        elif ql.archtype== QL_ARCH.X8664:
-            if ql.platform == QL_OS.MACOS:
-                fstat_buf = ql.pack64s(fstat_info.st_dev)
-            else:
-                fstat_buf = ql.pack64(fstat_info.st_dev)
-            fstat_buf += ql.pack(fstat_info.st_ino)
-            fstat_buf += ql.pack64(fstat_info.st_nlink)
-            fstat_buf += ql.pack32(fstat_info.st_mode)
-            fstat_buf += ql.pack32(fstat_info.st_uid)
-            fstat_buf += ql.pack32(fstat_info.st_gid)
-            fstat_buf += ql.pack32(0)
-            fstat_buf += ql.pack64(fstat_info.st_rdev)
-            fstat_buf += ql.pack64(fstat_info.st_size)
-            fstat_buf += ql.pack64(fstat_info.st_blksize)
-            fstat_buf += ql.pack64(fstat_info.st_blocks)
-            fstat_buf += ql.pack64(int(fstat_info.st_atime))
-            fstat_buf += ql.pack64(0)
-            fstat_buf += ql.pack64(int(fstat_info.st_mtime))
-            fstat_buf += ql.pack64(0)
-            fstat_buf += ql.pack64(int(fstat_info.st_ctime))
-            fstat_buf += ql.pack64(0)
-        elif ql.archtype== QL_ARCH.ARM64:
-            # struct stat is : 80 addr is : 0x4000811bc8
-            # buf.st_dev offest 0 8 0
-            # buf.st_ino offest 8 8 0
-            # buf.st_mode offest 10 4 0
-            # buf.st_nlink offest 14 4 0
-            # buf.st_uid offest 18 4 0
-            # buf.st_gid offest 1c 4 0
-            # buf.st_rdev offest 20 8 0
-            # buf.st_size offest 30 8 274886889936
-            # buf.st_blksize offest 38 4 8461328
-            # buf.st_blocks offest 40 8 274877909532
-            # buf.st_atime offest 48 8 274886368336
-            # buf.st_mtime offest 58 8 274877909472
-            # buf.st_ctime offest 68 8 274886368336
-            # buf.__glibc_reserved offest 78 8
-            if ql.platform == QL_OS.MACOS:
-                fstat_buf = ql.pack64s(fstat_info.st_dev)
-            else:
-                fstat_buf = ql.pack64(fstat_info.st_dev)
-            fstat_buf += ql.pack64(fstat_info.st_ino)
-            fstat_buf += ql.pack32(fstat_info.st_mode)
-            fstat_buf += ql.pack32(fstat_info.st_nlink)
-            fstat_buf += ql.pack32(ql.os.uid)
-            fstat_buf += ql.pack32(ql.os.gid)
-            fstat_buf += ql.pack64(fstat_info.st_rdev)
-            fstat_buf += ql.pack64(0)
-            fstat_buf += ql.pack64(fstat_info.st_size)
-            fstat_buf += ql.pack32(fstat_info.st_blksize)
-            fstat_buf += ql.pack32(0)
-            fstat_buf += ql.pack64(fstat_info.st_blocks)
-            fstat_buf += ql.pack64(int(fstat_info.st_atime))
-            fstat_buf += ql.pack64(0)
-            fstat_buf += ql.pack64(int(fstat_info.st_mtime))
-            fstat_buf += ql.pack64(0)
-            fstat_buf += ql.pack64(int(fstat_info.st_ctime))
-            fstat_buf += ql.pack64(0)
-        else:
-            # pack fstatinfo
-            fstat_buf = ql.pack32(fstat_info.st_dev)
-            fstat_buf += ql.pack(fstat_info.st_ino)
-            fstat_buf += ql.pack32(fstat_info.st_mode)
-            fstat_buf += ql.pack32(fstat_info.st_nlink)
-            fstat_buf += ql.pack32(fstat_info.st_uid)
-            fstat_buf += ql.pack32(fstat_info.st_gid)
-            fstat_buf += ql.pack32(fstat_info.st_rdev)
-            fstat_buf += ql.pack32(fstat_info.st_size)
-            fstat_buf += ql.pack32(fstat_info.st_blksize)
-            fstat_buf += ql.pack32(fstat_info.st_blocks)
-            fstat_buf += ql.pack32(int(fstat_info.st_atime))
-            fstat_buf += ql.pack32(int(fstat_info.st_mtime))
-            fstat_buf += ql.pack32(int(fstat_info.st_ctime))
-
+        fstat_buf = create_stat_struct(ql, fstat_info)
         ql.mem.write(fstat_add, fstat_buf)
         regreturn = 0
     else:
@@ -326,65 +332,12 @@ def ql_syscall_fstat(ql, fstat_fd, fstat_add, *args, **kw):
 # int stat64(const char *pathname, struct stat64 *buf);
 def ql_syscall_stat64(ql, stat64_pathname, stat64_buf_ptr, *args, **kw):
     stat64_file = (ql.mem.string(stat64_pathname))
-
     real_path = ql.os.transform_to_real_path(stat64_file)
-    relative_path = ql.os.transform_to_relative_path(stat64_file)
     if os.path.exists(real_path) == False:
         regreturn = -1
     else:
         stat64_info = Stat(real_path)
-
-        if ql.archtype== QL_ARCH.MIPS:
-            # packfstatinfo
-            # name offset size
-            # struct stat is : a0
-            # buf.st_dev offest 0 4
-            # buf.st_ino offest 10 8
-            # buf.st_mode offest 18 4
-            # buf.st_nlink offest 1c 4
-            # buf.st_uid offest 20 4
-            # buf.st_gid offest 24 4
-            # buf.st_rdev offest 28 4
-            # buf.st_size offest 38 8
-            # buf.st_blksize offest 58 4
-            # buf.st_blocks offest 60 8
-            # buf.st_atime offest 40 4
-            # buf.st_mtime offest 48 4
-            # buf.st_ctime offest 50 4
-            stat64_buf = ql.pack32(stat64_info.st_dev)
-            stat64_buf += ql.pack32(0) * 3
-            stat64_buf += ql.pack64(stat64_info.st_ino)
-            stat64_buf += ql.pack32(stat64_info.st_mode)
-            stat64_buf += ql.pack32(stat64_info.st_nlink)
-            stat64_buf += ql.pack32(1000)
-            stat64_buf += ql.pack32(1000)
-            stat64_buf += ql.pack32(stat64_info.st_rdev)
-            stat64_buf += ql.pack32(0) * 3
-            stat64_buf += ql.pack64(stat64_info.st_size)
-            stat64_buf += ql.pack64(int(stat64_info.st_atime))
-            stat64_buf += ql.pack64(int(stat64_info.st_mtime))
-            stat64_buf += ql.pack64(int(stat64_info.st_ctime))
-            stat64_buf += ql.pack32(stat64_info.st_blksize)
-            stat64_buf += ql.pack32(0)
-            stat64_buf += ql.pack64(stat64_info.st_blocks)
-        else:
-            # packfstatinfo
-            stat64_buf = ql.pack64(stat64_info.st_dev)
-            stat64_buf += ql.pack64(0x0000000300c30000)
-            stat64_buf += ql.pack32(stat64_info.st_mode)
-            stat64_buf += ql.pack32(stat64_info.st_nlink)
-            stat64_buf += ql.pack32(stat64_info.st_uid)
-            stat64_buf += ql.pack32(stat64_info.st_gid)
-            stat64_buf += ql.pack64(0x0000000000008800) #?? fstat_info.st_rdev
-            stat64_buf += ql.pack32(0xffffd257)
-            stat64_buf += ql.pack64(stat64_info.st_size)
-            stat64_buf += ql.pack32(0x00000400) #?? fstat_info.st_blksize
-            stat64_buf += ql.pack64(0x0000000000000000) #?? fstat_info.st_blocks
-            stat64_buf += ql.pack64(int(stat64_info.st_atime))
-            stat64_buf += ql.pack64(int(stat64_info.st_mtime))
-            stat64_buf += ql.pack64(int(stat64_info.st_ctime))
-            stat64_buf += ql.pack64(stat64_info.st_ino)
-
+        stat64_buf = create_stat64_struct(ql, stat64_info)
         ql.mem.write(stat64_buf_ptr, stat64_buf)
         regreturn = 0
 
@@ -406,45 +359,7 @@ def ql_syscall_stat(ql, stat_path, stat_buf_ptr, *args, **kw):
         regreturn = -1
     else:
         stat_info = Stat(real_path)
-
-        if ql.archtype== QL_ARCH.MIPS:
-            # pack fstatinfo
-            stat_buf = ql.pack32(stat_info.st_dev)
-            stat_buf += ql.pack32(0) * 3
-            stat_buf += ql.pack32(stat_info.st_ino)
-            stat_buf += ql.pack32(stat_info.st_mode)
-            stat_buf += ql.pack32(stat_info.st_nlink)
-            stat_buf += ql.pack32(stat_info.st_uid)
-            stat_buf += ql.pack32(stat_info.st_gid)
-            stat_buf += ql.pack32(stat_info.st_rdev)
-            stat_buf += ql.pack32(0) * 2
-            stat_buf += ql.pack32(stat_info.st_size)
-            stat_buf += ql.pack32(0)
-            stat_buf += ql.pack32(int(stat_info.st_atime))
-            stat_buf += ql.pack32(0)
-            stat_buf += ql.pack32(int(stat_info.st_mtime))
-            stat_buf += ql.pack32(0)
-            stat_buf += ql.pack32(int(stat_info.st_ctime))
-            stat_buf += ql.pack32(0)
-            stat_buf += ql.pack32(stat_info.st_blksize)
-            stat_buf += ql.pack32(stat_info.st_blocks)
-            stat_buf = stat_buf.ljust(0x90, b'\x00')
-        else:
-            # pack statinfo
-            stat_buf = ql.pack32(stat_info.st_mode)
-            stat_buf += ql.pack32(stat_info.st_ino)
-            stat_buf += ql.pack32(stat_info.st_dev)
-            stat_buf += ql.pack32(stat_info.st_rdev)
-            stat_buf += ql.pack32(stat_info.st_nlink)
-            stat_buf += ql.pack32(stat_info.st_size)
-            stat_buf += ql.pack32(stat_info.st_size)
-            stat_buf += ql.pack32(stat_info.st_size)
-            stat_buf += ql.pack32(int(stat_info.st_atime))
-            stat_buf += ql.pack32(int(stat_info.st_mtime))
-            stat_buf += ql.pack32(int(stat_info.st_ctime))
-            stat_buf += ql.pack32(stat_info.st_blksize)
-            stat_buf += ql.pack32(stat_info.st_blocks)
-
+        stat_buf = create_stat_struct(ql, stat_info)
         regreturn = 0
         ql.mem.write(stat_buf_ptr, stat_buf)
 
@@ -465,45 +380,7 @@ def ql_syscall_lstat(ql, lstat_path, lstat_buf_ptr, *args, **kw):
         regreturn = -1
     else:
         lstat_info = Lstat(real_path)
-
-        if ql.archtype== QL_ARCH.MIPS:
-            # pack fstatinfo
-            lstat_buf = ql.pack32(lstat_info.st_dev)
-            lstat_buf += ql.pack32(0) * 3
-            lstat_buf += ql.pack32(lstat_info.st_ino)
-            lstat_buf += ql.pack32(lstat_info.st_mode)
-            lstat_buf += ql.pack32(lstat_info.st_nlink)
-            lstat_buf += ql.pack32(lstat_info.st_uid)
-            lstat_buf += ql.pack32(lstat_info.st_gid)
-            lstat_buf += ql.pack32(lstat_info.st_rdev)
-            lstat_buf += ql.pack32(0) * 2
-            lstat_buf += ql.pack32(lstat_info.st_size)
-            lstat_buf += ql.pack32(0)
-            lstat_buf += ql.pack32(int(lstat_info.st_atime))
-            lstat_buf += ql.pack32(0)
-            lstat_buf += ql.pack32(int(lstat_info.st_mtime))
-            lstat_buf += ql.pack32(0)
-            lstat_buf += ql.pack32(int(lstat_info.st_ctime))
-            lstat_buf += ql.pack32(0)
-            lstat_buf += ql.pack32(lstat_info.st_blksize)
-            lstat_buf += ql.pack32(lstat_info.st_blocks)
-            lstat_buf = lstat_buf.ljust(0x90, b'\x00')
-        else:
-            # pack statinfo
-            lstat_buf = ql.pack32(lstat_info.st_mode)
-            lstat_buf += ql.pack32(lstat_info.st_ino)
-            lstat_buf += ql.pack32(lstat_info.st_dev)
-            lstat_buf += ql.pack32(lstat_info.st_rdev)
-            lstat_buf += ql.pack32(lstat_info.st_nlink)
-            lstat_buf += ql.pack32(lstat_info.st_size)
-            lstat_buf += ql.pack32(lstat_info.st_size)
-            lstat_buf += ql.pack32(lstat_info.st_size)
-            lstat_buf += ql.pack32(int(lstat_info.st_atime))
-            lstat_buf += ql.pack32(int(lstat_info.st_mtime))
-            lstat_buf += ql.pack32(int(lstat_info.st_ctime))
-            lstat_buf += ql.pack32(lstat_info.st_blksize)
-            lstat_buf += ql.pack32(lstat_info.st_blocks)
-
+        lstat_buf = create_stat_struct(ql, lstat_info)
         regreturn = 0
         ql.mem.write(lstat_buf_ptr, lstat_buf)
 
@@ -512,6 +389,28 @@ def ql_syscall_lstat(ql, lstat_path, lstat_buf_ptr, *args, **kw):
     else:
         ql.log.debug("lstat() read/write fail")
     return regreturn
+
+
+def ql_syscall_lstat64(ql, lstat64_path, lstat64_buf_ptr, *args, **kw):
+    lstat_file = (ql.mem.string(lstat64_path))
+
+    real_path = ql.os.transform_to_real_path(lstat_file)
+    relative_path = ql.os.transform_to_relative_path(lstat_file)
+
+    if os.path.exists(real_path) == False:
+        regreturn = -1
+    else:
+        lstat_info = Lstat(real_path)
+        lstat64_buf = create_stat64_struct(ql, lstat_info)
+        regreturn = 0
+        ql.mem.write(lstat64_buf_ptr, lstat64_buf)
+
+    if regreturn == 0:
+        ql.log.debug("lstat64() write completed")
+    else:
+        ql.log.debug("lstat64() read/write fail")
+    return regreturn
+
 
 def ql_syscall_mknodat(ql, dirfd, pathname, mode, dev, *args, **kw):
     # fix me. dirfd(relative path) not implement.

--- a/qiling/os/stat.py
+++ b/qiling/os/stat.py
@@ -9,49 +9,18 @@ class Stat(object):
     def __init__(self, path):
         super().__init__()
         self.path = path
-
-        self.st_dev = 0
-        self.st_blksize = 0
-        self.st_blocks = 0
-        self.st_gid = 0
-        self.st_ino = 0
-        self.st_mode = 0
-        self.st_nlink = 0
-        self.st_rdev = 0
-        self.st_size = 0
-        self.st_uid = 0
-        self.st_atime = 0
-        self.st_mtime = 0
-        self.st_ctime = 0
-
         stat_buf = os.stat(self.path)
         for name in dir(stat_buf):
-            if 'st_' in name:
+            if name.startswith('st_'):
                 setattr(self, name, getattr(stat_buf, name))
 
 class Fstat(object):
     def __init__(self, fd):
         super().__init__()
         self.fd = fd
-
-        self.st_atime = 0
-        self.st_blksize = 0
-        self.st_blocks = 0
-        self.st_ctime = 0
-        self.st_dev = 0
-        self.st_gid = 0
-        self.st_ino = 0
-        self.st_mode = 0
-        self.st_mtime = 0
-        self.st_nlink = 0
-        self.st_rdev = 0
-        self.st_size = 0
-        self.st_uid = 0
-
-
         fstat_buf = os.fstat(self.fd)
         for name in dir(fstat_buf):
-            if 'st_' in name:
+            if name.startswith('st_'):
                 setattr(self, name, getattr(fstat_buf, name))
 
 
@@ -59,25 +28,9 @@ class Lstat(object):
     def __init__(self, path):
         super().__init__()
         self.path = path
-
-        self.st_atime = 0
-        self.st_blksize = 0
-        self.st_blocks = 0
-        self.st_ctime = 0
-        self.st_dev = 0
-        self.st_gid = 0
-        self.st_ino = 0
-        self.st_mode = 0
-        self.st_mtime = 0
-        self.st_nlink = 0
-        self.st_rdev = 0
-        self.st_size = 0
-        self.st_uid = 0
-
-
         lstat_buf = os.lstat(self.path)
         for name in dir(lstat_buf):
-            if 'st_' in name:
+            if name.startswith('st_'):
                 setattr(self, name, getattr(lstat_buf, name))
 
 


### PR DESCRIPTION
PR for [issue Posix: fstat and stat should be "merged"](https://github.com/qilingframework/qiling/issues/674)

fstat/stat/lstat should create a struct of the same form. This is now the case because the struct creation is exported to a new function that contains the code from the fstat struct creation, since it has the most details. Same goes for fstat64/stat64. lstat64 was added aswell.

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [ ] This PR only contains minor fixes.
- [X] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [X] The imports are arranged properly.
- [ ] Essential comments are added.
- [X] The reference of the new code is pointed out.

### Extra tests?

- [X] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [X] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
