### PR TITLE
qltool refresh

### DIFF
--- a/qiling/arch/utils.py
+++ b/qiling/arch/utils.py
@@ -7,100 +7,87 @@
 This module is intended for general purpose functions that are only used in qiling.arch
 """
 
-from unicorn import UcError, UC_ERR_READ_UNMAPPED, UC_ERR_FETCH_UNMAPPED
-from keystone import *
-from capstone import *
+from capstone import Cs, CS_ARCH_ARM, CS_ARCH_ARM64, CS_ARCH_X86, CS_ARCH_MIPS, CS_MODE_16, CS_MODE_32, CS_MODE_64, CS_MODE_ARM, CS_MODE_THUMB, CS_MODE_MIPS32 ,CS_MODE_BIG_ENDIAN, CS_MODE_LITTLE_ENDIAN
+from keystone import Ks, KS_ARCH_ARM, KS_ARCH_ARM64, KS_ARCH_X86, KS_ARCH_MIPS, KS_MODE_16, KS_MODE_32, KS_MODE_64, KS_MODE_ARM, KS_MODE_THUMB, KS_MODE_MIPS32 ,KS_MODE_BIG_ENDIAN, KS_MODE_LITTLE_ENDIAN
 
-from qiling.const import QL_ARCH, QL_ENDIAN, QL_OS, QL_DEBUGGER, QL_ARCH_32BIT, QL_ARCH_64BIT, QL_ARCH_16BIT
-from qiling.exception import *
+from qiling.const import QL_ARCH, QL_ENDIAN
+from qiling.exception import QlErrorArch
 
+__cs_endian = {
+    QL_ENDIAN.EL : CS_MODE_LITTLE_ENDIAN,
+    QL_ENDIAN.EB : CS_MODE_BIG_ENDIAN
+}
 
-def ql_create_disassembler(archtype, archendian, reg_cpsr=None):
-    if archtype == QL_ARCH.ARM:  # QL_ARM
-        mode = CS_MODE_ARM
-        if archendian == QL_ENDIAN.EB:
-            # TODO: Test for big endian.
-            reg_cpsr_v = 0b100000
-            # reg_cpsr_v = 0b000000
-        else:
-            reg_cpsr_v = 0b100000
+__ks_endian = {
+    QL_ENDIAN.EL : KS_MODE_LITTLE_ENDIAN,
+    QL_ENDIAN.EB : KS_MODE_BIG_ENDIAN
+}
 
-        if reg_cpsr & reg_cpsr_v != 0:
-            mode = CS_MODE_THUMB
+__reg_cpsr_v = {
+    QL_ENDIAN.EL : 0b100000,
+    QL_ENDIAN.EB : 0b100000   # FIXME: should be: 0b000000
+}
 
-        if archendian == QL_ENDIAN.EB:
-            md = Cs(CS_ARCH_ARM, mode)
-            # md = Cs(CS_ARCH_ARM, mode + CS_MODE_BIG_ENDIAN)
-        else:
-            md = Cs(CS_ARCH_ARM, mode)
+def ql_create_disassembler(archtype: QL_ARCH, archendian: QL_ENDIAN, reg_cpsr=None) -> Cs:
+    if archtype == QL_ARCH.X86:
+        md = Cs(CS_ARCH_X86, CS_MODE_32)
+
+    elif archtype == QL_ARCH.X8664:
+        md = Cs(CS_ARCH_X86, CS_MODE_64)
+
+    elif archtype == QL_ARCH.ARM:
+        mode = CS_MODE_THUMB if reg_cpsr & __reg_cpsr_v[archendian] else CS_MODE_ARM
+
+        md = Cs(CS_ARCH_ARM, mode) # FIXME: should be: mode + __cs_endian[archendian]
 
     elif archtype == QL_ARCH.ARM_THUMB:
         md = Cs(CS_ARCH_ARM, CS_MODE_THUMB)
 
-    elif archtype == QL_ARCH.X86:  # QL_X86
-        md = Cs(CS_ARCH_X86, CS_MODE_32)
-
-    elif archtype == QL_ARCH.X8664:  # QL_X86_64
-        md = Cs(CS_ARCH_X86, CS_MODE_64)
-
-    elif archtype == QL_ARCH.ARM64:  # QL_ARM64
+    elif archtype == QL_ARCH.ARM64:
         md = Cs(CS_ARCH_ARM64, CS_MODE_ARM)
 
-    elif archtype == QL_ARCH.A8086:  # QL_A8086
+    elif archtype == QL_ARCH.MIPS:
+        md = Cs(CS_ARCH_MIPS, CS_MODE_MIPS32 + __cs_endian[archendian])
+
+    elif archtype == QL_ARCH.A8086:
         md = Cs(CS_ARCH_X86, CS_MODE_16)
 
-    elif archtype == QL_ARCH.MIPS:  # QL_MIPS32
-        if archendian == QL_ENDIAN.EB:
-            md = Cs(CS_ARCH_MIPS, CS_MODE_MIPS32 + CS_MODE_BIG_ENDIAN)
-        else:
-            md = Cs(CS_ARCH_MIPS, CS_MODE_MIPS32 + CS_MODE_LITTLE_ENDIAN)
+    elif archtype == QL_ARCH.EVM:
+        raise NotImplementedError('evm')
 
     else:
-        raise QlErrorArch("Unknown arch defined in utils.py (debug output mode)")
+        raise QlErrorArch(f'{archtype:d}')
 
     return md
 
-def ql_create_assembler(archtype, archendian, reg_cpsr=None):
-    if archtype == QL_ARCH.ARM:  # QL_ARM
-        mode = KS_MODE_ARM
-        if archendian == QL_ENDIAN.EB:
-            # TODO: Test for big endian.
-            reg_cpsr_v = 0b100000
-            # reg_cpsr_v = 0b000000
-        else:
-            reg_cpsr_v = 0b100000
+def ql_create_assembler(archtype: QL_ARCH, archendian: QL_ENDIAN, reg_cpsr=None) -> Ks:
+    if archtype == QL_ARCH.X86:
+        ks = Ks(KS_ARCH_X86, KS_MODE_32)
 
-        if reg_cpsr & reg_cpsr_v != 0:
-            mode = KS_MODE_THUMB
+    elif archtype == QL_ARCH.X8664:
+        ks = Ks(KS_ARCH_X86, KS_MODE_64)
 
-        if archendian == QL_ENDIAN.EB:
-            ks = Ks(KS_ARCH_ARM, mode)
-            # md = Cs(CS_ARCH_ARM, mode + CS_MODE_BIG_ENDIAN)
-        else:
-            ks = Ks(KS_ARCH_ARM, mode)
+    elif archtype == QL_ARCH.ARM:
+        mode = KS_MODE_THUMB if reg_cpsr & __reg_cpsr_v[archendian] else KS_MODE_ARM
+
+        ks = Ks(KS_ARCH_ARM, mode) # FIXME: should be: mode + __ks_endian[archendian]
 
     elif archtype == QL_ARCH.ARM_THUMB:
         ks = Ks(KS_ARCH_ARM, KS_MODE_THUMB)
 
-    elif archtype == QL_ARCH.X86:  # QL_X86
-        ks = Ks(KS_ARCH_X86, KS_MODE_32)
-
-    elif archtype == QL_ARCH.X8664:  # QL_X86_64
-        ks = Ks(KS_ARCH_X86, KS_MODE_64)
-
-    elif archtype == QL_ARCH.ARM64:  # QL_ARM64
+    elif archtype == QL_ARCH.ARM64:
         ks = Ks(KS_ARCH_ARM64, KS_MODE_LITTLE_ENDIAN)
 
-    elif archtype == QL_ARCH.A8086:  # QL_A8086
+    elif archtype == QL_ARCH.MIPS:
+        ks = Ks(KS_ARCH_MIPS, KS_MODE_MIPS32 + __ks_endian[archendian])
+
+    elif archtype == QL_ARCH.A8086:
         ks = Ks(KS_ARCH_X86, KS_MODE_16)
 
-    elif archtype == QL_ARCH.MIPS:  # QL_MIPS32
-        if archendian == QL_ENDIAN.EB:
-            ks = Ks(KS_ARCH_MIPS, KS_MODE_MIPS32 + KS_MODE_BIG_ENDIAN)
-        else:
-            ks = Ks(KS_ARCH_MIPS, KS_MODE_MIPS32 + KS_MODE_LITTLE_ENDIAN)
+    elif archtype == QL_ARCH.EVM:
+        raise NotImplementedError('evm')
 
     else:
-        raise QlErrorArch("Unknown arch defined in utils.py (debug output mode)")
+        raise QlErrorArch(f'{archtype:d}')
 
     return ks

--- a/qiling/const.py
+++ b/qiling/const.py
@@ -91,6 +91,14 @@ os_map = {
     "evm"       : QL_OS.EVM,
 }
 
+verbose_map = {
+    "off"       : QL_VERBOSE.OFF,
+    "default"   : QL_VERBOSE.DEFAULT,
+    "debug"     : QL_VERBOSE.DEBUG,
+    "disasm"    : QL_VERBOSE.DISASM,
+    "dump"      : QL_VERBOSE.DUMP
+}
+
 loader_map = {
     QL_OS.LINUX   : "ELF",
     QL_OS.FREEBSD : "ELF",

--- a/qiling/const.py
+++ b/qiling/const.py
@@ -3,12 +3,12 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-from enum import IntEnum
+from enum import EnumMeta, IntEnum
+from typing import Mapping
 
 class QL_ENDIAN(IntEnum):
     EL = 1
     EB = 2
-
 
 class QL_ARCH(IntEnum):
     X86 = 101
@@ -41,7 +41,6 @@ class QL_DEBUGGER(IntEnum):
     IDAPRO = 2
     QDB = 3
 
-
 class QL_INTERCEPT(IntEnum):
     CALL = 1
     ENTER = 2
@@ -64,40 +63,16 @@ QL_OS_POSIX         = (QL_OS.LINUX, QL_OS.FREEBSD, QL_OS.MACOS)
 QL_HOOK_BLOCK = 0b0001
 QL_CALL_BLOCK = 0b0010
 
-debugger_map = {
-    "gdb" : QL_DEBUGGER.GDB,
-    "ida" : QL_DEBUGGER.IDAPRO,
-    "qdb" : QL_DEBUGGER.QDB
-}
+def __reverse_enum(e: EnumMeta) -> Mapping[str, int]:
+    '''Create a reverse mapping for an enum.
+    '''
 
-arch_map = {
-    "x86"       : QL_ARCH.X86,
-    "x8664"     : QL_ARCH.X8664,
-    "mips"      : QL_ARCH.MIPS,
-    "arm"       : QL_ARCH.ARM,
-    "arm_thumb" : QL_ARCH.ARM_THUMB,
-    "arm64"     : QL_ARCH.ARM64,
-    "a8086"     : QL_ARCH.A8086,
-    "evm"       : QL_ARCH.EVM,
-}
+    return dict((k.lower(), v.value) for k, v in e.__members__.items())
 
-os_map = {
-    "linux"     : QL_OS.LINUX,
-    "macos"     : QL_OS.MACOS,
-    "freebsd"   : QL_OS.FREEBSD,
-    "windows"   : QL_OS.WINDOWS,
-    "uefi"      : QL_OS.UEFI,
-    "dos"       : QL_OS.DOS,
-    "evm"       : QL_OS.EVM,
-}
-
-verbose_map = {
-    "off"       : QL_VERBOSE.OFF,
-    "default"   : QL_VERBOSE.DEFAULT,
-    "debug"     : QL_VERBOSE.DEBUG,
-    "disasm"    : QL_VERBOSE.DISASM,
-    "dump"      : QL_VERBOSE.DUMP
-}
+debugger_map = __reverse_enum(QL_DEBUGGER)
+arch_map     = __reverse_enum(QL_ARCH)
+os_map       = __reverse_enum(QL_OS)
+verbose_map  = __reverse_enum(QL_VERBOSE)
 
 loader_map = {
     QL_OS.LINUX   : "ELF",

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .os.memory import QlMemoryManager
     from .loader.loader import QlLoader
 
-from .const import QL_ARCH_ENDIAN, QL_ENDIAN, QL_OS, QL_CUSTOM_ENGINE
+from .const import QL_ARCH_ENDIAN, QL_ENDIAN, QL_OS, QL_VERBOSE, QL_CUSTOM_ENGINE
 from .exception import QlErrorFileNotFound, QlErrorArch, QlErrorOsType, QlErrorOutput
 from .utils import *
 from .core_struct import QlCoreStructs
@@ -35,7 +35,7 @@ class Qiling(QlCoreHooks, QlCoreStructs):
             ostype=None,
             archtype=None,
             bigendian=False,
-            verbose=1,
+            verbose=QL_VERBOSE.DEFAULT,
             profile=None,
             console=True,
             log_file=None,

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -485,7 +485,7 @@ def profile_setup(ostype, profile, ql):
     config.read(profiles)
     return config, debugmsg
 
-def ql_resolve_logger_level(verbose):
+def ql_resolve_logger_level(verbose: QL_VERBOSE):
     level = logging.INFO
     if verbose == QL_VERBOSE.OFF:
         level = logging.WARNING

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -9,7 +9,8 @@ thoughout the qiling framework
 """
 import importlib, os, copy, re, pefile, configparser, logging, sys
 from logging import LogRecord
