### PR TITLE
Rename undefined mmap_fd to existing parameter

### DIFF
--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -96,7 +96,7 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
             pgoffset = pgoffset * 4096
     elif (ql.archtype== QL_ARCH.ARM) and (ql.ostype== QL_OS.QNX):
         MAP_ANONYMOUS=0x00080000
-        mmap_id = ql.unpack32s(ql.pack32s(mmap_fd))
+        mmap_id = ql.unpack32s(ql.pack32s(fd))
     else:
         fd = ql.unpack32s(ql.pack32(fd))
         if ver == 2:


### PR DESCRIPTION
The variable mmap_fd is undefined and based on the surrounding code the function parameter fd should be used here instead.

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
