### PR TITLE
Flexible Linux set_api hooks

### DIFF
--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -22,7 +22,7 @@ class QlOs:
     def __init__(self, ql: Qiling, resolvers: Mapping[Any, Resolver] = {}):
         self.ql = ql
         self.utils = QlOsUtils(ql)
-        self.fcall: Optional[QlFunctionCall] = None
+        self.fcall: QlFunctionCall
         self.fs_mapper = QlFsMapper(ql)
         self.child_processes = False
         self.thread_management = None


### PR DESCRIPTION
Linux `set_api` hooks will work only if set up before `ql.run()`, which means all hooks should be set up ahead of time.
This little modification gives more flexibility by allowing `set_api` hooks to be added as necessary during emulation time.

For example: hooking an API only after entering a specific function, when the hook becomes relevant [and not before, potentially trapping irrelevant calls to the same API]

That code change also fixes a bug where the `intercept` value was passed as the hook `user_data`.