-from typing import Optional, Mapping
+from typing import Container, Optional, Mapping
+from enum import EnumMeta
 
 from unicorn import UC_ERR_READ_UNMAPPED, UC_ERR_FETCH_UNMAPPED
 
@@ -178,11 +179,14 @@ def ql_get_arch_bits(arch: QL_ARCH) -> int:
 
     raise QlErrorArch("Invalid Arch Bit")
 
+def enum_values(e: EnumMeta) -> Container:
+    return e.__members__.values()
+
 def ql_is_valid_ostype(ostype: QL_OS) -> bool:
-    return ostype in QL_OS.__members__.values()
+    return ostype in enum_values(QL_OS)
 
 def ql_is_valid_arch(arch: QL_ARCH) -> bool:
-    return arch in QL_ARCH.__members__.values()
+    return arch in enum_values(QL_ARCH)
 
 def loadertype_convert_str(ostype: QL_OS) -> Optional[str]:
     adapter = {}
@@ -420,7 +424,7 @@ def debugger_setup(debugger, ql):
         else:  
             remotedebugsrv, *debug_opts = debug_opts
 
-        if debugger_convert(remotedebugsrv) not in (QL_DEBUGGER):
+        if debugger_convert(remotedebugsrv) not in enum_values(QL_DEBUGGER):
             raise QlErrorOutput("Error: Debugger not supported")
 
     debugsession = ql_get_module_function(f"qiling.debugger.{remotedebugsrv}.{remotedebugsrv}", f"Ql{str.capitalize(remotedebugsrv)}")

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -179,10 +179,10 @@ def ql_get_arch_bits(arch: QL_ARCH) -> int:
     raise QlErrorArch("Invalid Arch Bit")
 
 def ql_is_valid_ostype(ostype: QL_OS) -> bool:
-    return ostype in QL_OS
+    return ostype in QL_OS.__members__.values()
 
 def ql_is_valid_arch(arch: QL_ARCH) -> bool:
-    return arch in QL_ARCH
+    return arch in QL_ARCH.__members__.values()
 
 def loadertype_convert_str(ostype: QL_OS) -> Optional[str]:
     adapter = {}

--- a/qltool
+++ b/qltool
@@ -53,6 +53,10 @@ def __arg_env(argval: str) -> dict:
         env = {}
 
     return env
+
+def __arg_verbose(argval: str) -> QL_VERBOSE:
+    return verbose_map[argval]
+
     if options.format == 'hex':
         if options.input is not None:
             print ("Load HEX from ARGV")
@@ -171,6 +175,7 @@ if __name__ == '__main__':
         usage()
         exit(0)
 
+    comm_parser.add_argument('-v', '--verbose', required=False, choices=verbose_map.keys(), default='default', type=__arg_verbose, help='verbosity level')
     comm_parser.add_argument('--env', required=False, metavar="FILE", type=__arg_env, help="Pickle file containing an environment dictionary")
     comm_parser.add_argument('-g', '--gdb', required=False, help='enable gdb server')
     comm_parser.add_argument('--qdb', action='store_true', required=False, help='attach Qdb at entry point, it\'s MIPS, ARM(THUMB) supported only for now')

--- a/qltool
+++ b/qltool
@@ -3,15 +3,12 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+import argparse, os, sys, ast, unicorn
 
-import argparse, os, string, sys, ast, unicorn
-from binascii import unhexlify
-
-from qiling import *
-from qiling.const import QL_VERBOSE
+from qiling import Qiling
 from qiling.arch.utils import ql_create_assembler
 from qiling.utils import arch_convert
-from qiling.const import QL_ARCH, QL_ENDIAN
+from qiling.const import QL_VERBOSE, QL_ENDIAN
 from qiling.__version__ import __version__ as ql_version
 from qiling.extensions.coverage import utils as cov_utils
 from qiling.extensions.report import generate_report
@@ -24,7 +21,7 @@ def parse_args(parser, commands):
             split_argv.append([c])
         else:
             split_argv[-1].append(c)
-    
+
     # Initialize namespace
     args = argparse.Namespace()
     for c in commands.choices:
@@ -40,16 +37,16 @@ def parse_args(parser, commands):
 
 # read code from file
 def read_file(fname):
-    with open(fname,"rb") as f:
+    with open(fname, "rb") as f:
         content = f.read()
-        f.close
-        return content
+
+    return content
 
 def run_code(options):
     if not options.os in ("linux", "windows", "freebsd", "macos"):
             print("ERROR: -os required: either linux, windows, freebsd, macos")
             exit(1)
-    
+
     if not options.arch in ("arm", "arm64", "x86", "x8664", "mips"):
             print("ERROR: -arch required: either arm, arm64, x86, x8664, mips")
             exit(1)
@@ -96,7 +93,7 @@ def run_code(options):
     return Qiling(code = code, archtype = options.arch, bigendian = options.bigendian, ostype = options.os, rootfs = options.rootfs, verbose = options.verbose, profile = options.profile)
 
 def version():
