### PR TITLE
Fix hook_GetFileSize

### DIFF
--- a/qiling/os/windows/dlls/kernel32/fileapi.py
+++ b/qiling/os/windows/dlls/kernel32/fileapi.py
@@ -438,8 +438,8 @@ def hook_CreateDirectoryA(ql, address, params):
 @winsdkapi(cc=STDCALL, dllname=dllname, replace_params_type={'LPDWORD': 'DWORD'})
 def hook_GetFileSize(ql, address, params):
     try:
-        handle = ql.handle_manager.get(params['hFile'].file)
-        return os.path.getsize(handle.name)
+        handle = ql.os.handle_manager.get(params['hFile'])
+        return os.path.getsize(handle.obj.name)
     except:
         ql.os.last_error = ERROR_INVALID_HANDLE 
         return 0xFFFFFFFF #INVALID_FILE_SIZE


### PR DESCRIPTION
For `params['hFile'].file`:
The hFile parameter is an integer, which is the id of the handle. There is no `file` member.

For `ql.handle_manager`:
handle_manager is under ql.os. It should be `ql.os.handle_manager`.

For `handle.name`:
There is no member 'name'. The file name is stored in obj.name. It should be `handle.obj.name`.

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [ ] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
