### PR TITLE
Fixed some simple bugs in posix unistd syscalls

### DIFF
--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -257,7 +257,7 @@ def ql_syscall_write(ql, write_fd, write_buf, write_count, *args, **kw):
         if hasattr(ql.os.fd[write_fd], "write"):
             ql.os.fd[write_fd].write(buf)
         else:
-            ql.log.warning("write(%d,%x,%i) failed due to write_fd" % (write_fd, write_buf, write_count, regreturn))
+            ql.log.warning("write(%d,%x,%i) failed due to write_fd" % (write_fd, write_buf, write_count))
 
         regreturn = write_count
 
@@ -484,6 +484,8 @@ def ql_syscall_pipe(ql, pipe_pipefd, *args, **kw):
     rd, wd = ql_pipe.open()
 
     idx1 = -1
+    idx2 = -1
+
     for i in range(256):
         if ql.os.fd[i] == 0:
             idx1 = i


### PR DESCRIPTION
Wrong parameter count in format and possible reference before assignment. Found them just by looking at files in pycharm

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