-    print("qltool for Qiling %s, using Unicorn %s" %(ql_version, unicorn.__version__))
+    print(f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
 
 def usage():
     version()
@@ -136,11 +133,10 @@ def usage():
     """)
 
 if __name__ == '__main__':
-
     # argparse setup
     parser = argparse.ArgumentParser()
     commands = parser.add_subparsers(title='subcommands', description='valid subcommands', help='additional help', dest='subparser_name')
-    
+
     run_parser = commands.add_parser('run', help = 'run')
     run_parser.add_argument('-f', '--filename', required=False, default=None, metavar="FILE", dest="filename", help="filename")
     run_parser.add_argument('--rootfs', required=True, help='emulated rootfs')
@@ -157,7 +153,7 @@ if __name__ == '__main__':
     code_parser.add_argument('--asm', action='store_true', default=False, dest='asm', help='input file format, -asm')
     code_parser.add_argument('--hex', action='store_true', default=False, dest='hex', help='input file format, -hex')
     code_parser.add_argument('--bin', action='store_true', default=True, dest='bin', help='input file format, -bin')
-    
+
     if len(sys.argv) <= 1:
         usage()
         exit(0)
@@ -211,7 +207,7 @@ if __name__ == '__main__':
     elif options.debug:
         options.verbose = QL_VERBOSE.DEBUG
     elif options.disasm:
-        options.verbose = QL_VERBOSE.DISASM             
+        options.verbose = QL_VERBOSE.DISASM
 
     if options.profile:
         options.profile = str(options.profile)
@@ -230,12 +226,12 @@ if __name__ == '__main__':
             env = ast.literal_eval(options.env)
     else:
         env = {}
-    
+
 
     if options.debug_stop and not (options.dump or options.debug):
         print("ERROR: debug_stop must use with either dump or debug mode")
         usage()
-    
+
     # ql file setup
     if (options.subparser_name == 'run'):
         # with argv
@@ -262,7 +258,7 @@ if __name__ == '__main__':
     # ql code setup
     elif (options.subparser_name == 'code'):
         ql = run_code(options)
-    
+
     else:
         print("ERROR: Unknown command")
         usage()
@@ -273,7 +269,7 @@ if __name__ == '__main__':
 
     if options.debug_stop and (options.dump or options.debug):
         ql.debug_stop = True
-        
+
     if options.root is not None:
         ql.root = True
 
@@ -289,7 +285,7 @@ if __name__ == '__main__':
     timeout = 0
     if options.timeout != None:
         timeout = int(options.timeout)
-    
+
     # ql run
     with cov_utils.collect_coverage(ql, options.coverage_format, options.coverage_file):
         ql.run(timeout=timeout)

--- a/qltool
+++ b/qltool
@@ -3,40 +3,24 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import argparse, os, sys, ast, unicorn
+import argparse
+import os
+import sys
+import ast
+import pickle
+import unicorn
 
 from qiling import Qiling
 from qiling.arch.utils import ql_create_assembler
+from qiling.debugger.qdb import QlQdb
 from qiling.utils import arch_convert
 from qiling.const import QL_VERBOSE, QL_ENDIAN, os_map, arch_map, verbose_map
 from qiling.__version__ import __version__ as ql_version
 from qiling.extensions.coverage import utils as cov_utils
-from qiling.extensions.report import generate_report
-
-def parse_args(parser, commands):
-    # Divide argv by commands
-    split_argv = [[]]
-    for c in sys.argv[1:]:
-        if c in commands.choices:
-            split_argv.append([c])
-        else:
-            split_argv[-1].append(c)
-
-    # Initialize namespace
-    args = argparse.Namespace()
-    for c in commands.choices:
-        setattr(args, c, None)
-
-    # Parse each command
-    parser.parse_args(split_argv[0], namespace=args)  # Without command
-    for argv in split_argv[1:]:  # Commands
-        n = argparse.Namespace()
-        setattr(args, argv[0], n)
-        parser.parse_args(argv, namespace=n)
-    return args
+from qiling.extensions import report
 
 # read code from file
-def read_file(fname):
+def read_file(fname: str):
     with open(fname, "rb") as f:
         content = f.read()
 
@@ -203,17 +187,17 @@ if __name__ == '__main__':
     code_parser.add_argument('--rootfs', required=False, help='emulated root filesystem, that is where all libraries reside')
     code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')
 
-    if len(sys.argv) <= 1:
+    if len(sys.argv) < 2:
         usage()
         exit(0)
 
-    if (sys.argv[1] == 'run'):
+    if sys.argv[1] == 'run':
         comm_parser = run_parser
 
-    elif (sys.argv[1] == 'code'):
+    elif sys.argv[1] == 'code':
         comm_parser = code_parser
 
-    elif (sys.argv[1] == 'version') or (sys.argv[1] == '-v') or (sys.argv[1] == '--version'):
+    elif sys.argv[1] in ('version', '-v', '--version'):
         version()
         exit(0)
 
@@ -229,26 +213,17 @@ if __name__ == '__main__':
     comm_parser.add_argument('--rr', action='store_true', required=False, help='switch on record and replay feature in qdb, only works with --qdb')
     comm_parser.add_argument('--profile', required=False, dest='profile', help="Define customized profile")
     comm_parser.add_argument('--console', required=False, default=True, dest='console', help='display in console')
-    comm_parser.add_argument('-e', '--filter', metavar="FUNCTION NAME", required=False, dest="filter", default=None, 
-                            help="Apply regexp for filtering log output.")
+    comm_parser.add_argument('-e', '--filter', metavar="FUNCTION NAME", required=False, dest="filter", default=None, help="Apply regexp for filtering log output.")
     comm_parser.add_argument('--log-file', dest="log_file", help="Write log to a file")
     comm_parser.add_argument('--log-plain', action="store_true", dest="log_plain", help="Don't use color in log output.")
     comm_parser.add_argument('--root', action='store_true', default=False, dest='root', help='Enable sudo required mode')
-    comm_parser.add_argument('--debug_stop', action='store_true', default=False, dest='debug_stop', 
-                            help='Stop running while encounter any error; requires verbose to be set to either "debug" or "dump"')
+    comm_parser.add_argument('--debug_stop', action='store_true', default=False, dest='debug_stop', help='Stop running while encounter any error; requires verbose to be set to either "debug" or "dump"')
     comm_parser.add_argument('-m','--multithread', action='store_true', default=False, dest='multithread', help='Run in multithread mode')
     comm_parser.add_argument('--timeout', required=False, type=int, default=0, help='Emulation timeout')
     comm_parser.add_argument('-c', '--coverage-file', required=False, default=None, dest='coverage_file', help='Code coverage file name')
-    comm_parser.add_argument('--coverage-format', required=False, default='drcov', dest='coverage_format',
-                             choices=cov_utils.factory.formats, help='Code coverage file format')
+    comm_parser.add_argument('--coverage-format', required=False, default='drcov', dest='coverage_format', choices=cov_utils.factory.formats, help='Code coverage file format')
     comm_parser.add_argument('--json', action='store_true', default=False, dest='json', help='Print a json report of the emulation')
     options = parser.parse_args()
-
-    if options.verbose is not None:
-        options.verbose = verbose_map[options.verbose]
-
-    if options.profile:
-        options.profile = str(options.profile)
 
     if options.console == 'False':
         options.console = False
@@ -285,7 +260,6 @@ if __name__ == '__main__':
         ql.run(timeout=options.timeout)
 
     if options.json:
-        print(generate_report(ql, pretty_print=True))
+        print(report.generate_report(ql, pretty_print=True))
 
     exit(ql.os.exit_code)
-

--- a/qltool
+++ b/qltool
@@ -57,6 +57,7 @@ def __arg_env(argval: str) -> dict:
 def __arg_verbose(argval: str) -> QL_VERBOSE:
     return verbose_map[argval]
 
+def handle_code(options):
     if options.format == 'hex':
         if options.input is not None:
             print ("Load HEX from ARGV")
@@ -95,7 +96,39 @@ def __arg_verbose(argval: str) -> QL_VERBOSE:
             exit(1)
         code = read_file(options.filename)
 
-    return Qiling(code = code, archtype = options.arch, bigendian = (options.endian == 'big'), ostype = options.os, rootfs = options.rootfs, verbose = options.verbose, profile = options.profile)
+def handle_run(options):
+    effective_argv = []
+
+    # with argv
+    if options.filename is not None and options.run_args == []:
+        effective_argv = [options.filename] + options.args
+
+    # Without argv
+    elif options.filename is None and options.args == [] and options.run_args != []:
+        effective_argv = options.run_args
+
+    else:
+        print("ERROR: Command error!")
+        usage()
+
+    ql = Qiling(
+        argv=effective_argv,
+        rootfs=options.rootfs,
+        env=options.env,
+        verbose=options.verbose,
+        profile=options.profile,
+        console=options.console,
+        log_file=options.log_file,
+        log_plain=options.log_plain,
+        multithread=options.multithread
+    )
+
+    # attach Qdb at entry point
+    if options.qdb == True:
+        QlQdb(ql, rr=options.rr)
+        exit()
+
+    return ql
 
 def version():
     print(f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
@@ -172,6 +205,7 @@ if __name__ == '__main__':
         exit(0)
 
     else:
+        print("ERROR: Unknown command")
         usage()
         exit(0)
 
@@ -214,34 +248,11 @@ if __name__ == '__main__':
 
     # ql file setup
     if (options.subparser_name == 'run'):
-        # with argv
-        if options.filename is not None and options.run_args == []:
-            ql = Qiling(argv=[options.filename] + options.args, rootfs=options.rootfs, profile=options.profile,
-                        verbose=options.verbose, console=options.console, log_file=options.log_file, log_plain=options.log_plain, multithread=options.multithread, env=env)
-
-        # Without argv
-        elif options.filename is None and options.args == [] and options.run_args != []:
-            ql = Qiling(argv=options.run_args, rootfs=options.rootfs, profile=options.profile,
-                        verbose=options.verbose, console=options.console, log_file=options.log_file, log_plain=options.log_plain, multithread=options.multithread, env=env)
-        
-        else:
-            print("ERROR: Command error!")
-            usage()
-
-        # attach Qdb at entry point
-        if options.qdb == True:
-            from qiling.debugger.qdb import QlQdb as Qdb
-
-            Qdb(ql, rr=options.rr)
-            exit()
+        ql = handle_run(options)
 
     # ql code setup
     elif (options.subparser_name == 'code'):
-        ql = run_code(options)
-
-    else:
-        print("ERROR: Unknown command")
-        usage()
+        ql = handle_code(options)
 
     # ql execute additional options
     if options.gdb is not None:

--- a/qltool
+++ b/qltool
@@ -214,7 +214,7 @@ if __name__ == '__main__':
     comm_parser.add_argument('--qdb', action='store_true', required=False, help='attach Qdb at entry point, it\'s MIPS, ARM(THUMB) supported only for now')
     comm_parser.add_argument('--rr', action='store_true', required=False, help='switch on record and replay feature in qdb, only works with --qdb')
     comm_parser.add_argument('--profile', required=False, dest='profile', help="Define customized profile")
-    comm_parser.add_argument('--console', required=False, default=True, dest='console', help='display in console')
+    comm_parser.add_argument('--noconsole', required=False, action='store_false', dest='console', help='do not emit output to console')
     comm_parser.add_argument('-e', '--filter', metavar="FUNCTION NAME", required=False, dest="filter", default=None, help="Apply regexp for filtering log output.")
     comm_parser.add_argument('--log-file', dest="log_file", help="Write log to a file")
     comm_parser.add_argument('--log-plain', action="store_true", dest="log_plain", help="Don't use color in log output.")
@@ -226,11 +226,6 @@ if __name__ == '__main__':
     comm_parser.add_argument('--coverage-format', required=False, default='drcov', dest='coverage_format', choices=cov_utils.factory.formats, help='Code coverage file format')
     comm_parser.add_argument('--json', action='store_true', default=False, dest='json', help='Print a json report of the emulation')
     options = parser.parse_args()
-
-    if options.console == 'False':
-        options.console = False
-    else:
-        options.console = True
 
     if options.debug_stop and options.verbose not in (QL_VERBOSE.DEBUG, QL_VERBOSE.DUMP):
         print('ERROR: the debug_stop option requires verbose to be set to either "debug" or "dump"')

--- a/qltool
+++ b/qltool
@@ -129,9 +129,6 @@ def handle_run(options):
 
     return ql
 
-def version():
-    print(f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
-
 def handle_examples(parser: argparse.ArgumentParser):
     prog = os.path.basename(__file__)
 
@@ -170,9 +167,8 @@ def handle_examples(parser: argparse.ArgumentParser):
     parser.exit(0, __ql_examples)
 
 if __name__ == '__main__':
-    # argparse setup
     parser = argparse.ArgumentParser()
-    commands = parser.add_subparsers(title='subcommands', description='valid subcommands', help='additional help', dest='subparser_name')
+    parser.add_argument('--version', action='version', version=f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
 
     commands = parser.add_subparsers(title='sub commands', description='select execution mode', dest='subcommand', required=True)
     run_parser = commands.add_parser('run', help = 'run')

--- a/qltool
+++ b/qltool
@@ -171,7 +171,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', action='version', version=f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
 
-    commands = parser.add_subparsers(title='sub commands', description='select execution mode', dest='subcommand', required=True)
+    commands = parser.add_subparsers(title='sub commands', description='select execution mode', dest='subcommand')
 
     # set "run" subcommand options
     run_parser = commands.add_parser('run', help='run a program')
@@ -217,6 +217,11 @@ if __name__ == '__main__':
     comm_parser.add_argument('--coverage-format', default='drcov', choices=cov_utils.factory.formats, help='code coverage file format')
     comm_parser.add_argument('--json', action='store_true', help='print a json report of the emulation')
     options = parser.parse_args()
+
+    # subparser argument required=True is not supported in python 3.6
+    # manually check whether the user did not specify a subcommand (execution mode)
+    if not options.subcommand:
+        parser.error('please select execution mode')
 
     if options.subcommand == 'examples':
         handle_examples(parser)

--- a/qltool
+++ b/qltool
@@ -55,7 +55,7 @@ def run_code(options):
             print("ERROR: -bigendian only takes in boolean, True or False")
             exit(1)
 
-    elif options.hex == True:
+    elif options.format == 'hex':
         if options.input is not None:
             print ("Load HEX from ARGV")
             code = str(options.input).strip("\\\\x").split("x")
@@ -71,7 +71,7 @@ def run_code(options):
             print("ERROR: File not found")
             exit(1)
 
-    elif options.asm == True:
+    elif options.format == 'asm':
         print ("Load ASM from FILE")
         assembly = read_file(options.filename)
         archtype = arch_convert(options.arch)
@@ -83,7 +83,7 @@ def run_code(options):
         code, _ = assembler.asm(assembly)
         code = bytes(code)
 
-    else:
+    elif options.format == 'bin':
         print ("Load BIN from FILE")
         if options.filename is None:
             print("ERROR: File not found")
@@ -150,9 +150,7 @@ if __name__ == '__main__':
     code_parser.add_argument('--bigendian', required=False, default=False, help='Type: Bool True or False')
     code_parser.add_argument('--os', required=True, help='option are windows, linux, freebsd and macos')
     code_parser.add_argument('--rootfs', required=False, help='emulated rootfs, that is where all the so or dll sits')
-    code_parser.add_argument('--asm', action='store_true', default=False, dest='asm', help='input file format, -asm')
-    code_parser.add_argument('--hex', action='store_true', default=False, dest='hex', help='input file format, -hex')
-    code_parser.add_argument('--bin', action='store_true', default=True, dest='bin', help='input file format, -bin')
+    code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')
 
     if len(sys.argv) <= 1:
         usage()

--- a/qltool
+++ b/qltool
@@ -43,11 +43,7 @@ def read_file(fname):
     return content
 
 def run_code(options):
-    if type(options.bigendian) is not bool:
-            print("ERROR: -bigendian only takes in boolean, True or False")
-            exit(1)
-
-    elif options.format == 'hex':
+    if options.format == 'hex':
         if options.input is not None:
             print ("Load HEX from ARGV")
             code = str(options.input).strip("\\\\x").split("x")
@@ -67,9 +63,12 @@ def run_code(options):
         print ("Load ASM from FILE")
         assembly = read_file(options.filename)
         archtype = arch_convert(options.arch)
-        archendian = QL_ENDIAN.EL
-        if options.bigendian:
-            archendian = QL_ENDIAN.EB
+
+        archendian = {
+            'little': QL_ENDIAN.EL,
+            'big'   : QL_ENDIAN.EB
+        }[options.endian]
+
         # TODO: Thumb support.
         assembler = ql_create_assembler(archtype, archendian, 0)
         code, _ = assembler.asm(assembly)
@@ -82,7 +81,7 @@ def run_code(options):
             exit(1)
         code = read_file(options.filename)
 
-    return Qiling(code = code, archtype = options.arch, bigendian = options.bigendian, ostype = options.os, rootfs = options.rootfs, verbose = options.verbose, profile = options.profile)
+    return Qiling(code = code, archtype = options.arch, bigendian = (options.endian == 'big'), ostype = options.os, rootfs = options.rootfs, verbose = options.verbose, profile = options.profile)
 
 def version():
     print(f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
@@ -139,7 +138,7 @@ if __name__ == '__main__':
     code_parser.add_argument('-f', '--filename', required=False, metavar="FILE", dest="filename", help="filename")
     code_parser.add_argument('-i', '--input', required=False, metavar="INPUT", dest="input", help='input hex value')
     code_parser.add_argument('--arch', required=True, choices=arch_map.keys())
-    code_parser.add_argument('--bigendian', required=False, default=False, help='Type: Bool True or False')
+    code_parser.add_argument('--endian', choices=('little', 'big'), default='little')
     code_parser.add_argument('--os', required=True, choices=os_map.keys())
     code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')
 

--- a/qltool
+++ b/qltool
@@ -42,7 +42,17 @@ def read_file(fname):
 
     return content
 
-def run_code(options):
+def __arg_env(argval: str) -> dict:
+    if argval:
+        if os.path.exists(argval):
+            with open(argval, 'rb') as f:
+                env = pickle.load(f)
+        else:
+            env = ast.literal_eval(argval)
+    else:
+        env = {}
+
+    return env
     if options.format == 'hex':
         if options.input is not None:
             print ("Load HEX from ARGV")
@@ -161,8 +171,7 @@ if __name__ == '__main__':
         usage()
         exit(0)
 
-    comm_parser.add_argument('-v', '--verbose', required=False, choices=verbose_map.keys(), default='default', help='verbosity level')
-    comm_parser.add_argument('--env', required=False, default='', metavar="FILE", dest="env", help="Pickle file containing an environment dictionary")
+    comm_parser.add_argument('--env', required=False, metavar="FILE", type=__arg_env, help="Pickle file containing an environment dictionary")
     comm_parser.add_argument('-g', '--gdb', required=False, help='enable gdb server')
     comm_parser.add_argument('--qdb', action='store_true', required=False, help='attach Qdb at entry point, it\'s MIPS, ARM(THUMB) supported only for now')
     comm_parser.add_argument('--rr', action='store_true', required=False, help='switch on record and replay feature in qdb, only works with --qdb')
@@ -193,17 +202,6 @@ if __name__ == '__main__':
         options.console = False
     else:
         options.console = True
-
-    if options.env != '':
-        if os.path.exists(options.env):
-            import pickle
-            with open(options.env, 'rb') as f:
-                env = pickle.load(f)
-        else:
-            env = ast.literal_eval(options.env)
-    else:
-        env = {}
-
 
     if options.debug_stop and options.verbose not in (QL_VERBOSE.DEBUG, QL_VERBOSE.DUMP):
         print('ERROR: the debug_stop option requires verbose to be set to either "debug" or "dump"')

--- a/qltool
+++ b/qltool
@@ -88,7 +88,8 @@ def handle_code(options):
         archtype=options.arch,
         bigendian=(options.endian == 'big'),
         verbose=options.verbose,
-        profile=options.profile
+        profile=options.profile,
+        filter=options.filter
     )
 
     return ql
@@ -117,7 +118,8 @@ def handle_run(options):
         console=options.console,
         log_file=options.log_file,
         log_plain=options.log_plain,
-        multithread=options.multithread
+        multithread=options.multithread,
+        filter=options.filter
     )
 
     # attach Qdb at entry point
@@ -251,9 +253,6 @@ if __name__ == '__main__':
 
     if options.root is not None:
         ql.root = True
-
-    if options.filter:
-        ql.filter = options.filter
 
     # ql run
     with cov_utils.collect_coverage(ql, options.coverage_format, options.coverage_file):

--- a/qltool
+++ b/qltool
@@ -8,7 +8,7 @@ import argparse, os, sys, ast, unicorn
 from qiling import Qiling
 from qiling.arch.utils import ql_create_assembler
 from qiling.utils import arch_convert
-from qiling.const import QL_VERBOSE, QL_ENDIAN, os_map
+from qiling.const import QL_VERBOSE, QL_ENDIAN, os_map, arch_map
 from qiling.__version__ import __version__ as ql_version
 from qiling.extensions.coverage import utils as cov_utils
 from qiling.extensions.report import generate_report
@@ -43,10 +43,6 @@ def read_file(fname):
     return content
 
 def run_code(options):
-    if not options.arch in ("arm", "arm64", "x86", "x8664", "mips"):
-            print("ERROR: -arch required: either arm, arm64, x86, x8664, mips")
-            exit(1)
-
     if type(options.bigendian) is not bool:
             print("ERROR: -bigendian only takes in boolean, True or False")
             exit(1)
@@ -142,7 +138,7 @@ if __name__ == '__main__':
     code_parser = commands.add_parser('code', help = 'code')
     code_parser.add_argument('-f', '--filename', required=False, metavar="FILE", dest="filename", help="filename")
     code_parser.add_argument('-i', '--input', required=False, metavar="INPUT", dest="input", help='input hex value')
-    code_parser.add_argument('--arch', required=True, help='option are x86, x8664, arm, arm64, mips')
+    code_parser.add_argument('--arch', required=True, choices=arch_map.keys())
     code_parser.add_argument('--bigendian', required=False, default=False, help='Type: Bool True or False')
     code_parser.add_argument('--os', required=True, choices=os_map.keys())
     code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')

--- a/qltool
+++ b/qltool
@@ -8,7 +8,7 @@ import argparse, os, sys, ast, unicorn
 from qiling import Qiling
 from qiling.arch.utils import ql_create_assembler
 from qiling.utils import arch_convert
-from qiling.const import QL_VERBOSE, QL_ENDIAN
+from qiling.const import QL_VERBOSE, QL_ENDIAN, os_map
 from qiling.__version__ import __version__ as ql_version
 from qiling.extensions.coverage import utils as cov_utils
 from qiling.extensions.report import generate_report
@@ -43,10 +43,6 @@ def read_file(fname):
     return content
 
 def run_code(options):
-    if not options.os in ("linux", "windows", "freebsd", "macos"):
-            print("ERROR: -os required: either linux, windows, freebsd, macos")
-            exit(1)
-
     if not options.arch in ("arm", "arm64", "x86", "x8664", "mips"):
             print("ERROR: -arch required: either arm, arm64, x86, x8664, mips")
             exit(1)
@@ -148,8 +144,7 @@ if __name__ == '__main__':
     code_parser.add_argument('-i', '--input', required=False, metavar="INPUT", dest="input", help='input hex value')
     code_parser.add_argument('--arch', required=True, help='option are x86, x8664, arm, arm64, mips')
     code_parser.add_argument('--bigendian', required=False, default=False, help='Type: Bool True or False')
-    code_parser.add_argument('--os', required=True, help='option are windows, linux, freebsd and macos')
-    code_parser.add_argument('--rootfs', required=False, help='emulated rootfs, that is where all the so or dll sits')
+    code_parser.add_argument('--os', required=True, choices=os_map.keys())
     code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')
 
     if len(sys.argv) <= 1:

--- a/qltool
+++ b/qltool
@@ -139,12 +139,11 @@ def usage():
     Usage: {__file__} [run|code] OPTIONS
 
     With code:
-        {__file__} code --os linux --arch arm --hex -f examples/codes/linarm32_tcp_reverse_shell.hex
-        {__file__} code --os linux --arch x86 --asm -f examples/codes/lin32_execve.asm
-        {__file__} code --os linux --arch arm --hex -f examples/codes/linarm32_tcp_reverse_shell.hex --strace
+        {__file__} code --os linux --arch arm --format hex -f examples/codes/linarm32_tcp_reverse_shell.hex
+        {__file__} code --os linux --arch x86 --format asm -f examples/codes/lin32_execve.asm
 
     With binary file:
-        {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_hello --rootfs  examples/rootfs/x8664_linux
+        {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_hello --rootfs examples/rootfs/x8664_linux
         {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux
 
     With binary file and Qdb:
@@ -154,19 +153,18 @@ def usage():
     With binary file and gdbserver:
         {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_hello --gdb 127.0.0.1:9999 --rootfs examples/rootfs/x8664_linux
 
-    nWith binary file and additional argv:
+    With binary file and additional argv:
         {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_args --rootfs examples/rootfs/x8664_linux --args test1 test2 test3
 
     With binary file and various output format:
-        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --output=disasm
-        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --strace -e ^open
-        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --strace -e ^open
+        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --verbose disasm
+        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --filter ^open
 
     With UEFI file:
         {__file__} run -f examples/rootfs/x8664_efi/bin/TcgPlatformSetupPolicy --rootfs examples/rootfs/x8664_efi --env examples/rootfs/x8664_efi/rom2_nvar.pickel
 
     With binary file and json output:
-        {__file__} run -f examples/rootfs/x86_windows/bin/x86_hello.exe --rootfs  examples/rootfs/x86_windows/ --console False --json
+        {__file__} run -f examples/rootfs/x86_windows/bin/x86_hello.exe --rootfs examples/rootfs/x86_windows --console False --json
     """)
 
 if __name__ == '__main__':

