### PR TITLE
Let DLL files load to their preferred base address

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -130,6 +130,10 @@ class Process():
 
             self.ql.log.debug(f'DLL preferred base address: {image_base:#x}')
 
+            if (image_base + image_size) > self.ql.mem.max_mem_addr:
+                image_base = self.dll_last_address
+                self.ql.log.debug(f'DLL preferred base address exceeds memory upper bound, loading to: {image_base:#x}')
+
             if not self.ql.mem.is_available(image_base, image_size):
                 image_base = self.ql.mem.find_free_space(image_size, minaddr=image_base, align=0x10000)
                 self.ql.log.debug(f'DLL preferred base address is taken, loading to: {image_base:#x}')

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -428,20 +428,20 @@ class PETest(unittest.TestCase):
         del ql
 
     class RefreshCache(QlPeCache):
-        def restore(self, path, address):
+        def restore(self, path):
             # If the cache entry exists, delete it
-            fcache = self.create_filename(path, address)
+            fcache = self.create_filename(path)
             if os.path.exists(fcache):
                 os.remove(fcache)
-            return super().restore(path, address)
+            return super().restore(path)
 
     class TestCache(QlPeCache):
         def __init__(self, testcase):
-            self.testcase = testcase
             super().__init__()
+            self.testcase = testcase
 
-        def restore(self, path, address):
-            entry = super().restore(path, address)
+        def restore(self, path):
+            entry = super().restore(path)
             self.testcase.assertTrue(entry is not None)  # Check that it loaded a cache entry
             if path.endswith('msvcrt.dll'):
                 self.testcase.assertEqual(len(entry.cmdlines), 2)
@@ -450,7 +450,7 @@ class PETest(unittest.TestCase):
             self.testcase.assertIsInstance(entry.data, bytearray)
             return entry
 
-        def save(self, path, address, entry):
+        def save(self, path, entry):
             self.testcase.assertFalse(True)  # This should not be called!
 
 


### PR DESCRIPTION
Addressing #852 

Changelog:
- DLL files will load to their preferred base address, if available
- Cached DLL files no longer have the base address in their names
- Cached DLL files will try to load to the same address; if it is not available, the cached content is useless and the DLL will reload to have its symbols relocated according to the alternate address
- PE cache test adjusted accordingly