### PR TITLE
Add accessor to retrieve hooks for a specific address

### DIFF
--- a/qiling/core_hooks.py
+++ b/qiling/core_hooks.py
@@ -343,6 +343,9 @@ class QlCoreHooks:
         return HookRet(self, None, h)
     
 
+    def get_hook_address(self, address):
+        return self._addr_hook.get(address, [])
+
     def hook_intno(self, callback, intno, user_data=None):
         h = HookIntr(callback, intno, user_data)
         self._ql_hook(UC_HOOK_INTR, h)


### PR DESCRIPTION
I needed this to translate an address to a human readable name,
since f.e. uefi samples 'hook' addresses to use api's