### PR TITLE
Fix restore causing unicorn cpu exception

### DIFF
--- a/qiling/core.py
+++ b/qiling/core.py
@@ -804,14 +804,14 @@ class Qiling(QlCoreHooks, QlCoreStructs):
             with open(snapshot, "rb") as load_state:
                 saved_states = pickle.load(load_state)
 
+        if "mem" in saved_states:
+            self.mem.restore(saved_states["mem"])
+
         if "cpu_context" in saved_states:
             self.arch.context_restore(saved_states["cpu_context"])
 
         if "reg" in saved_states:
             self.reg.restore(saved_states["reg"])
-
-        if "mem" in saved_states:
-            self.mem.restore(saved_states["mem"])
 
         if "fd" in saved_states:
             self.os.fd.restore(saved_states["fd"])


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

When restoring a snapshot created with reg=True a unicorn cpu exception can
be thrown when restoring the GS register. It looks like for at least 32bit
mode on X86 processors unicorn will validate memory structures pointed to by
loaded GS reg. If the memory is not loaded the validation will surely fail,
and thus the exception. The fix is then to load the memory maps first,
before loading the registers. Note, this validation does not happen when
restoring via cpu_context.

Included is a test case which will have errors if this fix is not applied.

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [x] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review, if needed
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
