### PR TITLE
Implement standard streams as QlOs properties instead of Qiling's

### DIFF
--- a/examples/crackme_x86_linux.py
+++ b/examples/crackme_x86_linux.py
@@ -74,7 +74,7 @@ class Solver:
         hobj = self.ql.hook_code(__count_instructions)
 
         # feed stdin with input
-        self.ql.stdin.write(input + b'\n')
+        self.ql.os.stdin.write(input + b'\n')
 
         # resume emulation till function returns
         self.ql.run(begin=self.replay_starts, end=self.replay_ends)

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -5,7 +5,7 @@
 
 from configparser import ConfigParser
 import ntpath, os, pickle, platform
-import io
+
 # See https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 from typing import Dict, List, Union
 from typing import TYPE_CHECKING
@@ -493,48 +493,6 @@ class Qiling(QlCoreHooks, QlCoreStructs):
             Type: Exception
         """
         return self._internal_exception
-
-    @property
-    def stdin(self) -> io.IOBase:
-        """ Stdin of the program. Can be any object which implements (even part of) io.IOBase.
-
-            Type: io.Base
-            Example: - ql = Qiling(stdin=sys.stdin)
-                     - ql.stdin = sys.stdin
-        """
-        return self._stdin
-
-    @stdin.setter
-    def stdin(self, s):
-        self._stdin = s
-
-    @property
-    def stdout(self) -> io.IOBase:
-        """ Stdout of the program. Can be any object which implements (even part of) io.IOBase.
-
-            Type: io.Base
-            Example: - ql = Qiling(stdout=sys.stdout)
-                     - ql.stdout = sys.stdout
-        """
-        return self._stdout
-
-    @stdout.setter
-    def stdout(self, s):
-        self._stdout = s
-
-    @property
-    def stderr(self) -> io.IOBase:
-        """ Stdout of the program. Can be any object which implements (even part of) io.IOBase.
-
-            Type: io.Base
-            Example: - ql = Qiling(stderr=sys.stderr)
-                     - ql.stderr = sys.stderr
-        """
-        return self._stderr
-
-    @stderr.setter
-    def stderr(self, s):
-        self._stderr = s
 
     @property
     def libcache(self) -> bool:

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -48,9 +48,9 @@ class Qiling(QlCoreHooks, QlCoreStructs):
             filter = None,
             stop_on_stackpointer = False,
             stop_on_exit_trap = False,
-            stdin=0,
-            stdout=0,
-            stderr=0,
+            stdin=None,
+            stdout=None,
+            stderr=None,
     ):
         """ Create a Qiling instance.
 
@@ -89,9 +89,6 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         ##################################
         # Definition after ql=Qiling()   #
         ##################################
-        self._stdin = stdin
-        self._stdout = stdout
-        self._stderr = stderr
         self._verbose = verbose
         self._libcache = libcache
         self._patch_bin = []
@@ -229,7 +226,16 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         if (self.archtype not in QL_ARCH_NONEOS):
             if (self.archtype not in QL_ARCH_HARDWARE):
                 self._os = os_setup(self.archtype, self.ostype, self)
-        
+
+                if stdin is not None:
+                    self._os.stdin = stdin
+
+                if stdout is not None:
+                    self._os.stdout = stdout
+
+                if stderr is not None:
+                    self._os.stderr = stderr
+
         # Run the loader
         self.loader.run()
 

--- a/qiling/os/filestruct.py
+++ b/qiling/os/filestruct.py
@@ -4,6 +4,7 @@
 #
 
 import os
+from typing import AnyStr
 
 from qiling.exception import *
 from qiling.os.posix.stat import *
@@ -12,10 +13,9 @@ try:
     import fcntl
 except ImportError:
     pass
-import socket
 
 class ql_file:
-    def __init__(self, path, fd):
+    def __init__(self, path: AnyStr, fd: int):
         self.__path = path
         self.__fd = fd
         # information for syscall mmap
@@ -24,70 +24,70 @@ class ql_file:
         self._close_on_exec = 0
 
     @classmethod
