### PR TITLE
Introduce the 'update_struct' utility.

### DIFF
--- a/qiling/os/uefi/context.py
+++ b/qiling/os/uefi/context.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 from qiling.os.memory import QlMemoryHeap
-from qiling.os.uefi.utils import init_struct, str_to_guid
+from qiling.os.uefi.utils import init_struct, update_struct, str_to_guid
 from qiling.os.uefi.UefiSpec import EFI_CONFIGURATION_TABLE, EFI_SYSTEM_TABLE
 from qiling.os.uefi.smst import EFI_SMM_SYSTEM_TABLE2
 
@@ -62,9 +62,8 @@ class DxeContext(UefiContext):
 	def install_configuration_table(self, guid, table):
 		super().install_configuration_table(guid, table)
 		# Update number of configuration table entries in the ST.
-		gST = EFI_SYSTEM_TABLE.loadFrom(self.ql, self.ql.loader.gST)
-		gST.NumberOfTableEntries = len(self.conf_table_array)
-		gST.saveTo(self.ql, self.ql.loader.gST)
+		with update_struct(EFI_SYSTEM_TABLE, self.ql, self.ql.loader.gST) as gST:
+			gST.NumberOfTableEntries = len(self.conf_table_array)
 
 class SmmContext(UefiContext):
 	def __init__(self, ql):
@@ -81,6 +80,5 @@ class SmmContext(UefiContext):
 	def install_configuration_table(self, guid, table):
 		super().install_configuration_table(guid, table)
 		# Update number of configuration table entries in the SMST.
-		gSmst = EFI_SMM_SYSTEM_TABLE2.loadFrom(self.ql, self.ql.loader.gSmst)
-		gSmst.NumberOfTableEntries = len(self.conf_table_array)
-		gSmst.saveTo(self.ql, self.ql.loader.gSmst)
+		with update_struct(EFI_SMM_SYSTEM_TABLE2, self.ql, self.ql.loader.gSmst) as gSmst:
+			gSmst.NumberOfTableEntries = len(self.conf_table_array)

--- a/qiling/os/uefi/utils.py
+++ b/qiling/os/uefi/utils.py
@@ -7,6 +7,7 @@ import binascii
 
 from uuid import UUID
 from typing import Optional
+from contextlib import contextmanager
 
 from qiling.os.uefi.const import EFI_SUCCESS, EFI_INVALID_PARAMETER
 from qiling.os.uefi.UefiSpec import EFI_CONFIGURATION_TABLE, EFI_SYSTEM_TABLE
@@ -103,6 +104,14 @@ def init_struct(ql, base: int, descriptor: dict):
 	ql.log.info(f'')
 
 	return isntance
+
+@contextmanager
+def update_struct(cls, ql, address: int):
+	struct = cls.loadFrom(ql, address)
+	try:
+		yield struct
+	finally:
+		struct.saveTo(ql, address)
 
 def str_to_guid(guid: str) -> EFI_GUID:
 	"""Construct an EFI_GUID structure out of a plain GUID string.


### PR DESCRIPTION
When updating a structure, the following pattern is quite common:
```
x = STRUCT.loadFrom(ql, address)
x.member = y
x.saveTo(ql, address)
```

This PR suggests the `update_struct` utility as a means to avoid all this boilerplate code. As such, the code becomes much more concise:

```
with update_struct(STRUCT, ql, address) as x:
	x.member = y
```

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [ ] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [x] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [x] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
