### PR TITLE
Refactor POSIX syscalls handling to use CC methodology

### DIFF
--- a/qiling/cc/__init__.py
+++ b/qiling/cc/__init__.py
@@ -89,6 +89,7 @@ class QlCommonBaseCC(QlCC):
 
 	_argregs = ()
 	_shadow = 0
+	_retaddr_on_stack = True
 
 	def __init__(self, ql: Qiling, retreg: int):
 		super().__init__(ql)
@@ -125,7 +126,7 @@ class QlCommonBaseCC(QlCC):
 			si = index - self._argregs.index(None)
 
 			# skip return address and shadow space
-			return stack_access, (1 + self._shadow + si) * self._asize
+			return stack_access, (self._retaddr_on_stack + self._shadow + si) * self._asize
 		else:
 			return reg_access, reg
 

--- a/qiling/cc/mips.py
+++ b/qiling/cc/mips.py
@@ -10,6 +10,7 @@ from . import QlCommonBaseCC
 class mipso32(QlCommonBaseCC):
 	_argregs = (UC_MIPS_REG_A0, UC_MIPS_REG_A1, UC_MIPS_REG_A2, UC_MIPS_REG_A3) + (None, ) * 12
 	_shadow = 4
+	_retaddr_on_stack = False
 
 	def __init__(self, ql: Qiling):
 		super().__init__(ql, UC_MIPS_REG_V0)

--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -90,6 +90,7 @@ class QlOsPosix(QlOs):
         if (self.ql.archtype == QL_ARCH.ARM) and (self.ql.ostype == QL_OS.QNX):
             self.__syscall_id_reg = UC_ARM_REG_R12
 
