### PR TITLE
check fstat attr before using it

### DIFF
--- a/qiling/os/posix/syscall/stat.py
+++ b/qiling/os/posix/syscall/stat.py
@@ -850,9 +850,10 @@ def ql_syscall_newfstatat(ql, newfstatat_dirfd, newfstatat_path, newfstatat_buf_
     return regreturn
 
 def ql_syscall_fstat64(ql, fstat64_fd, fstat64_buf_ptr, *args, **kw):
-    if ql.os.fd[fstat64_fd].fstat() == -1:
+    if not hasattr(ql.os.fd[fstat64_fd], "fstat"):
+        regreturn = -1
+    elif ql.os.fd[fstat64_fd].fstat() == -1:
         regreturn = 0
-
     elif fstat64_fd < 256 and ql.os.fd[fstat64_fd] != 0:
         user_fileno = fstat64_fd
         fstat64_info = ql.os.fd[user_fileno].fstat()


### PR DESCRIPTION
Sometimes an error throwed as follows, so add a check before using it.
```shell
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 854, in gevent._gevent_cgreenlet.Greenlet.run
  File "~/qiling/qiling/os/linux/thread.py", line 248, in _run
    self.ql.emu_start(start_address, self.exit_point, count=30000)
  File "~/qiling/qiling/core.py", line 899, in emu_start
    raise self._internal_exception
  File "~/qiling/qiling/utils.py", line 158, in wrapper
    return func(*args, **kw)
  File "~/qiling/qiling/core_hooks.py", line 65, in _hook_intr_cb
    ret = h.call(ql, intno)
  File "~/qiling/qiling/core_hooks_types.py", line 23, in call
    return self.callback(ql, *args)
  File "~/qiling/qiling/os/linux/linux.py", line 88, in hook_syscall
    return self.load_syscall()
  File "~/qiling/qiling/os/posix/posix.py", line 297, in load_syscall
    raise e
  File "~/qiling/qiling/os/posix/posix.py", line 281, in load_syscall
    ret = syscall_hook(self.ql, *arg_values)
  File "~/qiling/qiling/os/posix/syscall/stat.py", line 855, in ql_syscall_fstat64
    if ql.os.fd[fstat64_fd].fstat() == -1:
AttributeError: 'int' object has no attribute 'fstat'
```