### PR TITLE
Signal event upon InstallProtocolInterface.

### DIFF
--- a/qiling/os/uefi/bs.py
+++ b/qiling/os/uefi/bs.py
@@ -132,14 +132,7 @@ def hook_SignalEvent(ql, address, params):
 	event_id = params["Event"]
 
 	if event_id in ql.loader.events:
-		event = ql.loader.events[event_id]
-
-		if not event["Set"]:
-			event["Set"] = True
-			notify_func = event["NotifyFunction"]
-			notify_context = event["NotifyContext"]
-			ql.loader.notify_list.append((event_id, notify_func, notify_context))
-
+		signal_event(ql, event_id)
 		return EFI_SUCCESS
 	else:
 		return EFI_INVALID_PARAMETER

--- a/qiling/os/uefi/protocols/common.py
+++ b/qiling/os/uefi/protocols/common.py
@@ -4,7 +4,7 @@
 #
 
 from qiling.os.uefi.const import EFI_SUCCESS, EFI_NOT_FOUND, EFI_UNSUPPORTED, EFI_BUFFER_TOO_SMALL, EFI_INVALID_PARAMETER
-from qiling.os.uefi.utils import read_int64, write_int64, check_and_notify_protocols
+from qiling.os.uefi.utils import read_int64, write_int64, check_and_notify_protocols, signal_event
 from qiling.os.uefi.UefiSpec import EFI_LOCATE_SEARCH_TYPE
 
 # TODO: get rid of this
@@ -37,6 +37,12 @@ def InstallProtocolInterface(context, params):
 
 	dic[params["Protocol"]] = params["Interface"]
 	context.protocols[handle] = dic
+
+	for (event_id, event_dic) in context.ql.loader.events.items():
+		if event_dic['Guid'] == params['Protocol']:
+			# The event was previously registered by 'RegisterProtocolNotify'.
+			signal_event(context.ql, event_id)	
+
 	check_and_notify_protocols(context.ql)
 	write_int64(context.ql, params["Handle"], handle)
 

--- a/qiling/os/uefi/utils.py
+++ b/qiling/os/uefi/utils.py
@@ -12,6 +12,15 @@ from qiling.os.uefi.const import EFI_SUCCESS, EFI_INVALID_PARAMETER
 from qiling.os.uefi.UefiSpec import EFI_CONFIGURATION_TABLE, EFI_SYSTEM_TABLE
 from qiling.os.uefi.UefiBaseType import EFI_GUID
 
+def signal_event(ql, event_id: int) -> None:
+	event = ql.loader.events[event_id]
+
+	if not event["Set"]:
+		event["Set"] = True
+		notify_func = event["NotifyFunction"]
+		notify_context = event["NotifyContext"]
+		ql.loader.notify_list.append((event_id, notify_func, notify_context))
+
 def check_and_notify_protocols(ql) -> bool:
 	if ql.loader.notify_list:
 		event_id, notify_func, notify_context = ql.loader.notify_list.pop(0)


### PR DESCRIPTION
A UEFI module can register a notification routine to be executed once a given protocol becomes available by:
1. [Creating](https://dox.ipxe.org/UefiSpec_8h.html#a136cb7690540176a224528745133f019) and initializing an `EFI_EVENT` with the notification function.
2. Passing the event, alongside the desired protocol GUID to [RegisterProtocolNotify](https://dox.ipxe.org/UefiSpec_8h.html#afd363625c194ad93f8786cee87a877f7).

This PR adds this functionality to the UEFI emulator by calling the relevant notification routines once a protocol becomes available.

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [x] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
