### PR TITLE
Qdb and syscall_writev improvements

### DIFF
--- a/qiling/debugger/qdb/frontend.py
+++ b/qiling/debugger/qdb/frontend.py
@@ -150,7 +150,7 @@ def context_reg(ql, saved_states=None, *args, **kwargs):
         for idx in range(8):
             _addr = ql.reg.arch_sp + idx * 4
             _val = ql.mem.read(_addr, ql.archbit // 8)
-            print("$sp+0x%02x|[0x%08x]=> 0x%08x" % (idx*4, _addr, ql.unpack(_val)), end="")
+            print(f"$sp+0x{idx*4:02x}|[0x{_addr:08x}]=> 0x{ql.unpack(_val):08x}", end="")
 
             try: # try to deference wether its a pointer
                 _deref = ql.mem.read(_addr, 4)
@@ -158,16 +158,16 @@ def context_reg(ql, saved_states=None, *args, **kwargs):
                 _deref = None
 
             if _deref:
-                print(" => 0x%08x" % ql.unpack(_deref))
+                print(f" => 0x{ql.unpack(_deref):08x}")
 
 
 def print_asm(ql, instructions):
     for ins in instructions:
         fmt = (ins.address, ins.mnemonic.ljust(6), ins.op_str)
         if ql.reg.arch_pc == ins.address:
-            print("PC ==>  0x%x\t%s %s" % fmt)
+            print(f"PC ==>  0x{fmt[0]:x}\t{fmt[1]} {fmt[2]}")
         else:
-            print("\t0x%x\t%s %s" % fmt)
+            print(f"\t0x{fmt[0]:x}\t{fmt[1]} {fmt[2]}")
 
 
 def context_asm(ql, address, size, *args, **kwargs):

--- a/qiling/debugger/qdb/qdb.py
+++ b/qiling/debugger/qdb/qdb.py
@@ -89,7 +89,7 @@ class QlQdb(cmd.Cmd, QlDebugger):
         self.breakpoints.update({address: {"hook": _hook, "hitted": False, "temp": _is_temp}})
 
         if _is_temp == False:
-            print("Breakpoint at 0x%08x" % address)
+            print(f"Breakpoint at 0x{address:08x}")
 
 
     def _breakpoint_handler(self, ql, _is_temp):
@@ -104,7 +104,7 @@ class QlQdb(cmd.Cmd, QlDebugger):
             if self.breakpoints.get(_cur_addr)["hitted"]:
                 return
 
-            print("hit breakpoint at 0x%08x" % _cur_addr)
+            print(f"hit breakpoint at 0x{_cur_addr:08x}")
             self.breakpoints.get(_cur_addr)["hitted"] = True
 
         self.do_context()
@@ -218,7 +218,7 @@ class QlQdb(cmd.Cmd, QlDebugger):
         """
         if self._ql is not None:
             _cur_addr = self._ql.reg.arch_pc
-            print("continued from 0x%08x" % _cur_addr)
+            print(f"continued from 0x{_cur_addr:08x}")
 
             self._run(_cur_addr)
 

--- a/qiling/os/posix/syscall/uio.py
+++ b/qiling/os/posix/syscall/uio.py
@@ -17,9 +17,15 @@ def ql_syscall_writev(ql, writev_fd, writev_vec, writev_vien, *args, **kw):
     size_t_len = ql.archbit // 8
     iov = ql.mem.read(writev_vec, writev_vien * size_t_len * 2)
     ql.log.debug("writev() CONTENT:")
+
     for i in range(writev_vien):
         addr = ql.unpack(iov[i * size_t_len * 2 : i * size_t_len * 2 + size_t_len])
         l = ql.unpack(iov[i * size_t_len * 2 + size_t_len : i * size_t_len * 2 + size_t_len * 2])
         regreturn += l
-        ql.log.debug("%s" % str(ql.mem.read(addr, l)))
+        buf = ql.mem.read(addr, l)
+        ql.log.debug(buf)
+
+        if hasattr(ql.os.fd[writev_fd], "write"):
+            ql.os.fd[writev_fd].write(buf)
+
     return regreturn

--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -244,10 +244,10 @@ def ql_syscall_write(ql, write_fd, write_buf, write_count, *args, **kw):
             ql.log.debug("%s" % buf)
 
         if hasattr(ql.os.fd[write_fd], "write"):
-            
             ql.os.fd[write_fd].write(buf)
         else:
             ql.log.warning("write(%d,%x,%i) failed due to write_fd" % (write_fd, write_buf, write_count, regreturn))
+
         regreturn = write_count
 
     except:


### PR DESCRIPTION
1. use f-string in qdb
2. fix qdb crashed when user try to continue a not-yet started qiling instance
3. make syscall writev actually write to fd