### PR TITLE
resolve multilevel symbolic links

### DIFF
--- a/examples/rootfs/arm_linux/bitdefender
+++ b/examples/rootfs/arm_linux/bitdefender
@@ -1,1 +1,0 @@
-/media/nand/bitdefender

--- a/examples/rootfs/arm_linux/bitdefender
+++ b/examples/rootfs/arm_linux/bitdefender
@@ -1,0 +1,1 @@
+/media/nand/bitdefender

--- a/examples/rootfs/arm_linux/lib/libsymlink_test.so
+++ b/examples/rootfs/arm_linux/lib/libsymlink_test.so
@@ -1,0 +1,1 @@
+/symlink_test/libsymlink_test.so

--- a/examples/rootfs/arm_linux/lib/libtest.so
+++ b/examples/rootfs/arm_linux/lib/libtest.so
@@ -1,0 +1,1 @@
+/bitdefender/libtest.so

--- a/examples/rootfs/arm_linux/lib/libtest.so
+++ b/examples/rootfs/arm_linux/lib/libtest.so
@@ -1,1 +1,0 @@
-/bitdefender/libtest.so

--- a/examples/rootfs/arm_linux/media
+++ b/examples/rootfs/arm_linux/media
@@ -1,0 +1,1 @@
+/tmp/media

--- a/examples/rootfs/arm_linux/symlink_test
+++ b/examples/rootfs/arm_linux/symlink_test
@@ -1,0 +1,1 @@
+/media/nand/symlink_test

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -332,6 +332,20 @@ class QlOsUtils:
             link_path = Path(os.readlink(real_path))
             if not link_path.is_absolute():
                 real_path = Path(os.path.join(os.path.dirname(real_path), link_path))
+
+            # resolve multilevel symbolic link
+            if not os.path.exists(real_path):
+                path_dirs = link_path.parts
+                if link_path.is_absolute():
+                    path_dirs = path_dirs[1:]
+
+                for i in range(0, len(path_dirs)-1):
+                    path_prefix = os.path.sep.join(path_dirs[:i+1])
+                    real_path_prefix = self.transform_to_real_path(path_prefix)
+                    path_remain = os.path.sep.join(path_dirs[i+1:])
+                    real_path = Path(os.path.join(real_path_prefix, path_remain))
+                    if os.path.exists(real_path):
+                        break
             
         return str(real_path.absolute())
 

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -933,8 +933,8 @@ class ELFTest(unittest.TestCase):
 
     def test_arm_directory_symlink(self):
         ql = Qiling(["../examples/rootfs/arm_linux/bin/arm_hello"], "../examples/rootfs/arm_linux", output = "debug")
-        real_path = ql.os.transform_to_real_path("/lib/libtest.so")
-        self.assertTrue(real_path.endswith("/examples/rootfs/arm_linux/tmp/media/nand/bitdefender/libtest.so"))
+        real_path = ql.os.transform_to_real_path("/lib/libsymlink_test.so")
+        self.assertTrue(real_path.endswith("/examples/rootfs/arm_linux/tmp/media/nand/symlink_test/libsymlink_test.so"))
         del ql
 
     def test_x8664_absolute_path(self):

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -931,6 +931,11 @@ class ELFTest(unittest.TestCase):
         ql.run()
         del ql
 
+    def test_arm_directory_symlink(self):
+        ql = Qiling(["../examples/rootfs/arm_linux/bin/arm_hello"], "../examples/rootfs/arm_linux", output = "debug")
+        real_path = ql.os.transform_to_real_path("/lib/libtest.so")
+        self.assertTrue(real_path.endswith("/examples/rootfs/arm_linux/tmp/media/nand/bitdefender/libtest.so"))
+        del ql
 
     def test_x8664_absolute_path(self):
         class MyPipe():


### PR DESCRIPTION
In IoT devices' file system, it's common to see there exists symbolic links on directory/file. We can manually fix the symbolic links, but it's better to handle them automatically.

By the way, the following lines even fail to handle a direct symbolic link. For example, the target link often starts with `'/'`. Then `not link_path.is_absolute()` will be `False`. As a result, `<rootfs>/lib/libbdbroker.so` will be returned.

https://github.com/qilingframework/qiling/blob/e4f07cf1e2cbbfe1c400d786ad7b41cb51446938/qiling/os/utils.py#L332-L334

```shell
$ ls -l ./lib/libbd*
lrwxrwxrwx 1 cq cq 48 Oct 19  2019 ./lib/libbdbroker.so -> /opt/bitdefender/patches/base/lib/libbdbroker.so

```