--- a/qltool
+++ b/qltool
@@ -100,37 +100,40 @@ def version():
 
 def usage():
     version()
-    print("\nUsage: ./qltool [run|code] OPTIONS")
 
-    print("\n\nWith code:")
-    print("\t ./qltool code --os linux --arch arm --hex -f examples/codes/linarm32_tcp_reverse_shell.hex")
-    print("\t ./qltool code --os linux --arch x86 --asm -f examples/codes/lin32_execve.asm")
-    print("\t ./qltool code --os linux --arch arm --hex -f examples/codes/linarm32_tcp_reverse_shell.hex")
+    print(f"""
+    Usage: {__file__} [run|code] OPTIONS
 
-    print("\n\nWith binary file:")
-    print("\t ./qltool run -f examples/rootfs/x8664_linux/bin/x8664_hello --rootfs  examples/rootfs/x8664_linux/")
-    print("\t ./qltool run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux")
+    With code:
+        {__file__} code --os linux --arch arm --hex -f examples/codes/linarm32_tcp_reverse_shell.hex
+        {__file__} code --os linux --arch x86 --asm -f examples/codes/lin32_execve.asm
+        {__file__} code --os linux --arch arm --hex -f examples/codes/linarm32_tcp_reverse_shell.hex --strace
 
-    print("\n\nWith binary file and Qdb:")
-    print("\t ./qltool run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --qdb")
-    print("\t ./qltool run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --qdb --rr")
+    With binary file:
+        {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_hello --rootfs  examples/rootfs/x8664_linux
+        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux
 
-    print("\n\nWith binary file and gdbserver:")
-    print("\t ./qltool run -f examples/rootfs/x8664_linux/bin/x8664_hello --gdb 127.0.0.1:9999 --rootfs examples/rootfs/x8664_linux")
+    With binary file and Qdb:
+        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --qdb
+        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --qdb --rr
 
-    print("\n\nWith binary file and additional argv:")
-    print("\t ./qltool run -f examples/rootfs/x8664_linux/bin/x8664_args --rootfs examples/rootfs/x8664_linux --args test1 test2 test3")
+    With binary file and gdbserver:
+        {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_hello --gdb 127.0.0.1:9999 --rootfs examples/rootfs/x8664_linux
 
-    print("\n\nwith binary file and various output format:")
-    print("\t ./qltool run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --disasm")
-    print("\t ./qltool run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux -e ^open")
-    print("\t ./qltool run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux -e ^(open|brk)")
-    
-    print("\n\nWith UEFI file:")
-    print("\t ./qltool run -f examples/rootfs/x8664_efi/bin/TcgPlatformSetupPolicy --rootfs examples/rootfs/x8664_efi --env examples/rootfs/x8664_efi/rom2_nvar.pickel")
+    nWith binary file and additional argv:
+        {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_args --rootfs examples/rootfs/x8664_linux --args test1 test2 test3
 
-    print("\n\nWith binary file and json output:")
-    print("\t ./qltool run -f examples/rootfs/x86_windows/bin/x86_hello.exe --rootfs  examples/rootfs/x86_windows/ --console False --json")
+    With binary file and various output format:
+        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --output=disasm
+        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --strace -e ^open
+        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --strace -e ^open
+
+    With UEFI file:
+        {__file__} run -f examples/rootfs/x8664_efi/bin/TcgPlatformSetupPolicy --rootfs examples/rootfs/x8664_efi --env examples/rootfs/x8664_efi/rom2_nvar.pickel
+
+    With binary file and json output:
+        {__file__} run -f examples/rootfs/x86_windows/bin/x86_hello.exe --rootfs  examples/rootfs/x86_windows/ --console False --json
+    """)
 
 if __name__ == '__main__':
 

