### PR TITLE
Fix mips syscall args

### DIFF
--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -251,7 +251,7 @@ class QlMemoryManager:
         return self.ql.uc.mem_read(addr, size)
 
     def read_ptr(self, addr: int, size: int=None) -> int:
-        """Read an integer value from a memory address.
+        """Read an pointer value from a memory address.
 
         Args:
             addr: memory address to read
@@ -261,6 +261,24 @@ class QlMemoryManager:
         """
 
         if not size:
+            size = self.ql.pointersize
+
+        return self.read_uint(addr, size)
+
+    def read_uint(self, addr: int, size: int=None) -> int:
+        """Read an unsigned integer value from a memory address.
+
+        Args:
+            addr: memory address to read
+            size: integer size (in bytes): either 1, 2, 4, 8, or None for arch native size
+
+        Returns: integer value stored at the specified memory address
+        """
+
+        if not size:
+            # Generally, the size of an unsigned integer is the same as pointer.
+            #     Maybe, It's better to add a new member(_uintsize) to Qiling (class),
+            #     And I think it's also OK like this.
             size = self.ql.pointersize
 
         __unpack = {

--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -123,8 +123,8 @@ class QlOsPosix(QlOs):
                 self.ql.reg.a1,
                 self.ql.reg.a2,
                 self.ql.reg.a3,
-                self.ql.reg.sp + 0x10,
-                self.ql.reg.sp + 0x14
+                self.ql.mem.read_uint(self.ql.reg.sp + 0x10, 4),
+                self.ql.mem.read_uint(self.ql.reg.sp + 0x14, 4),
             )
 
         def __syscall_args_x86():


### PR DESCRIPTION
1. ql.mem.read_uint() method.
2. correct the parameters of mips-syscall, the same as other CPUs.