### PR TITLE
Mock pipes extention

### DIFF
--- a/examples/crackme_x86_windows_auto.py
+++ b/examples/crackme_x86_windows_auto.py
@@ -7,28 +7,7 @@ import sys
 sys.path.append("..")
 
 from qiling import Qiling
-
-class StringBuffer:
-    def __init__(self):
-        self.buffer = b''
-
-    def read(self, n):
-        ret = self.buffer[:n]
-        self.buffer = self.buffer[n:]
-        return ret
-
-    def readline(self, end=b'\n'):
-        ret = b''
-        while True:
-            c = self.read(1)
-            ret += c
-            if c == end:
-                break
-        return ret
-
-    def write(self, string):
-        self.buffer += string
-        return len(string)
+from qiling.extensions import pipe
 
 def force_call_dialog_func(ql: Qiling):
     # get DialogFunc address
@@ -43,10 +22,9 @@ def force_call_dialog_func(ql: Qiling):
     ql.reg.eip = lpDialogFunc
 
 def our_sandbox(path, rootfs):
-    stdin = StringBuffer()
-    ql = Qiling(path, rootfs, stdin=stdin)
+    ql = Qiling(path, rootfs, stdin=pipe.SimpleInStream(sys.stdin.fileno()))
 
-    stdin.write(b"Ea5yR3versing\n")
+    ql.os.stdin.write(b"Ea5yR3versing\n")
     ql.hook_address(force_call_dialog_func, 0x00401016)
     ql.run()
 

--- a/qiling/extensions/pipe.py
+++ b/qiling/extensions/pipe.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# Cross Platform and Multi Architecture Advanced Binary Emulation Framework
+#
+
+from typing import TextIO
+
+from qiling.os.posix import stat
+
+class SimpleStringBuffer(TextIO):
+    """Simple FIFO pipe.
+    """
+
+    def __init__(self):
+        self.buff = bytearray()
+
+    def read(self, n: int = -1) -> bytes:
+        if n == -1:
+            ret = self.buff
+            rem = bytearray()
+        else:
+            ret = self.buff[:n]
+            rem = self.buff[n:]
+
+        self.buff = rem
+
+        return bytes(ret)
+
+    def readline(self, limit: int = -1) -> bytes:
+        ret = bytearray()
+
+        while not (ret.endswith(b'\n') or len(ret) == limit):
+            ret.extend(self.read(1))
+
+        return bytes(ret)
+
+    def write(self, s: bytes) -> int:
+        self.buff.extend(s)
+
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    def writable(self) -> bool:
+        return True
+
+    def readable(self) -> bool:
+        return True
+
+class SimpleStreamBase:
+    def __init__(self, fd: int, *args):
+        super().__init__(*args)
+
+        self.__fd = fd
+
+    def fileno(self) -> int:
+        return self.__fd
+
+    def fstat(self):
+        return stat.Fstat(self.fileno())
+
+class SimpleInStream(SimpleStreamBase, SimpleStringBuffer):
+    """Simple input stream. May be used to mock stdin.
+    """
+
+    pass
+
+class SimpleOutStream(SimpleStreamBase, SimpleStringBuffer):
+    """Simple output stream. May be used to mock stdout or stderr.
+    """
+
+    pass
+
+class NullOutStream(SimpleStreamBase):
+    """Null out-stream, may be used to disregard process output.
+    """
+
+    def write(self, s: bytes) -> int:
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    def writable(self) -> bool:
+        return True

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -10,6 +10,7 @@ sys.path.append("..")
 from qiling import Qiling
 from qiling.const import *
 from qiling.exception import *
+from qiling.extensions import pipe
 from qiling.loader.pe import QlPeCache
 from qiling.os.const import *
 from qiling.os.windows.fncc import *
@@ -349,28 +350,6 @@ class PETest(unittest.TestCase):
 
 
     def test_pe_win_x86_crackme(self):
-        class StringBuffer:
-            def __init__(self):
-                self.buffer = b''
-
-            def read(self, n):
-                ret = self.buffer[:n]
-                self.buffer = self.buffer[n:]
-                return ret
-
-            def readline(self, end=b'\n'):
-                ret = b''
-                while True:
-                    c = self.read(1)
-                    ret += c
-                    if c == end:
-                        break
-                return ret
-
-            def write(self, string):
-                self.buffer += string
-                return len(string)
-
         def force_call_dialog_func(ql):
             # get DialogFunc address
             lpDialogFunc = ql.unpack32(ql.mem.read(ql.reg.esp - 0x8, 4))
@@ -390,7 +369,7 @@ class PETest(unittest.TestCase):
             ql.patch(0x0040110B, b'\x90\x90')
             ql.patch(0x00401112, b'\x90\x90')
 
-            ql.os.stdin = StringBuffer()
+            ql.os.stdin = pipe.SimpleStringBuffer()
             ql.os.stdin.write(b"Ea5yR3versing\n")
 
             ql.hook_address(force_call_dialog_func, 0x00401016)


### PR DESCRIPTION
The `MyPipe` and `StringBuffer` classes are used by various tests and examples to redirect the process standard input and output streams. However, they are re-implemented each and every time. This new extentions module implements a few handy mock pipes that can be used to replace them (and reduce code duplication):
- `SimpleStringBuffer` - basic bufferred FIFO pipe
- `SimpleInStream` - basic input stream, may be used to mock `stdin`
- `SimpleOutStream` - basic output stream, may be used to mock `stdout` or `stderr`
- `NullOutStream` - nullified output stream, may be used to disregard program output (as if it was redirected to `/dev/null`)

Note: Windows program may also use `SimpleStringBuffer` to mock their standard IO stream, however using the `SimpleInStream` and `SimpleOutStream` classes would provide a better clarity.

Example:
```python3
from qiling import Qiling
from qiling.const import QL_VERBOSE
from qiling.extensions import pipe

mock_stdin = pipe.SimpleInStream(sys.stdin.fileno())
mock_stdout = pipe.NullOutStream(sys.stdout.fileno())

# create a silent qiling instance
ql = Qiling(argv, rootfs,
    verbose=QL_VERBOSE.OFF, # thwart qiling logger output
    stdin=mock_stdin,       # take over the input to the program using a fake stdin
    stdout=mock_stdout)     # disregard program output

# ...

ql.os.stdin.write(b'hello world!\n')
```