### PR TITLE
syscall/unistd.py: append setresuid && setresgid

### DIFF
--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -99,6 +99,11 @@ def ql_syscall_setgid32(ql, *args, **kw):
 def ql_syscall_setuid(ql, *args, **kw):
     return 0
 
+def ql_syscall_setresuid(ql, *args, **kw):
+    return 0
+
+def ql_syscall_setresgid(ql, *args, **kw):
+    return 0
 
 def ql_syscall_faccessat(ql, faccessat_dfd, faccessat_filename, faccessat_mode, *args, **kw):
 


### PR DESCRIPTION
Warning Message:

[!] [Thread 1855]       0x774cb514: syscall ql_syscall_setresuid number = 0x1059(4185) not implemented

Reference:

https://man7.org/linux/man-pages/man2/setresuid.2.html
