### PR TITLE
Flexible Linux set_api hooks

### DIFF
--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -22,7 +22,7 @@ class QlOs:
     def __init__(self, ql: Qiling, resolvers: Mapping[Any, Resolver] = {}):
         self.ql = ql
         self.utils = QlOsUtils(ql)
-        self.fcall: Optional[QlFunctionCall] = None
+        self.fcall: QlFunctionCall
         self.fs_mapper = QlFsMapper(ql)
         self.child_processes = False
         self.thread_management = None

--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -210,19 +210,25 @@ mac_open_flags = {
 
 
 linux_open_flags = {
-    'O_RDONLY'   : 0x0,
-    'O_WRONLY'   : 0x1,
-    'O_RDWR'     : 0x2,
-    'O_CREAT'    : 0x40,
-    'O_EXCL'     : 0x80,
-    'O_NOCTTY'   : 0x100,
-    'O_TRUNC'    : 0x200,
-    'O_APPEND'   : 0x400,
-    'O_NONBLOCK' : 0x800,
-    'O_ASYNC'    : 0x2000,
-    'O_DIRECTORY': 0x10000,
-    'O_NOFOLLOW' : 0x20000,
-    'O_SYNC'     : 0x101000,
+    'O_RDONLY'    : 0o000000000,
+    'O_WRONLY'    : 0o000000001,
+    'O_RDWR'      : 0o000000002,
+    'O_CREAT'     : 0o000000100,
+    'O_EXCL'      : 0o000000200,
+    'O_NOCTTY'    : 0o000000400,
+    'O_TRUNC'     : 0o000001000,
+    'O_APPEND'    : 0o000002000,
+    'O_NONBLOCK'  : 0o000004000,
+    'O_DSYNC'     : 0o000010000,
+    'FASYNC'      : 0o000020000,
+    'O_DIRECT'    : 0o000040000,
+    'O_LARGEFILE' : 0o000100000,
+    'O_DIRECTORY' : 0o000200000,
+    'O_NOFOLLOW'  : 0o000400000,
+    'O_NOATIME'   : 0o001000000,
+    'O_CLOEXEC'   : 0o002000000,
+    'O_SYNC'      : 0o004000000 | 0o000010000, # O_DSYNC
+    'O_PATH'      : 0o010000000
 }
 
 

--- a/qiling/os/posix/syscall/fcntl.py
+++ b/qiling/os/posix/syscall/fcntl.py
@@ -3,7 +3,7 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-
+from qiling import Qiling
 from qiling.const import *
 from qiling.os.linux.thread import *
 from qiling.os.posix.filestruct import *
@@ -12,21 +12,15 @@ from qiling.os.posix.const import *
 from qiling.os.posix.const_mapping import *
 from qiling.exception import *
 
-
-def ql_syscall_open(ql, filename, flags, mode, *args, **kw):
-    path = ql.mem.string(filename)
+def ql_syscall_open(ql: Qiling, filename, flags, mode, *args, **kw):
+    path = ql.os.utils.read_cstring(filename)
     real_path = ql.os.path.transform_to_real_path(path)
     relative_path = ql.os.path.transform_to_relative_path(path)
 
-    flags = flags & 0xffffffff
-    mode = mode & 0xffffffff
+    flags &= 0xffffffff
+    mode &= 0xffffffff
 
-    for i in range(NR_OPEN):
-        if ql.os.fd[i] == 0:
-            idx = i
-            break
-    else:
-        idx = -1
+    idx = next((i for i in range(NR_OPEN) if ql.os.fd[i] == 0), -1)
 
     if idx == -1:
         regreturn = -EMFILE
@@ -49,22 +43,17 @@ def ql_syscall_open(ql, filename, flags, mode, *args, **kw):
         ql.log.debug("File Not Found %s" % real_path)
     return regreturn
 
-def ql_syscall_creat(ql, filename, mode, *args, **kw):
+def ql_syscall_creat(ql: Qiling, filename, mode, *args, **kw):
     flags = linux_open_flags["O_WRONLY"] | linux_open_flags["O_CREAT"] | linux_open_flags["O_TRUNC"]
 
-    path = ql.mem.string(filename)
+    path = ql.os.utils.read_cstring(filename)
     real_path = ql.os.path.transform_to_real_path(path)
     relative_path = ql.os.path.transform_to_relative_path(path)
 
-    flags = flags & 0xffffffff
-    mode = mode & 0xffffffff
+    flags &= 0xffffffff
+    mode &= 0xffffffff
 
-    for i in range(NR_OPEN):
-        if ql.os.fd[i] == 0:
-            idx = i
-            break
-    else:
-        idx = -1
+    idx = next((i for i in range(NR_OPEN) if ql.os.fd[i] == 0), -1)
 
     if idx == -1:
         regreturn = -ENOMEM 
@@ -79,7 +68,7 @@ def ql_syscall_creat(ql, filename, mode, *args, **kw):
         except QlSyscallError as e:
             regreturn = -e.errno
 
-    ql.log.debug("open(%s, %s, 0o%o) = %d" % (relative_path, open_flags_mapping(flags, ql.archtype), mode, regreturn))
+    ql.log.debug("creat(%s, %s, 0o%o) = %d" % (relative_path, open_flags_mapping(flags, ql.archtype), mode, regreturn))
 
     if regreturn >= 0 and regreturn != 2:
         ql.log.debug("File Found: %s" % real_path)
@@ -87,22 +76,15 @@ def ql_syscall_creat(ql, filename, mode, *args, **kw):
         ql.log.debug("File Not Found %s" % real_path)
     return regreturn
 
-def ql_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, *args, **kw):
-    openat_fd = ql.unpacks(ql.pack(openat_fd))
-    openat_path = ql.mem.string(openat_path)
+def ql_syscall_openat(ql: Qiling, fd, path, flags, mode, *args, **kw):
+    path = ql.os.utils.read_cstring(path)
+    # real_path = ql.os.path.transform_to_real_path(path)
+    # relative_path = ql.os.path.transform_to_relative_path(path)
 
