### PR TITLE
speed up gdb setup

### DIFF
--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -60,14 +60,12 @@ class QlGdb(QlDebugger, object):
             load_address = ql.loader.load_address
             exit_point = load_address + os.path.getsize(ql.path)
 
-        self.gdb.initialize(self.ql, exit_point=exit_point, mappings=[(hex(load_address))])
-        
         if self.ql.ostype in (QL_OS.LINUX, QL_OS.FREEBSD) and not self.ql.code:
             self.entry_point = self.ql.os.elf_entry
         else:
             self.entry_point = self.ql.os.entry_point
-           
-        self.gdb.bp_insert(self.entry_point)
+
+        self.gdb.initialize(self.ql, self.entry_point, exit_point=exit_point, mappings=[(hex(load_address))])
 
         #Setup register tables, order of tables is important
         self.tables = {


### PR DESCRIPTION
Currently, the inbuilt gdb feature utilize the `hook_code()` to instruct every executed instruction. The speed is slow, compared to original gdb.

When setting up gdb, it will also hook code in related elf loader. In my case, it will take a few seconds (maybe more) to reach at the entry of target binary.

https://github.com/qilingframework/qiling/blob/589e81c78b6fbbf475981fd260b42698811863cd/qiling/debugger/gdb/utils.py#L26-L31

From debugging view, hooking code in elf loader is not necessary. So I use a trick: place a `hook_address()` directly at the entry of target binary, after that use `hook_code()`. With this change, set up gdb is faster in my case.

By the way, since using `hook_code()` in entire target elf binary is still slow, can we use `hook_address()` for breakpoints similarly? I'm not familiar with the gdb protocol. So just share my ideas. 