--- a/qltool
+++ b/qltool
@@ -107,7 +107,6 @@ def handle_run(options):
 
     else:
         print("ERROR: Command error!")
-        usage()
 
     ql = Qiling(
         argv=effective_argv,
@@ -132,46 +131,49 @@ def handle_run(options):
 def version():
     print(f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
 
-def usage():
-    version()
+def handle_examples(parser: argparse.ArgumentParser):
+    prog = os.path.basename(__file__)
 
-    print(f"""
-    Usage: {__file__} [run|code] OPTIONS
+    __ql_examples = f"""Examples:
 
     With code:
-        {__file__} code --os linux --arch arm --format hex -f examples/codes/linarm32_tcp_reverse_shell.hex
-        {__file__} code --os linux --arch x86 --format asm -f examples/codes/lin32_execve.asm
+        {prog} code --os linux --arch arm --format hex -f examples/codes/linarm32_tcp_reverse_shell.hex
+        {prog} code --os linux --arch x86 --format asm -f examples/codes/lin32_execve.asm
 
     With binary file:
-        {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_hello --rootfs examples/rootfs/x8664_linux
-        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux
+        {prog} run -f examples/rootfs/x8664_linux/bin/x8664_hello --rootfs examples/rootfs/x8664_linux
+        {prog} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux
 
     With binary file and Qdb:
-        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --qdb
-        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --qdb --rr
+        {prog} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --qdb
+        {prog} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --qdb --rr
 
     With binary file and gdbserver:
-        {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_hello --gdb 127.0.0.1:9999 --rootfs examples/rootfs/x8664_linux
+        {prog} run -f examples/rootfs/x8664_linux/bin/x8664_hello --gdb 127.0.0.1:9999 --rootfs examples/rootfs/x8664_linux
 
     With binary file and additional argv:
-        {__file__} run -f examples/rootfs/x8664_linux/bin/x8664_args --rootfs examples/rootfs/x8664_linux --args test1 test2 test3
+        {prog} run -f examples/rootfs/x8664_linux/bin/x8664_args --rootfs examples/rootfs/x8664_linux --args test1 test2 test3
 
     With binary file and various output format:
-        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --verbose disasm
-        {__file__} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --filter ^open
+        {prog} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --verbose disasm
+        {prog} run -f examples/rootfs/mips32el_linux/bin/mips32el_hello --rootfs examples/rootfs/mips32el_linux --filter ^open
 
     With UEFI file:
-        {__file__} run -f examples/rootfs/x8664_efi/bin/TcgPlatformSetupPolicy --rootfs examples/rootfs/x8664_efi --env examples/rootfs/x8664_efi/rom2_nvar.pickel
+        {prog} run -f examples/rootfs/x8664_efi/bin/TcgPlatformSetupPolicy --rootfs examples/rootfs/x8664_efi --env examples/rootfs/x8664_efi/rom2_nvar.pickel
 
     With binary file and json output:
-        {__file__} run -f examples/rootfs/x86_windows/bin/x86_hello.exe --rootfs examples/rootfs/x86_windows --console False --json
-    """)
+        {prog} run -f examples/rootfs/x86_windows/bin/x86_hello.exe --rootfs examples/rootfs/x86_windows --no-console --json
+
+"""
+
+    parser.exit(0, __ql_examples)
 
 if __name__ == '__main__':
     # argparse setup
     parser = argparse.ArgumentParser()
     commands = parser.add_subparsers(title='subcommands', description='valid subcommands', help='additional help', dest='subparser_name')
 
+    commands = parser.add_subparsers(title='sub commands', description='select execution mode', dest='subcommand', required=True)
     run_parser = commands.add_parser('run', help = 'run')
     run_parser.add_argument('-f', '--filename', required=False, default=None, metavar="FILE", dest="filename", help="filename")
     run_parser.add_argument('--rootfs', required=True, help='emulated rootfs')
@@ -186,6 +188,8 @@ if __name__ == '__main__':
     code_parser.add_argument('--os', required=True, choices=os_map.keys())
     code_parser.add_argument('--rootfs', required=False, help='emulated root filesystem, that is where all libraries reside')
     code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')
+
+    expl_parser = commands.add_parser('examples', help='show examples and exit', add_help=False)
 
     if len(sys.argv) < 2:
         usage()
@@ -225,16 +229,19 @@ if __name__ == '__main__':
     comm_parser.add_argument('--json', action='store_true', default=False, dest='json', help='Print a json report of the emulation')
     options = parser.parse_args()
 
+    if options.subcommand == 'examples':
+        handle_examples(parser)
+
     if options.debug_stop and options.verbose not in (QL_VERBOSE.DEBUG, QL_VERBOSE.DUMP):
         print('ERROR: the debug_stop option requires verbose to be set to either "debug" or "dump"')
         usage()
 
     # ql file setup
-    if (options.subparser_name == 'run'):
+    if options.subcommand == 'run':
         ql = handle_run(options)
 
     # ql code setup
-    elif (options.subparser_name == 'code'):
+    elif options.subcommand == 'code':
         ql = handle_code(options)
 
     # ql execute additional options

--- a/qltool
+++ b/qltool
@@ -76,10 +76,11 @@ def handle_code(options: argparse.Namespace):
 
     elif options.format == 'bin':
         print ("Load BIN from FILE")
-        if options.filename is None:
+        if options.filename is not None:
+            code = read_file(options.filename)
+        else:
             print("ERROR: File not found")
             exit(1)
-        code = read_file(options.filename)
 
     ql = Qiling(
         rootfs=options.rootfs,
@@ -95,7 +96,7 @@ def handle_code(options: argparse.Namespace):
 
     return ql
 
-def handle_run(options):
+def handle_run(options: argparse.Namespace):
     effective_argv = []
 
     # with argv
@@ -171,67 +172,57 @@ if __name__ == '__main__':
     parser.add_argument('--version', action='version', version=f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
 
     commands = parser.add_subparsers(title='sub commands', description='select execution mode', dest='subcommand', required=True)
-    run_parser = commands.add_parser('run', help = 'run')
-    run_parser.add_argument('-f', '--filename', required=False, default=None, metavar="FILE", dest="filename", help="filename")
+
+    # set "run" subcommand options
+    run_parser = commands.add_parser('run', help='run a program')
+    run_parser.add_argument('-f', '--filename', default=None, metavar="FILE", help="filename")
     run_parser.add_argument('--rootfs', required=True, help='emulated rootfs')
-    run_parser.add_argument('--args', required=False, default=[], nargs=argparse.REMAINDER, dest="args", help="args")
+    run_parser.add_argument('--args', default=[], nargs=argparse.REMAINDER, dest="args", help="args")
     run_parser.add_argument('run_args', default=[], nargs=argparse.REMAINDER)
 
-    code_parser = commands.add_parser('code', help = 'code')
-    code_parser.add_argument('-f', '--filename', required=False, metavar="FILE", dest="filename", help="filename")
-    code_parser.add_argument('-i', '--input', required=False, metavar="INPUT", dest="input", help='input hex value')
-    code_parser.add_argument('--arch', required=True, choices=arch_map.keys())
+    # set "code" subcommand options
+    code_parser = commands.add_parser('code', help='execute a shellcode')
+    code_parser.add_argument('-f', '--filename', metavar="FILE", help="filename")
+    code_parser.add_argument('-i', '--input', metavar="INPUT", dest="input", help='input hex value')
+    code_parser.add_argument('--arch', required=True, choices=arch_map)
     code_parser.add_argument('--endian', choices=('little', 'big'), default='little')
-    code_parser.add_argument('--os', required=True, choices=os_map.keys())
-    code_parser.add_argument('--rootfs', required=False, help='emulated root filesystem, that is where all libraries reside')
+    code_parser.add_argument('--os', required=True, choices=os_map)
+    code_parser.add_argument('--rootfs', help='emulated root filesystem, that is where all libraries reside')
     code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')
 
+    # set "examples" subcommand
     expl_parser = commands.add_parser('examples', help='show examples and exit', add_help=False)
 
-    if len(sys.argv) < 2:
-        usage()
-        exit(0)
+    comm_parser = run_parser
 
-    if sys.argv[1] == 'run':
-        comm_parser = run_parser
-
-    elif sys.argv[1] == 'code':
+    if len(sys.argv) > 1 and sys.argv[1] == 'code':
         comm_parser = code_parser
 
-    elif sys.argv[1] in ('version', '-v', '--version'):
-        version()
-        exit(0)
-
-    else:
-        print("ERROR: Unknown command")
-        usage()
-        exit(0)
-
-    comm_parser.add_argument('-v', '--verbose', required=False, choices=verbose_map.keys(), default='default', type=__arg_verbose, help='verbosity level')
-    comm_parser.add_argument('--env', required=False, metavar="FILE", type=__arg_env, help="Pickle file containing an environment dictionary")
-    comm_parser.add_argument('-g', '--gdb', required=False, help='enable gdb server')
-    comm_parser.add_argument('--qdb', action='store_true', required=False, help='attach Qdb at entry point, it\'s MIPS, ARM(THUMB) supported only for now')
-    comm_parser.add_argument('--rr', action='store_true', required=False, help='switch on record and replay feature in qdb, only works with --qdb')
-    comm_parser.add_argument('--profile', required=False, dest='profile', help="Define customized profile")
-    comm_parser.add_argument('--noconsole', required=False, action='store_false', dest='console', help='do not emit output to console')
-    comm_parser.add_argument('-e', '--filter', metavar="FUNCTION NAME", required=False, dest="filter", default=None, help="Apply regexp for filtering log output.")
-    comm_parser.add_argument('--log-file', dest="log_file", help="Write log to a file")
-    comm_parser.add_argument('--log-plain', action="store_true", dest="log_plain", help="Don't use color in log output.")
-    comm_parser.add_argument('--root', action='store_true', default=False, dest='root', help='Enable sudo required mode')
-    comm_parser.add_argument('--debug_stop', action='store_true', default=False, dest='debug_stop', help='Stop running while encounter any error; requires verbose to be set to either "debug" or "dump"')
-    comm_parser.add_argument('-m','--multithread', action='store_true', default=False, dest='multithread', help='Run in multithread mode')
-    comm_parser.add_argument('--timeout', required=False, type=int, default=0, help='Emulation timeout')
-    comm_parser.add_argument('-c', '--coverage-file', required=False, default=None, dest='coverage_file', help='Code coverage file name')
-    comm_parser.add_argument('--coverage-format', required=False, default='drcov', dest='coverage_format', choices=cov_utils.factory.formats, help='Code coverage file format')
-    comm_parser.add_argument('--json', action='store_true', default=False, dest='json', help='Print a json report of the emulation')
+    # set common options
+    comm_parser.add_argument('-v', '--verbose', choices=verbose_map, default=QL_VERBOSE.DEFAULT, action=__arg_verbose, help='set verbosity level')
+    comm_parser.add_argument('--env', metavar="FILE", action=__arg_env, help="pickle file containing an environment dictionary")
+    comm_parser.add_argument('-g', '--gdb', help='enable gdb server')
+    comm_parser.add_argument('--qdb', action='store_true', help='attach Qdb at entry point, it\'s MIPS, ARM(THUMB) supported only for now')
+    comm_parser.add_argument('--rr', action='store_true', help='switch on record and replay feature in qdb, only works with --qdb')
+    comm_parser.add_argument('--profile', help="define a customized profile")
+    comm_parser.add_argument('--no-console', action='store_false', dest='console', help='do not emit output to console')
+    comm_parser.add_argument('-e', '--filter', metavar='REGEXP', default=None, help="apply a filtering regexp on log output")
+    comm_parser.add_argument('--log-file', help="write log to a file")
+    comm_parser.add_argument('--log-plain', action='store_true', help="do not use colors in log output")
+    comm_parser.add_argument('--root', action='store_true', help='enable sudo required mode')
+    comm_parser.add_argument('--debug-stop', action='store_true', help='stop running on error; requires verbose to be set to either "debug" or "dump"')
+    comm_parser.add_argument('-m', '--multithread',action='store_true', help='run in multithread mode')
+    comm_parser.add_argument('--timeout', type=int, default=0, help='set emulation timeout')
+    comm_parser.add_argument('-c', '--coverage-file', default=None, help='code coverage file name')
+    comm_parser.add_argument('--coverage-format', default='drcov', choices=cov_utils.factory.formats, help='code coverage file format')
+    comm_parser.add_argument('--json', action='store_true', help='print a json report of the emulation')
     options = parser.parse_args()
 
     if options.subcommand == 'examples':
         handle_examples(parser)
 
     if options.debug_stop and options.verbose not in (QL_VERBOSE.DEBUG, QL_VERBOSE.DUMP):
-        print('ERROR: the debug_stop option requires verbose to be set to either "debug" or "dump"')
-        usage()
+        parser.error('the debug_stop option requires verbose to be set to either "debug" or "dump"')
 
     # ql file setup
     if options.subcommand == 'run':
@@ -242,13 +233,13 @@ if __name__ == '__main__':
         ql = handle_code(options)
 
     # ql execute additional options
-    if options.gdb is not None:
+    if options.gdb:
         ql.debugger = options.gdb
 
     if options.debug_stop:
         ql.debug_stop = True
 
-    if options.root is not None:
+    if options.root:
         ql.root = True
 
     # ql run

--- a/qltool
+++ b/qltool
@@ -8,7 +8,7 @@ import argparse, os, sys, ast, unicorn
 from qiling import Qiling
 from qiling.arch.utils import ql_create_assembler
 from qiling.utils import arch_convert
-from qiling.const import QL_VERBOSE, QL_ENDIAN, os_map, arch_map
+from qiling.const import QL_VERBOSE, QL_ENDIAN, os_map, arch_map, verbose_map
 from qiling.__version__ import __version__ as ql_version
 from qiling.extensions.coverage import utils as cov_utils
 from qiling.extensions.report import generate_report
@@ -160,25 +160,20 @@ if __name__ == '__main__':
         usage()
         exit(0)
 
-    comm_parser.add_argument('-v', '--verbose', required=False, default=QL_VERBOSE.DEFAULT, dest='verbose', type=int,
-                            help='verbose mode, must be int and use with --debug or --dump')
-    comm_parser.add_argument('--env', required=False, default='', metavar="FILE", dest="env", help="Pickle file containing an environment dictionary")                            
+    comm_parser.add_argument('-v', '--verbose', required=False, choices=verbose_map.keys(), default='default', help='verbosity level')
+    comm_parser.add_argument('--env', required=False, default='', metavar="FILE", dest="env", help="Pickle file containing an environment dictionary")
     comm_parser.add_argument('-g', '--gdb', required=False, help='enable gdb server')
     comm_parser.add_argument('--qdb', action='store_true', required=False, help='attach Qdb at entry point, it\'s MIPS, ARM(THUMB) supported only for now')
     comm_parser.add_argument('--rr', action='store_true', required=False, help='switch on record and replay feature in qdb, only works with --qdb')
     comm_parser.add_argument('--profile', required=False, dest='profile', help="Define customized profile")
-    comm_parser.add_argument('--dump', action='store_true', default=False, dest='dump', help='Enable Debug + Diassembler mode')
-    comm_parser.add_argument('--debug', action='store_true', default=False, dest='debug', help='Enable Debug mode')
-    comm_parser.add_argument('--disasm', action='store_true', default=False, dest='disasm', help='Run in disassemble mode')
     comm_parser.add_argument('--console', required=False, default=True, dest='console', help='display in console')
     comm_parser.add_argument('-e', '--filter', metavar="FUNCTION NAME", required=False, dest="filter", default=None, 
                             help="Apply regexp for filtering log output.")
     comm_parser.add_argument('--log-file', dest="log_file", help="Write log to a file")
     comm_parser.add_argument('--log-plain', action="store_true", dest="log_plain", help="Don't use color in log output.")
-    comm_parser.add_argument('--trace', action='store_true', default=False, dest='trace', help='Run in trace mode')
     comm_parser.add_argument('--root', action='store_true', default=False, dest='root', help='Enable sudo required mode')
     comm_parser.add_argument('--debug_stop', action='store_true', default=False, dest='debug_stop', 
-                            help='Stop running while encounter any error (only use it with debug mode)')
+                            help='Stop running while encounter any error; requires verbose to be set to either "debug" or "dump"')
     comm_parser.add_argument('-m','--multithread', action='store_true', default=False, dest='multithread', help='Run in multithread mode')
     comm_parser.add_argument('--timeout', required=False, help='Emulation timeout')
     comm_parser.add_argument('-c', '--coverage-file', required=False, default=None, dest='coverage_file', help='Code coverage file name')
@@ -187,15 +182,8 @@ if __name__ == '__main__':
     comm_parser.add_argument('--json', action='store_true', default=False, dest='json', help='Print a json report of the emulation')
     options = parser.parse_args()
 
-    # var check
-    if options.trace:
-        options.verbose = QL_VERBOSE.DISASM
-    elif options.dump:
-        options.verbose = QL_VERBOSE.DUMP
-    elif options.debug:
-        options.verbose = QL_VERBOSE.DEBUG
-    elif options.disasm:
-        options.verbose = QL_VERBOSE.DISASM
+    if options.verbose is not None:
+        options.verbose = verbose_map[options.verbose]
 
     if options.profile:
         options.profile = str(options.profile)
@@ -216,8 +204,8 @@ if __name__ == '__main__':
         env = {}
 
 
-    if options.debug_stop and not (options.dump or options.debug):
-        print("ERROR: debug_stop must use with either dump or debug mode")
+    if options.debug_stop and options.verbose not in (QL_VERBOSE.DEBUG, QL_VERBOSE.DUMP):
+        print('ERROR: the debug_stop option requires verbose to be set to either "debug" or "dump"')
         usage()
 
     # ql file setup
@@ -255,16 +243,11 @@ if __name__ == '__main__':
     if options.gdb is not None:
         ql.debugger = options.gdb
 
-    if options.debug_stop and (options.dump or options.debug):
+    if options.debug_stop:
         ql.debug_stop = True
 
     if options.root is not None:
         ql.root = True
-
-    if options.verbose is not None:
-        ql.verbose = int(options.verbose)
-    else:
-        ql.verbose = QL_VERBOSE.DEFAULT
 
     if options.filter:
         ql.filter = options.filter

--- a/qltool
+++ b/qltool
@@ -190,7 +190,7 @@ if __name__ == '__main__':
     comm_parser.add_argument('--debug_stop', action='store_true', default=False, dest='debug_stop', 
                             help='Stop running while encounter any error; requires verbose to be set to either "debug" or "dump"')
     comm_parser.add_argument('-m','--multithread', action='store_true', default=False, dest='multithread', help='Run in multithread mode')
-    comm_parser.add_argument('--timeout', required=False, help='Emulation timeout')
+    comm_parser.add_argument('--timeout', required=False, type=int, default=0, help='Emulation timeout')
     comm_parser.add_argument('-c', '--coverage-file', required=False, default=None, dest='coverage_file', help='Code coverage file name')
     comm_parser.add_argument('--coverage-format', required=False, default='drcov', dest='coverage_format',
                              choices=cov_utils.factory.formats, help='Code coverage file format')
@@ -256,14 +256,9 @@ if __name__ == '__main__':
     if options.filter:
         ql.filter = options.filter
 
-
-    timeout = 0
-    if options.timeout != None:
-        timeout = int(options.timeout)
-
     # ql run
     with cov_utils.collect_coverage(ql, options.coverage_format, options.coverage_file):
-        ql.run(timeout=timeout)
+        ql.run(timeout=options.timeout)
 
     if options.json:
         print(generate_report(ql, pretty_print=True))

--- a/qltool
+++ b/qltool
@@ -96,6 +96,19 @@ def handle_code(options):
             exit(1)
         code = read_file(options.filename)
 
+    ql = Qiling(
+        rootfs=options.rootfs,
+        env=options.env,
+        code=code,
+        ostype=options.os,
+        archtype=options.arch,
+        bigendian=(options.endian == 'big'),
+        verbose=options.verbose,
+        profile=options.profile
+    )
+
+    return ql
+
 def handle_run(options):
     effective_argv = []
 

--- a/qltool
+++ b/qltool
@@ -201,7 +201,7 @@ if __name__ == '__main__':
     # set common options
     comm_parser.add_argument('-v', '--verbose', choices=verbose_map, default=QL_VERBOSE.DEFAULT, action=__arg_verbose, help='set verbosity level')
     comm_parser.add_argument('--env', metavar="FILE", action=__arg_env, help="pickle file containing an environment dictionary")
-    comm_parser.add_argument('-g', '--gdb', help='enable gdb server')
+    comm_parser.add_argument('-g', '--gdb', action='store_true', help='enable gdb server')
     comm_parser.add_argument('--qdb', action='store_true', help='attach Qdb at entry point, it\'s MIPS, ARM(THUMB) supported only for now')
     comm_parser.add_argument('--rr', action='store_true', help='switch on record and replay feature in qdb, only works with --qdb')
     comm_parser.add_argument('--profile', help="define a customized profile")
@@ -234,7 +234,7 @@ if __name__ == '__main__':
 
     # ql execute additional options
     if options.gdb:
-        ql.debugger = options.gdb
+        ql.debugger = True
 
     if options.debug_stop:
         ql.debug_stop = True

--- a/qltool
+++ b/qltool
@@ -26,22 +26,23 @@ def read_file(fname: str):
 
     return content
 
-def __arg_env(argval: str) -> dict:
-    if argval:
-        if os.path.exists(argval):
-            with open(argval, 'rb') as f:
-                env = pickle.load(f)
-        else:
-            env = ast.literal_eval(argval)
-    else:
+class __arg_env(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string):
         env = {}
 
-    return env
+        if os.path.exists(values):
+            with open(values, 'rb') as f:
+                env = pickle.load(f)
+        else:
+            env = ast.literal_eval(values)
 
-def __arg_verbose(argval: str) -> QL_VERBOSE:
-    return verbose_map[argval]
+        setattr(namespace, self.dest, env)
 
-def handle_code(options):
+class __arg_verbose(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string):
+        setattr(namespace, self.dest, verbose_map[values])
+
+def handle_code(options: argparse.Namespace):
     if options.format == 'hex':
         if options.input is not None:
             print ("Load HEX from ARGV")

--- a/qltool
+++ b/qltool
@@ -140,6 +140,7 @@ if __name__ == '__main__':
     code_parser.add_argument('--arch', required=True, choices=arch_map.keys())
     code_parser.add_argument('--endian', choices=('little', 'big'), default='little')
     code_parser.add_argument('--os', required=True, choices=os_map.keys())
+    code_parser.add_argument('--rootfs', required=False, help='emulated root filesystem, that is where all libraries reside')
     code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')
 
     if len(sys.argv) <= 1:

--- a/tests/test_qltool.py
+++ b/tests/test_qltool.py
@@ -13,7 +13,7 @@ import os
 
 class Qltool_Test(unittest.TestCase):
     def test_qltool_exec_args(self):
-        create = [sys.executable, '../qltool', 'run', '-f', '../examples/rootfs/x8664_linux/bin/x8664_args', '--rootfs', '../examples/rootfs/x8664_linux', '--verbose', '0', '--args', 'test1', 'test2' ,'test3']
+        create = [sys.executable, '../qltool', 'run', '-f', '../examples/rootfs/x8664_linux/bin/x8664_args', '--rootfs', '../examples/rootfs/x8664_linux', '--verbose', 'off', '--args', 'test1', 'test2' ,'test3']
         p = subprocess.Popen(create, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in iter(p.stdout.readline, b''):
             self.stdout = line
@@ -22,7 +22,7 @@ class Qltool_Test(unittest.TestCase):
 		
 
     def test_qltool_shellcode(self):
-        create = [sys.executable, '../qltool', 'code', '--os','linux','--arch', 'x86','--asm', '-f', '../examples/shellcodes/lin32_execve.asm']
+        create = [sys.executable, '../qltool', 'code', '--os','linux','--arch', 'x86', '--format', 'asm', '-f', '../examples/shellcodes/lin32_execve.asm']
         try:
             subprocess.check_output(create,stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:    
@@ -37,7 +37,7 @@ class Qltool_Test(unittest.TestCase):
             raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output)) 
 
     def test_qltool_json(self):
-        create = [sys.executable, '../qltool', 'run', '-f','../examples/rootfs/x86_linux/bin/x86_hello','--rootfs', '../examples/rootfs/x86_linux','--verbose', '0', '--json']
+        create = [sys.executable, '../qltool', 'run', '-f','../examples/rootfs/x86_linux/bin/x86_hello','--rootfs', '../examples/rootfs/x86_linux','--verbose', 'off', '--json']
         try:
             subprocess.check_output(create, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Refactored and cleaned up `qltool` to make it simpler to use (and maintain).

Highlights:
- The mutually exclusive flags `asm`, `hex` and `bin` are now consolidated into one option: `--format {asm, hex, bin}`
- The mutually exclusive flags `dump`, `debug`, `disasm` and `trace` are now consolidated into `--verbose` that now accepts a logging level name (instead of a meaningless integer value before): `--verbose {off, default, debug, diasm, dump}`
- Changed `--console False` to `--no-console` to make it more intuitive
- Changed `--bigendian` to `--endian {little, big}` to make it more intuitive (default: `little`)
- Removed manual arguments validation (e.g. allowing choosing only from specific choices in `arch` and `os`), and set `argparse` to handle it
- Removed manual hack for handling `--version`, and set it as a formal flag
- Usage message including all verbosed examples was changed to `examples` and set as a subparser. It will no longer be shown on every `qltool` command line syntax error, but with `qltool examples`
- Enhanced help / usage
- Refreshed the examples message (e.g. removed obsolete / nonexisting flags)
- Code cleaned and tidied up
- Few minor bugfixes
- Test file updated to meet the new options / flags
