### PR TITLE
append syscall_getrlimit

### DIFF
--- a/qiling/os/posix/syscall/resource.py
+++ b/qiling/os/posix/syscall/resource.py
@@ -29,6 +29,8 @@ def ql_syscall_ugetrlimit(ql, ugetrlimit_resource, ugetrlimit_rlim, *args, **kw)
     regreturn = 0
     return regreturn
 
+def ql_syscall_getrlimit(ql, getrlimit_resource, getrlimit_rlim, *args, **kw):
+    return ql_syscall_ugetrlimit(ql, getrlimit_resource, getrlimit_rlim, *args, **kw)
 
 def ql_syscall_setrlimit(ql, setrlimit_resource, setrlimit_rlim, *args, **kw):
     # maybe we can nop the setrlimit


### PR DESCRIPTION
Warning message:
```
[!]	0x4106b4: syscall ql_syscall_getrlimit number = 0xfec(4076) not implemented
```

And, I think getrlimit should be the same as ugetrlimit.