### PR TITLE
Set PE_RUN to False if there are no more uefi modules to run

### DIFF
--- a/qiling/os/uefi/shutdown.py
+++ b/qiling/os/uefi/shutdown.py
@@ -23,3 +23,4 @@ def hook_EndOfExecution(ql):
 
         ql.log.info(f'No more modules to run')
         ql.emu_stop()
+        ql.os.PE_RUN = False


### PR DESCRIPTION
It might be a good idea to drop PE_RUN entirely, and set some generic flag when calling `emu_stop`,
but for now this is good enough.