### PR TITLE
munmap logic change to avoid crashes

### DIFF
--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -38,7 +38,12 @@ def ql_syscall_munmap(ql, munmap_addr, munmap_len, *args, **kw):
                 _fd.write(_buff)
 
     munmap_len = ((munmap_len + 0x1000 - 1) // 0x1000) * 0x1000
-    ql.mem.unmap(munmap_addr, munmap_len)
+    
+    # making more gentle unmap mempage-by-mempage to avoid "unicorn.unicorn.UcError: No memory available or memory not present (UC_ERR_NOMEM)" error
+    for begin, end, perms, name in ql.mem.map_info[:]:
+        if munmap_addr <= begin < munmap_addr + munmap_len:
+            ql.mem.unmap(begin, min(munmap_addr + munmap_len, end - begin))
+         
     regreturn = 0
     return regreturn
 

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -40,9 +40,16 @@ def ql_syscall_munmap(ql, munmap_addr, munmap_len, *args, **kw):
     munmap_len = ((munmap_len + 0x1000 - 1) // 0x1000) * 0x1000
     
     # making more gentle unmap mempage-by-mempage to avoid "unicorn.unicorn.UcError: No memory available or memory not present (UC_ERR_NOMEM)" error
+    munmap_flag = False # set True if we was found any memory allocation within range [munmap_addr, munmap_addr + munmap_len)
     for begin, end, perms, name in ql.mem.map_info[:]:
         if munmap_addr <= begin < munmap_addr + munmap_len:
+            print("munmap...")
+            print(hex(begin), hex(min(munmap_addr + munmap_len, end - begin)))
             ql.mem.unmap(begin, min(munmap_addr + munmap_len, end - begin))
+            munmap_flag = True
+
+    if not munmap_flag:
+        ql.mem.unmap(munmap_addr, munmap_len)
          
     regreturn = 0
     return regreturn


### PR DESCRIPTION
ql.mem.unmap will crash if we will munmap more memory than available in unicorn memory, which can be used to break qiling execution. This patch will unmap only available memory pages.

## Case 1 - intentionally breaking qiling (possible malware case)

Code:
```cpp
// compile with: g++ mmap_things.c --static -o mmap_things.elf
#include <stdio.h>
#include <sys/mman.h>


int main (void)
{
	void* goal_addr = (void*)0x10000;
	void* ptr = mmap(goal_addr, 0x10000, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, 0, 0 );
	
	if(ptr == MAP_FAILED){
		printf("mmap - fail\n");
		return 1;
	}
	
	char* c;
	for (c = (char*)ptr; c <  ((char*)ptr) + 10; c++) {
		*c = ((long long)c & 0xff);
	}

	for (c = (char*)ptr; c <  ((char*)ptr) + 10; c++) {
		printf("wrote byte %d to location %p\n", *c, c);
	}
  
  
	printf("Check 1 - munmap more than allocated size\n");
  	int err = munmap(ptr, 0x20000);
	if(err != 0){
		printf("munmap - fail\n");
		return 1;
	}
	
	printf("Check 2 - munmap unallocated memory\n");
	void* goal_addr2 = (void*)0xe0000;
  	err = munmap(goal_addr2, 0x20000);
	if(err != 0){
		printf("munmap - fail\n");
		return 1;
	}
	
	
	printf("All checks passed!\n");
	return 0;
}
```

Execution by actual linux system:
```
wrote byte 0 to location 0x10000
wrote byte 1 to location 0x10001
wrote byte 2 to location 0x10002
wrote byte 3 to location 0x10003
wrote byte 4 to location 0x10004
wrote byte 5 to location 0x10005
wrote byte 6 to location 0x10006
wrote byte 7 to location 0x10007
wrote byte 8 to location 0x10008
wrote byte 9 to location 0x10009
Check 1 - munmap more than allocated size
Check 2 - munmap unallocated memory
All checks passed!
```

Execution by qiling:
```
...
[+]     0x000000000044976f: write(fd = 0x1, buf = 0x6c1480, count = 0x2a)
[+]     write() CONTENT:
[+]     bytearray(b'Check 1 - munmap more than allocated size\n')
Check 1 - munmap more than allocated size
[+]     write() = 0x2a
[+]     0x000000000044a445: munmap(addr = 0x10000, len = 0x20000)
[x]
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/posix.py", line 282, in load_syscall
    ret = syscall_hook(self.ql, *arg_values)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/syscall/mman.py", line 40, in ql_syscall_munmap
    ql.mem.unmap(munmap_addr, munmap_len)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/memory.py", line 335, in unmap
    self.ql.uc.mem_unmap(addr, size)
  File "/home/user/.local/lib/python3.6/site-packages/unicorn/unicorn.py", line 461, in mem_unmap
    raise UcError(status)
unicorn.unicorn.UcError: No memory available or memory not present (UC_ERR_NOMEM)
[=]     Syscall ERROR: ql_syscall_munmap DEBUG: No memory available or memory not present (UC_ERR_NOMEM)
[x]

[x]     ah      :        0x0
[x]     al      :        0xb
[x]     ch      :        0x2a
[x]     cl      :        0x84
[x]     dh      :        0xbd
[x]     dl      :        0x30
[x]     bh      :        0x4
[x]     bl      :        0x0
[x]     ax      :        0xb
[x]     cx      :        0x2a84
[x]     dx      :        0xbd30
[x]     bx      :        0x400
[x]     sp      :        0xdd28
[x]     bp      :        0xdd60
[x]     si      :        0x0
[x]     di      :        0x0
[x]     ip      :        0xa447
[x]     eax     :        0xb
[x]     ecx     :        0xfbad2a84
[x]     edx     :        0x6bbd30
[x]     ebx     :        0x400400
[x]     esp     :        0xdd28
[x]     ebp     :        0xdd60
[x]     esi     :        0x20000
[x]     edi     :        0x10000
[x]     eip     :        0x44a447
[x]     rax     :        0xb
[x]     rbx     :        0x400400
[x]     rcx     :        0xfbad2a84
[x]     rdx     :        0x6bbd30
[x]     rsi     :        0x20000
[x]     rdi     :        0x10000
[x]     rbp     :        0x80000000dd60
[x]     rsp     :        0x80000000dd28
[x]     r8      :        0x2031206b63656843
[x]     r9      :        0x70616d6e756d202d
[x]     r10     :        0x68742065726f6d20
[x]     r11     :        0x636f6c6c61206e61
[x]     r12     :        0x401a20
[x]     r13     :        0x0
[x]     r14     :        0x6b9018
[x]     r15     :        0x0
[x]     rip     :        0x44a447
[x]     cr0     :        0x11
[x]     cr1     :        0x0
[x]     cr2     :        0x0
[x]     cr3     :        0x0
[x]     cr4     :        0x0
[x]     cr5     :        0x0
[x]     cr6     :        0x0
[x]     cr7     :        0x0
[x]     cr8     :        0x0
[x]     cr9     :        0x0
[x]     cr10    :        0x0
[x]     cr11    :        0x0
[x]     cr12    :        0x0
[x]     cr13    :        0x0
[x]     cr14    :        0x0
[x]     cr15    :        0x0
[x]     st0     :        0x0
[x]     st1     :        0x0
[x]     st2     :        0x0
[x]     st3     :        0x0
[x]     st4     :        0x0
[x]     st5     :        0x0
[x]     st6     :        0x0
[x]     st7     :        0x0
[x]     ef      :        0x0
[x]     cs      :        0x1b
[x]     ss      :        0x28
[x]     ds      :        0x28
[x]     es      :        0x28
[x]     fs      :        0x0
[x]     gs      :        0x0
[x]     r8b     :        0x43
[x]     r9b     :        0x2d
[x]     r10b    :        0x20
[x]     r11b    :        0x61
[x]     r12b    :        0x20
[x]     r13b    :        0x0
[x]     r14b    :        0x18
[x]     r15b    :        0x0
[x]     r8w     :        0x6843
[x]     r9w     :        0x202d
[x]     r10w    :        0x6d20
[x]     r11w    :        0x6e61
[x]     r12w    :        0x1a20
[x]     r13w    :        0x0
[x]     r14w    :        0x9018
[x]     r15w    :        0x0
[x]     r8d     :        0x63656843
[x]     r9d     :        0x756d202d
[x]     r10d    :        0x726f6d20
[x]     r11d    :        0x61206e61
[x]     r12d    :        0x401a20
[x]     r13d    :        0x0
[x]     r14d    :        0x6b9018
[x]     r15d    :        0x0
[x]     fsbase  :        0x6bf880
[x]     gsbase  :        0x6000000
[x]

[x]     PC = 0x44a447
[x]      (/mnt/c/Users/user/Documents/qiling_crash_case/examples/mmap_fixed_tests/mmap_things.elf+0x44a447)
[=]     Start      End        Perm    Label          Image
[=]     00030000 - 00031000   rwx     [GDT]          /mnt/c/Users/user/Documents/qiling_crash_case/examples/mmap_fixed_tests/mmap_things.elf
[=]     00400000 - 004b6000   r-x     /mnt/c/Users/user/Documents/qiling_crash_case/examples/mmap_fixed_tests/mmap_things.elf   /mnt/c/Users/user/Documents/qiling_crash_case/examples/mmap_fixed_tests/mmap_things.elf
[=]     006b6000 - 006bd000   rw-     /mnt/c/Users/user/Documents/qiling_crash_case/examples/mmap_fixed_tests/mmap_things.elf   /mnt/c/Users/user/Documents/qiling_crash_case/examples/mmap_fixed_tests/mmap_things.elf
[=]     006bd000 - 006bf000   rwx     [hook_mem]
[=]     006bf000 - 006c1000   rwx     [brk]
[=]     006c1000 - 006e2000   rwx     [brk]
[=]     06000000 - 07400000   rwx     [GS]
[=]     7ffffffde000 - 80000000e000   rwx     [stack]
[=]     ffffffffff600000 - ffffffffff601000   rwx     [vsyscall]
[x]     ['0x48', '0x3d', '0x1', '0xf0', '0xff', '0xff', '0x73', '0x1']
[=]

[=]     0x000000000044a447 {mmap_things.elf      + 0x04a447}   48 3d 01 f0 ff ff 73 01 c3 48 c7 c1 c0 ff ff ff f7 d8 64 89 01 48 83 c8 ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 44 00 00 b8 0a 00 00 00 0f 05 48 3d 01 f0 ff ff 73 01 c3 48 c7 c1 c0 ff ff ff cmp rax, -0xfff
> jae 0x44a450
> ret
> mov rcx, -0x40
> neg eax
> mov dword ptr fs:[rcx], eax
> or rax, 0xffffffffffffffff
> ret
> nop word ptr cs:[rax + rax]
> nop dword ptr [rax + rax]
> mov eax, 0xa
> syscall
> cmp rax, -0xfff
> jae 0x44a480
> ret
> mov rcx, -0x40
Traceback (most recent call last):
  File "upxunpack.py", line 111, in <module>
    main()
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "upxunpack.py", line 108, in main
    ql.run()
  File "/home/user/.local/lib/python3.6/site-packages/qiling/core.py", line 755, in run
    self.os.run()
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/linux/linux.py", line 136, in run
    self.ql.emu_start(self.ql.loader.elf_entry, self.exit_point, self.ql.timeout, self.ql.count)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/core.py", line 899, in emu_start
    raise self._internal_exception
  File "/home/user/.local/lib/python3.6/site-packages/qiling/utils.py", line 158, in wrapper
    return func(*args, **kw)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/core_hooks.py", line 81, in _hook_insn_cb
    ret = h.call(ql, *args[ : -1])
  File "/home/user/.local/lib/python3.6/site-packages/qiling/core_hooks_types.py", line 23, in call
    return self.callback(ql, *args)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/linux/linux.py", line 88, in hook_syscall
    return self.load_syscall()
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/posix.py", line 298, in load_syscall
    raise e
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/posix.py", line 282, in load_syscall
    ret = syscall_hook(self.ql, *arg_values)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/syscall/mman.py", line 40, in ql_syscall_munmap
    ql.mem.unmap(munmap_addr, munmap_len)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/memory.py", line 335, in unmap
    self.ql.uc.mem_unmap(addr, size)
  File "/home/user/.local/lib/python3.6/site-packages/unicorn/unicorn.py", line 461, in mem_unmap
    raise UcError(status)
unicorn.unicorn.UcError: No memory available or memory not present (UC_ERR_NOMEM)
```

## Case 2 - upx unpack process on MIPS (the case that was the reason for this pr)

Sample - upxed hello world for mipsel:
```
#include <stdio.h>

// mipsel-linux-gnu-gcc -o hello_mipsel -Wall --static hello_void.c
// upx -D -o hello_mipsel_upx hello_mipsel

int main (void)
{
  printf ("Hello, void!\n");
  return 0;
}
```


Qiling run:
```
[+]     load 0x100000 - 0x13e000
[+]     load 0x491000 - 0x492000
[+]     mem_start: 0x100000 mem_end: 0x492000
[+]     mmap_address is : 0x774bf000
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x0013d058: mmap(addr = 0x190000, length = 0x10000, prot = 0x7, flags = 0x812, fd = 0x7ff3cf18, pgoffset = 0x7ff3cf1c)
[+]     mmap(0x190000, 0x10000, PROT_READ | PROT_WRITE | PROT_EXEC (0x7), MAP_PRIVATE | MAP_FIXED | 2048 (0x812), 7ff3cf18, 0x7ff3cf1c)
[+]     mmap - mapping needed for 0x190000
[+]     mmap - addr range  0x190000 - 0x19ffff:
[+]     mmap(0x190000, 0x10000, 0x7, 0x812, 0, 0x0) = 0x190000
[+]     mmap() = 0x190000
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[!]     0x13cf4c: syscall ql_syscall_cacheflush number = 0x1033(4147) not implemented
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x001900a4: readlink(path_name = 0x19008c, path_buff = 0x7ff3bfc0, path_buffsize = 0xfff)
[+]     readlink(/proc/self/exe, 0x7ff3bfc0, 0xfff) = -1
[+]     readlink() = 0x1
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[!]     0x13cf4c: syscall ql_syscall_cacheflush number = 0x1033(4147) not implemented
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x00190134: mmap(addr = 0x400000, length = 0x7bcb4, prot = 0x7, flags = 0x812, fd = 0x7ff3bc80, pgoffset = 0x7ff3bc84)
[+]     mmap(0x400000, 0x7bcb4, PROT_READ | PROT_WRITE | PROT_EXEC (0x7), MAP_PRIVATE | MAP_FIXED | 2048 (0x812), 7ff3bc80, 0x7ff3bc84)
[+]     mmap - mapping needed for 0x400000
[+]     mmap - addr range  0x400000 - 0x47bfff:
[+]     mmap(0x400000, 0x7bcb4, 0x7, 0x812, -1, 0x0) = 0x400000
[+]     mmap() = 0x400000
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[!]     0x13cf4c: syscall ql_syscall_cacheflush number = 0x1033(4147) not implemented
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[!]     0x13cf4c: syscall ql_syscall_cacheflush number = 0x1033(4147) not implemented
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x00190140: mprotect(start = 0x400000, mlen = 0x7bcb4, prot = 0x5)
[+]     mprotect(0x400000, 0x7bcb4, PROT_READ | PROT_EXEC) = 0
[+]     mprotect() = 0x0
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x00190134: mmap(addr = 0x48c000, length = 0x46e4, prot = 0x3, flags = 0x812, fd = 0x7ff3bc80, pgoffset = 0x7ff3bc84)
[+]     mmap(0x48c000, 0x46e4, PROT_READ | PROT_WRITE (0x3), MAP_PRIVATE | MAP_FIXED | 2048 (0x812), 7ff3bc80, 0x7ff3bc84)
[+]     mmap - mapping needed for 0x48c000
[+]     mmap - addr range  0x48c000 - 0x490fff:
[+]     mmap(0x48c000, 0x46e4, 0x3, 0x812, -1, 0x0) = 0x48c000
[+]     mmap() = 0x48c000
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[!]     0x13cf4c: syscall ql_syscall_cacheflush number = 0x1033(4147) not implemented
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x00190140: mprotect(start = 0x48c000, mlen = 0x46e4, prot = 0x3)
[+]     mprotect(0x48c000, 0x46e4, PROT_READ | PROT_WRITE) = 0
[+]     mprotect() = 0x0
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x00190134: mmap(addr = 0x491000, length = 0x4bc, prot = 0x3, flags = 0x812, fd = 0x7ff3bc80, pgoffset = 0x7ff3bc84)
[+]     mmap(0x491000, 0x4bc, PROT_READ | PROT_WRITE (0x3), MAP_PRIVATE | MAP_FIXED | 2048 (0x812), 7ff3bc80, 0x7ff3bc84)
[+]     mmap - MAP_FIXED, mapping not needed
[+]     mmap - addr range  0x491000 - 0x491fff:
[+]     mmap(0x491000, 0x4bc, 0x3, 0x812, -1, 0x0) = 0x491000
[+]     mmap() = 0x491000
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x00190140: brk(input = 0x492000)
[+]     brk return(0x492000)
[+]     brk() = 0x492000
[+]     [+] Received Interupt: 17 Hooked Interupt: 17
[+]     0x0047bcb8: munmap(addr = 0x100000, len = 0x9fb54)
[x]
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/posix.py", line 282, in load_syscall
    ret = syscall_hook(self.ql, *arg_values)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/syscall/mman.py", line 40, in ql_syscall_munmap
    ql.mem.unmap(munmap_addr, munmap_len)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/memory.py", line 335, in unmap
    self.ql.uc.mem_unmap(addr, size)
  File "/home/user/.local/lib/python3.6/site-packages/unicorn/unicorn.py", line 461, in mem_unmap
    raise UcError(status)
unicorn.unicorn.UcError: No memory available or memory not present (UC_ERR_NOMEM)
[=]     Syscall ERROR: ql_syscall_munmap DEBUG: No memory available or memory not present (UC_ERR_NOMEM)
[x]

[x]     zero    :        0x0
[x]     at      :        0x47bcb4
[x]     v0      :        0xffb
[x]     v1      :        0x6474e552
[x]     a0      :        0x100000
[x]     a1      :        0x9fb54
[x]     a2      :        0x400350
[x]     a3      :        0x0
[x]     t0      :        0xffffffff
[x]     t1      :        0x0
[x]     t2      :        0x1
[x]     t3      :        0x1
[x]     t4      :        0x0
[x]     t5      :        0x80000000
[x]     t6      :        0x0
[x]     t7      :        0xffffffff
[x]     s0      :        0x7ff3bf2c
[x]     s1      :        0x10008c
[x]     s2      :        0x9fb54
[x]     s3      :        0x100000
[x]     s4      :        0x7ff3bf34
[x]     s5      :        0x3cdc4
[x]     s6      :        0x7ff3bfbc
[x]     s7      :        0x13cde8
[x]     t8      :        0x0
[x]     t9      :        0x400350
[x]     k0      :        0x0
[x]     k1      :        0x0
[x]     gp      :        0x0
[x]     sp      :        0x7ff3bf20
[x]     s8      :        0x0
[x]     ra      :        0x1900e0
[x]     status  :        0x0
[x]     lo      :        0x0
[x]     hi      :        0x0
[x]     badvaddr        :        0x0
[x]     cause   :        0x0
[x]     pc      :        0x47bcb8
[x]     cp0_config3     :        0x0
[x]     cp0_userlocal   :        0x0
[x]

[x]     PC = 0x47bcb8
[x]      (/mnt/c/Users/user/Documents/qiling_crash_case/examples/hello_mipsel_upx+0x47bcb8)
[=]     Start      End        Perm    Label          Image
[=]     00400000 - 0047c000   rwx     [syscall_mmap]   /mnt/c/Users/user/Documents/qiling_crash_case/examples/hello_mipsel_upx
[=]     0048c000 - 00491000   rwx     [syscall_mmap]   /mnt/c/Users/user/Documents/qiling_crash_case/examples/hello_mipsel_upx
[=]     00491000 - 00492000   rw-     /mnt/c/Users/user/Documents/qiling_crash_case/examples/hello_mipsel_upx   /mnt/c/Users/user/Documents/qiling_crash_case/examples/hello_mipsel_upx
[=]     7ff0d000 - 7ff3d000   rwx     [stack]
[x]     ['0x8', '0x0', '0x20', '0x3', '0x0', '0x0', '0x0', '0x0']
[=]

[=]     0x0047bcb8 {[syscall_mmap]       + 0x07bcb8}   08 00 20 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 jr $t9
> nop
> nop
> nop
> nop
> nop
> nop
> nop
> nop
> nop
> nop
> nop
> nop
> nop
> nop
> nop
Traceback (most recent call last):
  File "upxunpack.py", line 111, in <module>
    main()
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "upxunpack.py", line 108, in main
    ql.run()
  File "/home/user/.local/lib/python3.6/site-packages/qiling/core.py", line 755, in run
    self.os.run()
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/linux/linux.py", line 136, in run
    self.ql.emu_start(self.ql.loader.elf_entry, self.exit_point, self.ql.timeout, self.ql.count)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/core.py", line 899, in emu_start
    raise self._internal_exception
  File "/home/user/.local/lib/python3.6/site-packages/qiling/utils.py", line 158, in wrapper
    return func(*args, **kw)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/core_hooks.py", line 65, in _hook_intr_cb
    ret = h.call(ql, intno)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/core_hooks_types.py", line 23, in call
    return self.callback(ql, *args)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/linux/linux.py", line 88, in hook_syscall
    return self.load_syscall()
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/posix.py", line 298, in load_syscall
    raise e
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/posix.py", line 282, in load_syscall
    ret = syscall_hook(self.ql, *arg_values)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/posix/syscall/mman.py", line 40, in ql_syscall_munmap
    ql.mem.unmap(munmap_addr, munmap_len)
  File "/home/user/.local/lib/python3.6/site-packages/qiling/os/memory.py", line 335, in unmap
    self.ql.uc.mem_unmap(addr, size)
  File "/home/user/.local/lib/python3.6/site-packages/unicorn/unicorn.py", line 461, in mem_unmap
    raise UcError(status)
unicorn.unicorn.UcError: No memory available or memory not present (UC_ERR_NOMEM)
```

So this patch will solve both problems - by checking munmap target mem existence and handling address overlapping.

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