-    def open(self, open_path, open_flags, open_mode, dir_fd=None):
+    def open(cls, open_path: AnyStr, open_flags: int, open_mode: int, dir_fd: int = None):
         open_mode &= 0x7fffffff
 
         try:
             fd = os.open(open_path, open_flags, open_mode, dir_fd=dir_fd)
         except OSError as e:
             raise QlSyscallError(e.errno, e.args[1] + ' : ' + e.filename)
-        return self(open_path, fd)
 
-    def read(self, read_len):
+        return cls(open_path, fd)
+
+    def read(self, read_len: int) -> bytes:
         return os.read(self.__fd, read_len)
-    
-    def write(self, write_buf):
+
+    def write(self, write_buf: bytes) -> int:
         return os.write(self.__fd, write_buf)
-    
-    def fileno(self):
+
+    def fileno(self) -> int:
         return self.__fd
-    
-    def lseek(self, lseek_offset, lseek_origin = os.SEEK_SET):
+
+    def lseek(self, lseek_offset: int, lseek_origin: int = os.SEEK_SET) -> int:
         return os.lseek(self.__fd, lseek_offset, lseek_origin)
-    
-    def close(self):
-        return os.close(self.__fd)
-    
+
+    def close(self) -> None:
+        os.close(self.__fd)
+
     def fstat(self):
         return Fstat(self.__fd)
 
-    def fcntl(self, fcntl_cmd, fcntl_arg):
+    def fcntl(self, fcntl_cmd: int, fcntl_arg):
         try:
             return fcntl.fcntl(self.__fd, fcntl_cmd, fcntl_arg)
         except Exception:
             pass
-    
+
     def ioctl(self, ioctl_cmd, ioctl_arg):
         try:
             return fcntl.ioctl(self.__fd, ioctl_cmd, ioctl_arg)
         except Exception:
             pass
 
-    def tell(self):
+    def tell(self) -> int:
         return self.lseek(0, os.SEEK_CUR)
-    
+
     def dup(self):
         new_fd = os.dup(self.__fd)
-        new_ql_file = ql_file(self.__path, new_fd)
-        return new_ql_file
-    
-    def readline(self, end = b'\n'):
-        ret = b''
-        while True:
-            c = self.read(1)
-            ret += c
-            if c == end:
-                break
-        return ret
-    
+
+        return ql_file(self.__path, new_fd)
+
+    def readline(self, end: bytes = b'\n') -> bytes:
+        ret = bytearray()
+
+        while not ret.endswith(end):
+            ret.extend(self.read(1))
+
+        return bytes(ret)
+
     @property
     def name(self):
         return self.__path
 
     @property
-    def close_on_exec(self):
+    def close_on_exec(self) -> int:
         return self._close_on_exec
 
     @close_on_exec.setter
-    def close_on_exec(self, value: int):
+    def close_on_exec(self, value: int) -> None:
         self._close_on_exec = value

--- a/qiling/os/windows/windows.py
+++ b/qiling/os/windows/windows.py
@@ -172,15 +172,6 @@ class QlOsWindows(QlOs):
         if  self.ql.entry_point is not None:
             self.ql.loader.entry_point = self.ql.entry_point
 
-        if self.ql.stdin != 0:
-            self.stdin = self.ql.stdin
-
-        if self.ql.stdout != 0:
-            self.stdout = self.ql.stdout
-
-        if self.ql.stderr != 0:
-            self.stderr = self.ql.stderr
-
         try:
             if self.ql.code:
                 self.ql.emu_start(self.ql.loader.entry_point, (self.ql.loader.entry_point + len(self.ql.code)), self.ql.timeout, self.ql.count)

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -467,7 +467,7 @@ def ql_syscall_mapping_function(ostype):
     return ql_get_module_function(f"qiling.os.{ostype_str.lower()}.map_syscall", "map_syscall")
 
 
-def os_setup(archtype, ostype, ql):
+def os_setup(archtype: QL_ARCH, ostype: QL_OS, ql):
     if not ql_is_valid_ostype(ostype):
         raise QlErrorOsType("Invalid OSType")
 

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -389,8 +389,10 @@ class PETest(unittest.TestCase):
             ql.patch(0x004010CD, b'\x90\x90')
             ql.patch(0x0040110B, b'\x90\x90')
             ql.patch(0x00401112, b'\x90\x90')