-    real_path = ql.os.path.transform_to_real_path(openat_path)
-    relative_path = ql.os.path.transform_to_relative_path(openat_path)
+    flags &= 0xffffffff
+    mode &= 0xffffffff
 
-    openat_flags = openat_flags & 0xffffffff
-    openat_mode = openat_mode & 0xffffffff
-
-    for i in range(NR_OPEN):
-        if ql.os.fd[i] == 0:
-            idx = i
-            break
-    else:
-        idx = -1
+    idx = next((i for i in range(NR_OPEN) if ql.os.fd[i] == 0), -1)
 
     if idx == -1:
         regreturn = -EMFILE
@@ -111,26 +93,23 @@ def ql_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, *ar
             if ql.archtype== QL_ARCH.ARM:
                 mode = 0
 
-            openat_flags = ql_open_flag_mapping(ql, openat_flags)
+            flags = ql_open_flag_mapping(ql, flags)
             try:
-                dir_fd = ql.os.fd[openat_fd].fileno()
+                dir_fd = ql.os.fd[fd].fileno()
             except:
                 dir_fd = None
 
-            ql.os.fd[idx] = ql.os.fs_mapper.open_ql_file(openat_path, openat_flags, openat_mode, dir_fd)
+            ql.os.fd[idx] = ql.os.fs_mapper.open_ql_file(path, flags, mode, dir_fd)
             regreturn = idx
         except QlSyscallError as e:
             regreturn = -e.errno
 
-    ql.log.debug(
-        "openat(fd = %d, path = %s, flags = %s, mode = 0o%o) = %d" % 
-        (openat_fd, openat_path, open_flags_mapping(openat_flags, ql.archtype), openat_mode, regreturn)
-    )
-    
+    ql.log.debug(f'openat(fd = {fd:d}, path = {path}, flags = {open_flags_mapping(flags, ql.archtype)}, mode = {mode:#o}) = {regreturn:d}')
+
     return regreturn
 
 
-def ql_syscall_fcntl(ql, fcntl_fd, fcntl_cmd, fcntl_arg, *args, **kw):
+def ql_syscall_fcntl(ql: Qiling, fcntl_fd, fcntl_cmd, fcntl_arg, *args, **kw):
     if not (0 <= fcntl_fd < NR_OPEN) or \
             ql.os.fd[fcntl_fd] == 0:
         return -EBADF
@@ -170,7 +149,7 @@ def ql_syscall_fcntl(ql, fcntl_fd, fcntl_cmd, fcntl_arg, *args, **kw):
     return regreturn
 
 
-def ql_syscall_fcntl64(ql, fcntl_fd, fcntl_cmd, fcntl_arg, *args, **kw):
+def ql_syscall_fcntl64(ql: Qiling, fcntl_fd, fcntl_cmd, fcntl_arg, *args, **kw):
 
     # https://linux.die.net/man/2/fcntl64
     if fcntl_cmd == F_DUPFD:
@@ -208,15 +187,15 @@ def ql_syscall_flock(ql, flock_fd, flock_operation, *args, **kw):
     return regreturn
 
 
-def ql_syscall_rename(ql, oldname_buf, newname_buf, *args, **kw):
+def ql_syscall_rename(ql: Qiling, oldname_buf, newname_buf, *args, **kw):
     """
     rename(const char *oldpath, const char *newpath)
     description: change the name or location of a file
     ret value: On success, zero is returned. On error, -1 is returned
     """
     regreturn = 0  # default value is success
-    oldpath = ql.mem.string(oldname_buf)
-    newpath = ql.mem.string(newname_buf)
+    oldpath = ql.os.utils.read_cstring(oldname_buf)
+    newpath = ql.os.utils.read_cstring(newname_buf)
 
     ql.log.debug(f"rename() path: {oldpath} -> {newpath}")
 

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -190,7 +190,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, *args):
             target = False
