### PR TITLE
Call new_thread_id() as method outside of QlLinuxX8664Thread object

### DIFF
--- a/qiling/os/posix/syscall/sched.py
+++ b/qiling/os/posix/syscall/sched.py
@@ -6,7 +6,6 @@
 import types
 from multiprocessing import Process
 
-
 from qiling.const import *
 from qiling.os.linux.thread import *
 from qiling.const import *

--- a/qiling/os/posix/syscall/sched.py
+++ b/qiling/os/posix/syscall/sched.py
@@ -72,7 +72,7 @@ def ql_syscall_clone(ql, clone_flags, clone_child_stack, clone_parent_tidptr, cl
             ql.os.child_processes = True
 
             f_th.update_global_thread_id()
-            f_th.new_thread_id()
+            new_thread_id()
 
             if clone_flags & CLONE_SETTLS == CLONE_SETTLS:
                 f_th.set_thread_tls(clone_newtls)


### PR DESCRIPTION
Minor bugfix for `clone()` system call emulation

### Issue Encoutered

I'm emulating a multithreaded application, and `clone()` failed cause of the following:

```
[=] [Thread 2000]	0x7fffb7eddb1a: clone(flags=0x1200011, childstack=0x0, parenttidptr=0x0, newtls=0x7fffb81eaa10, childtidptr=0x7fffb81ea740)
[x] [Thread 2000]	
Traceback (most recent call last):
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/os/posix/posix.py", line 191, in load_syscall
    ret = self.syscall_map(self.ql, self.get_func_arg()[0], self.get_func_arg()[1], self.get_func_arg()[2], self.get_func_arg()[3], self.get_func_arg()[4], self.get_func_arg()[5])
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/os/posix/syscall/sched.py", line 75, in ql_syscall_clone
    f_th.new_thread_id()
AttributeError: 'QlLinuxX8664Thread' object has no attribute 'new_thread_id'
[=] [Thread 2000]	Syscall ERROR: ql_syscall_clone DEBUG: 'QlLinuxX8664Thread' object has no attribute 'new_thread_id'
[=] [Thread 2000]	0x7fffb7e37feb: rt_sigaction(sigactionsignum=0x1, sigactionact=0x80000000aa70, sigactionoldact=0x80000000ab10)
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/os/linux/thread.py", line 253, in _run
    self.ql.emu_start(start_address, self.exit_point, count=30000)
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/core.py", line 900, in emu_start
    raise self._internal_exception
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/utils.py", line 156, in wrapper
    return func(*args, **kw)
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/core_hooks.py", line 132, in _hook_insn_cb
    ret = h.call(ql, *args[ : -1])
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/core_hooks.py", line 34, in call
    return self.callback(ql, *args)
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/os/linux/linux.py", line 72, in hook_syscall
    return self.load_syscall()
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/os/posix/posix.py", line 206, in load_syscall
    raise e
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/os/posix/posix.py", line 191, in load_syscall
    ret = self.syscall_map(self.ql, self.get_func_arg()[0], self.get_func_arg()[1], self.get_func_arg()[2], self.get_func_arg()[3], self.get_func_arg()[4], self.get_func_arg()[5])
  File "/home/alan/Code/deobfuscate/venv/lib/python3.8/site-packages/qiling/os/posix/syscall/sched.py", line 75, in ql_syscall_clone
    f_th.new_thread_id()
AttributeError: 'QlLinuxX8664Thread' object has no attribute 'new_thread_id'
2021-03-19T15:56:18Z <QlLinuxX8664Thread at 0x7f7bab93f6a0: _run> failed with AttributeError
```

### Fix

A simple fix is made such that `new_thread_id()` is called outside of the `QlLinuxX8664Thread` object, since it doesn't exist as an attribute.