-            ql.stdin = StringBuffer()
-            ql.stdin.write(b"Ea5yR3versing\n")
+
+            ql.os.stdin = StringBuffer()
+            ql.os.stdin.write(b"Ea5yR3versing\n")
+
             ql.hook_address(force_call_dialog_func, 0x00401016)
             ql.run()
             del ql
@@ -402,13 +404,13 @@ class PETest(unittest.TestCase):
         ql = Qiling(
         ["../examples/rootfs/x86_windows/bin/cmdln32.exe", 'arg1', 'arg2 with spaces'],
         "../examples/rootfs/x86_windows")
-        ql.stdout = TestOut()
+        ql.os.stdout = TestOut()
         ql.run()
         expected_string = b'<C:\\Users\\Qiling\\Desktop\\cmdln32.exe arg1 "arg2 with spaces">\n'
         expected_keys = [b'_acmdln', b'_wcmdln', b'__p__acmdln', b'__p__wcmdln', b'GetCommandLineA', b'GetCommandLineW']
         for key in expected_keys:
-            self.assertTrue(key in ql.stdout.output)
-            self.assertEqual(expected_string, ql.stdout.output[key])
+            self.assertTrue(key in ql.os.stdout.output)
+            self.assertEqual(expected_string, ql.os.stdout.output[key])
         del ql
 
 
@@ -416,13 +418,13 @@ class PETest(unittest.TestCase):
         ql = Qiling(
         ["../examples/rootfs/x8664_windows/bin/cmdln64.exe", 'arg1', 'arg2 with spaces'],
         "../examples/rootfs/x8664_windows")
-        ql.stdout = TestOut()
+        ql.os.stdout = TestOut()
         ql.run()
         expected_string = b'<C:\\Users\\Qiling\\Desktop\\cmdln64.exe arg1 "arg2 with spaces">\n'
         expected_keys = [b'_acmdln', b'_wcmdln', b'GetCommandLineA', b'GetCommandLineW']
         for key in expected_keys:
-            self.assertTrue(key in ql.stdout.output)
-            self.assertEqual(expected_string, ql.stdout.output[key])
+            self.assertTrue(key in ql.os.stdout.output)
+            self.assertEqual(expected_string, ql.os.stdout.output[key])
         del ql
 
     class RefreshCache(QlPeCache):

--- a/tests/test_windows_stdio.py
+++ b/tests/test_windows_stdio.py
@@ -37,13 +37,13 @@ def instruction_count(ql, address, size, user_data):
 
 def get_count(flag):
     ql = Qiling(["../examples/rootfs/x86_windows/bin/crackme.exe"], "../examples/rootfs/x86_windows", verbose=QL_VERBOSE.OFF, libcache = True)
-    ql.stdin = StringBuffer()
-    ql.stdout = StringBuffer()
-    ql.stdin.write(bytes("".join(flag) + "\n", 'utf-8'))
+    ql.os.stdin = StringBuffer()
+    ql.os.stdout = StringBuffer()
+    ql.os.stdin.write(bytes("".join(flag) + "\n", 'utf-8'))
     count = [0]
     ql.hook_code(instruction_count, count)
     ql.run()
-    print(ql.stdout.read_all().decode('utf-8'), end='')
+    print(ql.os.stdout.read_all().decode('utf-8'), end='')
     print(" ============ count: %d ============ " % count[0])
     return count[0]
 


### PR DESCRIPTION
This PR addresses issue #877 .

Changelog:
- Made standard streams (i.e. `stdin`, `stdout` and `stderr`) `QlOs` properties instead of `Qiling`'s.
   Now they may be accessed by:
  - `ql.os.stdin`
  - `ql.os.stdout`
  - `ql.os.stderr`
  That should improve readability by offloading properties from the core to where they intuitively belong.
  Additionally, that would enable users to switch standard streams at any point during emulation instead of up until calling `ql.run`.
- Typing annotations FTW