+        # TODO: use abstract to access __syscall_cc and __syscall_id_reg by defining a system call class
         self.__syscall_cc: QlCC = {
             QL_ARCH.ARM64: aarch64,
             QL_ARCH.ARM  : aarch32,
@@ -242,6 +243,9 @@ class QlOsPosix(QlOs):
 
     def get_syscall(self) -> int:
         return self.ql.reg.read(self.__syscall_id_reg)
+
+    def set_syscall_return(self, retval: int):
+        self.__syscall_cc.setReturnValue(retval)
 
     @property
     def fd(self):

--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -12,6 +12,7 @@ from unicorn.mips_const import UC_MIPS_REG_V0
 from unicorn.x86_const import UC_X86_REG_EAX, UC_X86_REG_RAX
 
 from qiling import Qiling
+from qiling.cc import QlCC, intel, arm, mips
 from qiling.const import QL_ARCH, QL_OS, QL_INTERCEPT, QL_CALL_BLOCK, QL_VERBOSE
 from qiling.exception import QlErrorSyscallNotFound
 from qiling.os.os import QlOs
@@ -25,6 +26,30 @@ from qiling.os.freebsd.syscall import *
 from qiling.os.qnx.syscall import *
 
 SYSCALL_PREF: str = f'ql_syscall_'
+
+class intel32(intel.QlIntel32):
+    _argregs = (UC_X86_REG_EBX, UC_X86_REG_ECX, UC_X86_REG_EDX, UC_X86_REG_ESI, UC_X86_REG_EDI, UC_X86_REG_EBP)
+
+class intel64(intel.QlIntel64):
+    _argregs = (UC_X86_REG_RDI, UC_X86_REG_RSI, UC_X86_REG_RDX, UC_X86_REG_R10, UC_X86_REG_R8, UC_X86_REG_R9)
+
+class aarch32(arm.aarch32):
+    _argregs = (UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3, UC_ARM_REG_R4, UC_ARM_REG_R5)
+
+class aarch64(arm.aarch64):
+    pass
+
+class mipso32(mips.mipso32):
+    # TODO: should it be part of the standard mipso32 cc?
+    def setReturnValue(self, value: int):
+        if -1134 < value < 0:
+            a3return = 1
+            value = -value
+        else:
+            a3return = 0
+
+        self.ql.reg.v0 = value
+        self.ql.reg.a3 = a3return
 
 class QlOsPosix(QlOs):
 
@@ -65,95 +90,13 @@ class QlOsPosix(QlOs):
         if (self.ql.archtype == QL_ARCH.ARM) and (self.ql.ostype == QL_OS.QNX):
             self.__syscall_id_reg = UC_ARM_REG_R12
 
-        def __set_syscall_ret_arm(retval: int):
-            self.ql.reg.r0 = retval
-
-        def __set_syscall_ret_arm64(retval: int):
-            self.ql.reg.x0 = retval
-
-        def __set_syscall_ret_x86(retval: int):
-            self.ql.reg.eax = retval
-
-        def __set_syscall_ret_x8664(retval: int):
-            self.ql.reg.rax = retval
-
-        def __set_syscall_ret_mips(retval: int):
-            if -1134 < retval < 0:
-                a3return = 1
-                retval = -retval
-            else:
-                a3return = 0
-
-            self.ql.reg.v0 = retval
-            self.ql.reg.a3 = a3return
-
-            return retval
-
-        self.__set_syscall_retval: Callable = {
-            QL_ARCH.ARM64: __set_syscall_ret_arm64,
-            QL_ARCH.ARM  : __set_syscall_ret_arm,
-            QL_ARCH.MIPS : __set_syscall_ret_mips,
-            QL_ARCH.X86  : __set_syscall_ret_x86,
-            QL_ARCH.X8664: __set_syscall_ret_x8664
-        }[self.ql.archtype]
-
-        def __syscall_args_arm64():
-            return (
-                self.ql.reg.x0,
-                self.ql.reg.x1,
-                self.ql.reg.x2,
-                self.ql.reg.x3,
-                self.ql.reg.x4,
-                self.ql.reg.x5
-            )
-
-        def __syscall_args_arm():
-            return (
-                self.ql.reg.r0,
-                self.ql.reg.r1,
-                self.ql.reg.r2,
-                self.ql.reg.r3,
-                self.ql.reg.r4,
-                self.ql.reg.r5
-            )
-
-        def __syscall_args_mips():
-            return (
-                self.ql.reg.a0,
-                self.ql.reg.a1,
-                self.ql.reg.a2,
-                self.ql.reg.a3,
-                self.ql.reg.sp + 0x10,
-                self.ql.reg.sp + 0x14
-            )
-
-        def __syscall_args_x86():
-            return (
-                self.ql.reg.ebx,
-                self.ql.reg.ecx,
-                self.ql.reg.edx,
-                self.ql.reg.esi,
-                self.ql.reg.edi,
-                self.ql.reg.ebp
-            )
-
-        def __syscall_args_x8664():
-            return (
-                self.ql.reg.rdi,
-                self.ql.reg.rsi,
-                self.ql.reg.rdx,
-                self.ql.reg.r10,
-                self.ql.reg.r8,
-                self.ql.reg.r9
-            )
-
-        self.__syscall_args: Callable = {
-            QL_ARCH.ARM64: __syscall_args_arm64,
-            QL_ARCH.ARM  : __syscall_args_arm,
-            QL_ARCH.MIPS : __syscall_args_mips,
-            QL_ARCH.X86  : __syscall_args_x86,
-            QL_ARCH.X8664: __syscall_args_x8664
-        }[self.ql.archtype]
+        self.__syscall_cc: QlCC = {
+            QL_ARCH.ARM64: aarch64,
+            QL_ARCH.ARM  : aarch32,
+            QL_ARCH.MIPS : mipso32,
+            QL_ARCH.X86  : intel32,
+            QL_ARCH.X8664: intel64
+        }[self.ql.archtype](ql)
 
         self._fd = QlFileDes([0] * NR_OPEN)
         self._fd[0] = self.stdin
@@ -226,76 +169,71 @@ class QlOsPosix(QlOs):
                 syscall_hook = None
 
         if syscall_hook:
-            args = self.get_syscall_args()
+            params = [self.__syscall_cc.getRawParam(i) for i in range(6)]
 
+            try:
+        		# if set, fire up the on-enter hook and let it override original args set
+                if onenter_hook:
+                    overrides = onenter_hook(self.ql, *params)
+
+                    if overrides is not None:
+                        _, params = overrides
+
+        		# perform syscall
+                retval = syscall_hook(self.ql, *params)
+
+                # if set, fire up the on-exit hook and let it override the return value
+                if onexit_hook:
+                    override = onexit_hook(self.ql, *params, retval)
+
+                    if override is not None:
+                        retval = override
+
+                # set return value
+                if retval is not None:
+                    self.__syscall_cc.setReturnValue(retval)
+
+            except KeyboardInterrupt:
+                raise
+
+            except Exception as e:
+                self.ql.log.exception("")
+                self.ql.log.info(f'Syscall ERROR: {syscall_name} DEBUG: {e}')
+                raise e
+
+            # print out log entry
+            syscall_basename = syscall_hook.__name__[len(SYSCALL_PREF):]
+            args = []
+
+            # ignore first arg, which is 'ql'
+            arg_names = tuple(signature(syscall_hook).parameters.values())[1:]
+
+            for name, value in zip(arg_names, params):
+                name = str(name)
+
+                # ignore python special args
+                if name in ('*args', '**kw', '**kwargs'):
+                    continue
+
+                # cut the first part of the arg if it is of form fstatat64_fd
+                if name.startswith(f'{syscall_basename}_'):
+                    name = name.partition('_')[-1]
+
+                args.append((name, f'{value:#x}'))
+
+            sret = retval and QlOsPosix.getNameFromErrorCode(retval)
+            self.utils.print_function(self.ql.reg.arch_pc, syscall_basename, args, sret, False)
+
+            # record syscall statistics
             self.utils.syscalls.setdefault(syscall_name, []).append({
-                "params": {
-                    "param0": args[0],
-                    "param1": args[1],
-                    "param2": args[2],
-                    "param3": args[3],
-                    "param4": args[4],
-                    "param5": args[5]
-                },
-                "result": None,
+                "params": dict(zip((f'param{i}' for i in range(6)), params)),
+                "result": retval,
                 "address": self.ql.reg.arch_pc,
                 "return_address": None,
                 "position": self.utils.syscalls_counter
             })
 
             self.utils.syscalls_counter += 1
-
-            try:
-
-                if onenter_hook is not None:
-                    onenter_hook(self.ql, *self.get_syscall_args())
-
-                syscall_basename = syscall_hook.__name__[len(SYSCALL_PREF):]
-                args = []
-
-                # ignore first arg, which is 'ql'
-                arg_names = tuple(signature(syscall_hook).parameters.values())[1:]
-                arg_values = self.get_syscall_args()
-
-                for name, value in zip(arg_names, arg_values):
-                    name = str(name)
-
-                    # ignore python special args
-                    if name in ('*args', '**kw', '**kwargs'):
-                        continue
-
-                    # cut the first part of the arg if it is of form fstatat64_fd
-                    if name.startswith(f'{syscall_basename}_'):
-                        name = name.partition('_')[-1]
-
-                    args.append(f'{name} = {value:#x}')
-
-                faddr = f'{self.ql.reg.arch_pc:#0{self.ql.archbit // 4 + 2}x}: ' if self.ql.verbose >= QL_VERBOSE.DEBUG else ''
-                fargs = ', '.join(args)
-
-                ret = syscall_hook(self.ql, *arg_values)
-                log = f'{faddr}{syscall_basename}({fargs}) = {QlOsPosix.getNameFromErrorCode(ret)}'
-
-                if self.ql.verbose >= QL_VERBOSE.DEBUG:
-                    self.ql.log.debug(log)
-                else:
-                    self.ql.log.info(log)
-
-                if ret is not None and type(ret) is int:
-                    # each name has a list of calls, we want the last one and we want to update the return value
-                    self.utils.syscalls[syscall_name][-1]["result"] = ret
-                    ret = self.set_syscall_return(ret)
-                    # self.ql.log.debug(f'{syscall_basename}() = {QlOsPosix.getNameFromErrorCode(ret)}')
-
-                if onexit_hook is not None:
-                    onexit_hook(self.ql, *self.get_syscall_args())
-
-            except KeyboardInterrupt:
-                raise
-            except Exception as e:
-                self.ql.log.exception("")
-                self.ql.log.info(f'Syscall ERROR: {syscall_name} DEBUG: {e}')
-                raise e
         else:
             self.ql.log.warning(f'{self.ql.reg.arch_pc:#x}: syscall {syscall_name} number = {syscall:#x}({syscall:d}) not implemented')
 
@@ -304,12 +242,6 @@ class QlOsPosix(QlOs):
 
     def get_syscall(self) -> int:
         return self.ql.reg.read(self.__syscall_id_reg)
-
-    def set_syscall_return(self, retval: int) -> int:
-        return self.__set_syscall_retval(retval) or retval
-
-    def get_syscall_args(self):
-        return self.__syscall_args()
 
     @property
     def fd(self):

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -90,8 +90,6 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
     if (ql.archtype == QL_ARCH.ARM64) or (ql.archtype == QL_ARCH.X8664):
         fd = ql.unpack64(ql.pack64(fd))
     elif (ql.archtype == QL_ARCH.MIPS):
-        fd = ql.unpack32s(ql.mem.read(fd, 4))
-        pgoffset = ql.unpack32(ql.mem.read(pgoffset, 4))
         MAP_ANONYMOUS = 2048
         if ver == 2:
             pgoffset = pgoffset * 4096

--- a/qiling/os/posix/syscall/sched.py
+++ b/qiling/os/posix/syscall/sched.py
@@ -48,9 +48,6 @@ def ql_syscall_clone(ql, clone_flags, clone_child_stack, clone_parent_tidptr, cl
         clone_child_tidptr = clone_newtls
         clone_newtls = ori_clone_newtls
 
-    if ql.archtype== QL_ARCH.MIPS:
-        clone_child_tidptr = ql.unpack32(ql.mem.read(clone_child_tidptr, 4))
-
     f_th = ql.os.thread_management.cur_thread	
     newtls = None
     set_child_tid_addr = None

--- a/qiling/os/posix/syscall/select.py
+++ b/qiling/os/posix/syscall/select.py
@@ -44,10 +44,7 @@ def ql_syscall__newselect(ql, _newselect_nfds, _newselect_readfds, _newselect_wr
     n = ql.pointersize
 
     if _newselect_timeout != 0:
-        if ql.archtype == QL_ARCH.MIPS:
-            timeout_ptr = ql.unpack(ql.mem.read(_newselect_timeout, n))
-        else:
-            timeout_ptr = _newselect_timeout
+        timeout_ptr = _newselect_timeout
         sec = ql.unpack(ql.mem.read(timeout_ptr, n))
         usec = ql.unpack(ql.mem.read(timeout_ptr + n, n))
         timeout_total = sec + float(usec)/1000000

--- a/qiling/os/posix/syscall/socket.py
+++ b/qiling/os/posix/syscall/socket.py
@@ -69,11 +69,6 @@ def ql_bin_to_ip(ip):
 
 
 def ql_syscall_socket(ql, socket_domain, socket_type, socket_protocol, *args, **kw):
-    if ql.archtype== QL_ARCH.MIPS and socket_type == 2:
-        socket_type = 1
-    elif ql.archtype== QL_ARCH.MIPS and socket_type == 1:
-        socket_type = 1
-
     idx = -1
     for i in range(NR_OPEN):
         if ql.os.fd[i] == 0:

--- a/qiling/os/utils.py
+++ b/qiling/os/utils.py
@@ -7,7 +7,7 @@
 This module is intended for general purpose functions that are only used in qiling.os
 """
 
-from typing import Any, MutableMapping, Mapping, Optional, Sequence, MutableSequence, Tuple
+from typing import Any, MutableMapping, Mapping, Union, Sequence, MutableSequence, Tuple
 from os.path import basename
 from uuid import UUID
 import ctypes
@@ -103,7 +103,7 @@ class QlOsUtils:
     def stringify(s: str) -> str:
         return f'"{repr(s)[1:-1]}"'
 
-    def print_function(self, address: int, fname: str, pargs: Sequence[Tuple[str, str]], ret: Optional[int], passthru: bool):
+    def print_function(self, address: int, fname: str, pargs: Sequence[Tuple[str, str]], ret: Union[int, str, None], passthru: bool):
         '''Print out function invocation detais.
 
         Args:
@@ -127,8 +127,11 @@ class QlOsUtils:
         # arguments list
         fargs = ', '.join(__assign_arg(name, value) for name, value in pargs)
 
+        if type(ret) is int:
+            ret = f'{ret:#x}'
+
         # optional prefixes and suffixes
-        fret = f' = {ret:#x}' if ret is not None else ''
+        fret = f' = {ret}' if ret is not None else ''
         fpass = f' (PASSTHRU)' if passthru else ''
         faddr = f'{address:#0{self.ql.archbit // 4 + 2}x}: ' if self.ql.verbose >= QL_VERBOSE.DEBUG else ''
 


### PR DESCRIPTION
Changelog Highlights:
- POSIX syscalls arguments and retval are now accessed using the `cc` abstraction
- Fixed a bug in MIPS `cc` where args on the stack were accessed as if there was a return address (and there is not)
- POSIX syscalls adjusted to meet the change in arguments access (as made by @rootkiter !)

This PR comes to enhance and replace PR #859 