-            pathname = ql.mem.string(openat_path)
+            pathname = ql.os.utils.read_cstring(openat_path)
 
             if pathname == "test_syscall_open.txt":
                 print("test => openat(%d, %s, 0x%x, 0%o)" % (openat_fd, pathname, openat_flags, openat_mode))
@@ -208,7 +208,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_unlink(ql, unlink_pathname, *args):
             target = False
-            pathname = ql.mem.string(unlink_pathname)
+            pathname = ql.os.utils.read_cstring(unlink_pathname)
 
             if pathname == "test_syscall_unlink.txt":
                 print("test => unlink(%s)" % (pathname))
@@ -224,7 +224,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_truncate(ql, trunc_pathname, trunc_length, *args):
             target = False
-            pathname = ql.mem.string(trunc_pathname)
+            pathname = ql.os.utils.read_cstring(trunc_pathname)
 
             if pathname == "test_syscall_truncate.txt":
                 print("test => truncate(%s, 0x%x)" % (pathname, trunc_length))
@@ -331,7 +331,7 @@ class ELFTest(unittest.TestCase):
 
         # def test_syscall_open(ql, open_pathname, open_flags, open_mode, *args):
             # target = False
-            # pathname = ql.mem.string(open_pathname)
+            # pathname = ql.os.utils.read_cstring(open_pathname)
 
             # if pathname == "test_syscall_open.txt":
                 # print("test => open(%s, 0x%x, 0%o)" % (pathname, open_flags, open_mode))
@@ -346,7 +346,7 @@ class ELFTest(unittest.TestCase):
 
         # def test_syscall_unlink(ql, unlink_pathname, *args):
             # target = False
-            # pathname = ql.mem.string(unlink_pathname)
+            # pathname = ql.os.utils.read_cstring(unlink_pathname)
 
             # if pathname == "test_syscall_unlink.txt":
                 # print("test => unlink(%s)" % (pathname))
@@ -360,7 +360,7 @@ class ELFTest(unittest.TestCase):
 
         # def test_syscall_truncate(ql, trunc_pathname, trunc_length, *args):
             # target = False
-            # pathname = ql.mem.string(trunc_pathname)
+            # pathname = ql.os.utils.read_cstring(trunc_pathname)
 
             # if pathname == "test_syscall_truncate.txt":
                 # print("test => truncate(%s, 0x%x)" % (pathname, trunc_length))
@@ -493,7 +493,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_openat(ql, openat_fd, openat_path, openat_flags, openat_mode, *args):
             target = False
-            pathname = ql.mem.string(openat_path)
+            pathname = ql.os.utils.read_cstring(openat_path)
 
             if pathname == "test_syscall_open.txt":
                 print("test => openat(%d, %s, 0x%x, 0%o)" % (openat_fd, pathname, openat_flags, openat_mode))
@@ -512,7 +512,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_unlink(ql, unlink_pathname, *args):
             target = False
-            pathname = ql.mem.string(unlink_pathname)
+            pathname = ql.os.utils.read_cstring(unlink_pathname)
 
             if pathname == "test_syscall_unlink.txt":
                 print("test => unlink(%s)" % (pathname))
@@ -529,7 +529,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_truncate(ql, trunc_pathname, trunc_length, *args):
             target = False
-            pathname = ql.mem.string(trunc_pathname)
+            pathname = ql.os.utils.read_cstring(trunc_pathname)
 
             if pathname == "test_syscall_truncate.txt":
                 print("test => truncate(%s, 0x%x)" % (pathname, trunc_length))
@@ -639,7 +639,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_open(ql, open_pathname, open_flags, open_mode, *args):
             target = False
-            pathname = ql.mem.string(open_pathname)
+            pathname = ql.os.utils.read_cstring(open_pathname)
 
             if pathname == "test_syscall_open.txt":
                 print("test => open(%s, 0x%x, 0%o)" % (pathname, open_flags, open_mode))
@@ -657,7 +657,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_unlink(ql, unlink_pathname, *args):
             target = False
-            pathname = ql.mem.string(unlink_pathname)
+            pathname = ql.os.utils.read_cstring(unlink_pathname)
 
             if pathname == "test_syscall_unlink.txt":
                 print("test => unlink(%s)" % (pathname))
@@ -673,7 +673,7 @@ class ELFTest(unittest.TestCase):
 
         def test_syscall_truncate(ql, trunc_pathname, trunc_length, *args):
             target = False
-            pathname = ql.mem.string(trunc_pathname)
+            pathname = ql.os.utils.read_cstring(trunc_pathname)
 
             if pathname == "test_syscall_truncate.txt":
                 print("test => truncate(%s, 0x%x)" % (pathname, trunc_length))


### PR DESCRIPTION
[Replaces #870, as branch had to be rebased]

Linux `set_api` hooks will work only if set up before `ql.run()`, which means all hooks should be set up ahead of time.
This little modification gives more flexibility by allowing `set_api` hooks to be added as necessary during emulation time.

For example: hooking an API only after entering a specific function, when the hook becomes relevant [and not before, potentially trapping irrelevant calls to the same API]

That code change also fixes a bug where the `intercept` value was passed as the hook `user_data`.