### PR TITLE
Adjust mmap syscall to handle subsequent calls to the same region

### DIFF
--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -106,6 +106,9 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
     mmap_base = addr
     need_mmap = True
     eff_mmap_size = ((mlen + 0x1000 - 1) // 0x1000) * 0x1000
+    # align eff_mmap_size to page boundary
+    aligned_address = (addr >> 12) << 12
+    eff_mmap_size -= mmap_base - aligned_address
 
     # initial ql.loader.mmap_address
     if addr != 0 and ql.mem.is_mapped(addr, mlen):
@@ -115,7 +118,7 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
                 ql.mem.protect(addr, mlen, prot)
             except Exception as e:
                 ql.log.debug(e)
-                raise QlMemoryMappedError("Error: change protection at: 0x%x - 0x%x" % (addr, addr + eff_mmap_size - 1))
+                raise QlMemoryMappedError("Error: change protection at: 0x%x - 0x%x" % (addr, addr + mlen - 1))
             need_mmap = False
 
     # initialized mapping

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -97,7 +97,7 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
             pgoffset = pgoffset * 4096
     elif (ql.archtype== QL_ARCH.ARM) and (ql.ostype== QL_OS.QNX):
         MAP_ANONYMOUS=0x00080000
-        mmap_id = ql.unpack32s(ql.pack32s(fd))
+        fd = ql.unpack32s(ql.pack32s(fd))
     else:
         fd = ql.unpack32s(ql.pack32(fd))
         if ver == 2:

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -112,7 +112,7 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
         if (flags & MAP_FIXED) > 0:
             ql.log.debug("%s - MAP_FIXED, mapping not needed" % api_name)
             try:
-                ql.mem.protect(addr, eff_mmap_size, prot)
+                ql.mem.protect(addr, mlen, prot)
             except Exception as e:
                 ql.log.debug(e)
                 raise QlMemoryMappedError("Error: change protection at: 0x%x - 0x%x" % (addr, addr + eff_mmap_size - 1))

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -131,13 +131,13 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
         except Exception as e:
             raise QlMemoryMappedError("Error: mapping needed but failed")
 
-    ql.log.debug("%s - addr range  0x%x - 0x%x: " % (api_name, mmap_base, mmap_base + eff_mmap_size - 1))
+        # FIXME: MIPS32 Big Endian
+        try:
+            ql.mem.write(mmap_base, b'\x00' * eff_mmap_size)
+        except Exception as e:
+            raise QlMemoryMappedError("Error: trying to zero memory")
 
-    # FIXME: MIPS32 Big Endian
-    try:
-        ql.mem.write(mmap_base, b'\x00' * eff_mmap_size)
-    except Exception as e:
-        raise QlMemoryMappedError("Error: trying to zero memory")
+    ql.log.debug("%s - addr range  0x%x - 0x%x: " % (api_name, mmap_base, mmap_base + eff_mmap_size - 1))
 
     if ((flags & MAP_ANONYMOUS) == 0) and 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
         ql.os.fd[fd].lseek(pgoffset)

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -115,7 +115,7 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
                 ql.mem.protect(addr, mlen, prot)
             except Exception as e:
                 ql.log.debug(e)
-                raise QlMemoryMappedError("Error: change protection at: 0x%x - 0x%x" % (addr, addr + mlen - 1))
+                raise QlMemoryMappedError("Error: change protection at: 0x%x - 0x%x" % (addr, addr + eff_mmap_size - 1))
             need_mmap = False
 
     # initialized mapping
@@ -148,7 +148,7 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
         ql.log.debug("mem write : " + hex(len(data)))
         ql.log.debug("mem mmap  : " + mem_info)
         ql.mem.add_mapinfo(mmap_base,
-                           mmap_base + (eff_mmap_size if need_mmap else mlen),
+                           mmap_base + eff_mmap_size,
                            mem_p=UC_PROT_ALL,
                            mem_info=("[%s] " % api_name) + mem_info)
         try:

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -115,7 +115,7 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
                 ql.mem.protect(addr, mlen, prot)
             except Exception as e:
                 ql.log.debug(e)
-                raise QlMemoryMappedError("Error: change protection at: 0x%x - 0x%x" % (addr, addr + eff_mmap_size - 1))
+                raise QlMemoryMappedError("Error: change protection at: 0x%x - 0x%x" % (addr, addr + mlen - 1))
             need_mmap = False
 
     # initialized mapping
@@ -148,7 +148,7 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
         ql.log.debug("mem write : " + hex(len(data)))
         ql.log.debug("mem mmap  : " + mem_info)
         ql.mem.add_mapinfo(mmap_base,
-                           mmap_base + eff_mmap_size,
+                           mmap_base + (eff_mmap_size if need_mmap else mlen),
                            mem_p=UC_PROT_ALL,
                            mem_info=("[%s] " % api_name) + mem_info)
         try:

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -131,13 +131,13 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
         except Exception as e:
             raise QlMemoryMappedError("Error: mapping needed but failed")
 
-        # FIXME: MIPS32 Big Endian
-        try:
-            ql.mem.write(mmap_base, b'\x00' * eff_mmap_size)
-        except Exception as e:
-            raise QlMemoryMappedError("Error: trying to zero memory")
-
     ql.log.debug("%s - addr range  0x%x - 0x%x: " % (api_name, mmap_base, mmap_base + eff_mmap_size - 1))
+
+    # FIXME: MIPS32 Big Endian
+    try:
+        ql.mem.write(mmap_base, b'\x00' * eff_mmap_size)
+    except Exception as e:
+        raise QlMemoryMappedError("Error: trying to zero memory")
 
     if ((flags & MAP_ANONYMOUS) == 0) and 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
         ql.os.fd[fd].lseek(pgoffset)


### PR DESCRIPTION
The loading of shared libraries in QNX performs multiple mmap calls on the same memory region. The first mmap call has the form
mmap(addr = 0, len = sizeof library, prot = PROT_NONE, flags = MAP_PRIVATE | MAP_LAZY | MAP_ANONYMOUS)
then for the different ELF sections of the library mmap calls are performed to parts of the memory region returned from this first mmap call. The current implementation of mmap has serveral problems:

* calls to mapped regions use the aligned effective size to call mem.protect(), but the mem.protect() function also performs page alignment and this double alignment of the size can result in sizes larger than the memory page
* every call to mmap causes a zero-initialization which (in combination with page alignment) can cause access to unmapped memory
* usage of the effective size for add_mapinfo() can also exceede the page size and results in the failure of subsequent mmap calls

The changes in this pull request result in a functioning mmap under QNX for my application, but this mixing of memory page alignment in the mmap implemenation seems a bit fragile. I guess this could be improved in the future.

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
