### PR TITLE
Refactored POSIX syscalls

### DIFF
--- a/qiling/core.py
+++ b/qiling/core.py
@@ -178,7 +178,6 @@ class Qiling(QlCoreHooks, QlCoreStructs):
                                                               self._log_file,
                                                               self._console,
                                                               self._filter,
-                                                              self._multithread,
                                                               self._log_override,
                                                               self._log_plain)
 

--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -245,7 +245,7 @@ class QlOsPosix(QlOs):
 
             # record syscall statistics
             self.utils.syscalls.setdefault(syscall_name, []).append({
-                "params": dict(zip((f'param{i}' for i in range(6)), params)),
+                "params": dict(zip(param_names, params)),
                 "result": retval,
                 "address": self.ql.reg.arch_pc,
                 "return_address": None,

--- a/qiling/os/posix/stat.py
+++ b/qiling/os/posix/stat.py
@@ -6,32 +6,30 @@
 import os
 
 class StatBase:
-    def __init__(self):
-        self._stat_buf = None
+    def __init__(self, stat: os.stat_result):
+        self._stat_buf = stat
 
     # Never iterate this object!
     def __getitem__(self, key):
         if type(key) is not str:
             raise TypeError
-        if not key.startswith("__") and key in dir(self._stat_buf):
+
+        if not key.startswith("__") and hasattr(self._stat_buf, key):
             return self._stat_buf.__getattribute__(key)
+
         return 0
-    
+
     def __getattr__(self, key):
         return self.__getitem__(key)
+
 class Stat(StatBase):
     def __init__(self, path):
-        super(Stat, self).__init__()
-        self._stat_buf = os.stat(path)
+        super().__init__(os.stat(path))
 
 class Fstat(StatBase):
-    def __init__(self, fd):
-        super(Fstat, self).__init__()
-        self._stat_buf = os.fstat(fd)
+    def __init__(self, fd: int):
+        super().__init__(os.fstat(fd))
 
 class Lstat(StatBase):
     def __init__(self, path):
-        super(Lstat, self).__init__()
-        self._stat_buf = os.lstat(path)
-
-
+        super().__init__(os.lstat(path))

--- a/qiling/os/posix/syscall/futex.py
+++ b/qiling/os/posix/syscall/futex.py
@@ -3,24 +3,17 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from qiling import Qiling
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
+def ql_syscall_set_robust_list(ql: Qiling, head_ptr: int, head_len: int):
+    if ql.multithread:
+        ql.os.thread_management.cur_thread.robust_list_head_ptr = head_ptr
+        ql.os.thread_management.cur_thread.robust_list_head_len = head_len
 
-def ql_syscall_set_robust_list(ql, set_robust_list_head_ptr, set_robust_list_head_len, *args, **kw):
-    if ql.multithread == True:
-        ql.os.thread_management.cur_thread.robust_list_head_ptr = set_robust_list_head_ptr
-        ql.os.thread_management.cur_thread.robust_list_head_len = set_robust_list_head_len
-    regreturn = 0
-    return regreturn
+    return 0
 
 
-def ql_syscall_futex(ql, futex_uaddr, futex_op, futex_val, futex_timeout, futex_uaddr2, futex_val3):
+def ql_syscall_futex(ql: Qiling, uaddr: int, op: int, val: int, timeout: int, uaddr2: int, val3: int):
     FUTEX_WAIT = 0
     FUTEX_WAKE = 1
     FUTEX_FD = 2
@@ -36,36 +29,24 @@ def ql_syscall_futex(ql, futex_uaddr, futex_op, futex_val, futex_timeout, futex_
     FUTEX_CMP_REQUEUE_PI = 12
     FUTEX_PRIVATE_FLAG = 128
 
-    if futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAIT:
+    if op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAIT:
         # def futex_wait_addr(ql, th, arg):
         #     addr, val = arg
-        #     if ql.unpack32(ql.mem.read(addr, 4)) != val:
-        #         return False
-        #     else:
-        #         return True
-        regreturn = ql.os.futexm.futex_wait(ql, futex_uaddr,
-                                            ql.os.thread_management.cur_thread,
-                                            futex_val)
-        ql.log.debug("futex(%x, %d, %d, %x) = %d" % (futex_uaddr, futex_op, futex_val, futex_timeout, regreturn))
-    elif futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAIT_BITSET:
-        regreturn = ql.os.futexm.futex_wait(ql, futex_uaddr,
-                                            ql.os.thread_management.cur_thread,
-                                            futex_val,
-                                            futex_val3)
-        ql.log.debug("futex(%x, %d, %d, %x, %x, %x) = %d" % (futex_uaddr,
-                                                          futex_op, futex_val,
-                                                          futex_timeout,
-                                                          futex_uaddr2,
-                                                          futex_val3,
-                                                          regreturn))
-    elif futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAKE:
-        regreturn = ql.os.futexm.futex_wake(ql, futex_uaddr,ql.os.thread_management.cur_thread, futex_val)
-        ql.log.debug("futex(%x, %d, %d) = %d" % (futex_uaddr, futex_op, futex_val, regreturn))
-    elif futex_op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAKE_BITSET:
-        regreturn = ql.os.futexm.futex_wake(ql, futex_uaddr,ql.os.thread_management.cur_thread, futex_val, futex_val3)
-        ql.log.debug("futex(%x, %d, %d) = %d" % (futex_uaddr, futex_op, futex_val, regreturn))
+        #     return ql.unpack32(ql.mem.read(addr, 4)) == val
+
+        regreturn = ql.os.futexm.futex_wait(ql, uaddr, ql.os.thread_management.cur_thread, val)
+
+    elif op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAIT_BITSET:
+        regreturn = ql.os.futexm.futex_wait(ql, uaddr, ql.os.thread_management.cur_thread, val, val3)
+
+    elif op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAKE:
+        regreturn = ql.os.futexm.futex_wake(ql, uaddr,ql.os.thread_management.cur_thread, val)
+
+    elif op & (FUTEX_PRIVATE_FLAG - 1) == FUTEX_WAKE_BITSET:
+        regreturn = ql.os.futexm.futex_wake(ql, uaddr,ql.os.thread_management.cur_thread, val, val3)
+
     else:
-        ql.log.debug("futex(%x, %d, %d) = ?" % (futex_uaddr, futex_op, futex_val))
+        ql.log.debug(f'futex({uaddr:x}, {op:d}, {val:d}) = ?')
         ql.emu_stop()
         #ql.os.thread_management.cur_thread.stop()
         #ql.os.thread_management.cur_thread.stop_event = THREAD_EVENT_EXIT_GROUP_EVENT

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -3,86 +3,67 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from unicorn import UC_PROT_ALL
 
-from unicorn import (
-    UC_PROT_ALL,
-    UC_PROT_EXEC,
-    UC_PROT_NONE,
-    UC_PROT_READ,
-    UC_PROT_WRITE,
-)
-
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const import *
+from qiling import Qiling
+from qiling.exception import QlMemoryMappedError
+from qiling.os.filestruct import ql_file
 from qiling.os.posix.const_mapping import *
-from qiling.exception import *
 
-
-def ql_syscall_munmap(ql, munmap_addr, munmap_len, *args, **kw):
+def ql_syscall_munmap(ql: Qiling, addr: int, length: int):
 
     # get all mapped fd with flag MAP_SHARED and we definitely dont want to wipe out share library
     mapped_fd = [fd for fd in ql.os.fd if fd != 0 and isinstance(fd, ql_file) and fd._is_map_shared and not (fd.name.endswith(".so") or fd.name.endswith(".dylib"))]
 
-    if len(mapped_fd):
+    if mapped_fd:
         all_mem_info = [_mem_info for _, _, _, _mem_info in ql.mem.map_info if _mem_info not in ("[mapped]", "[stack]", "[hook_mem]")]
 
         for _fd in mapped_fd:
             if _fd.name in [each.split()[-1] for each in all_mem_info]:
                 ql.log.debug("Flushing file: %s" % _fd.name)
                 # flushes changes to disk file
-                _buff = ql.mem.read(munmap_addr, munmap_len)
+                _buff = ql.mem.read(addr, length)
                 _fd.lseek(_fd._mapped_offset)
                 _fd.write(_buff)
 
-    munmap_len = ((munmap_len + 0x1000 - 1) // 0x1000) * 0x1000
-    ql.mem.unmap(munmap_addr, munmap_len)
-    regreturn = 0
-    return regreturn
+    length = ((length + 0x1000 - 1) // 0x1000) * 0x1000
+    ql.mem.unmap(addr, length)
+
+    return 0
 
 
-def ql_syscall_madvise(ql, madvise_addr, madvise_length, madvise_advice, *args, **kw):
+def ql_syscall_madvise(ql: Qiling, addr: int, length: int, advice: int):
     MADV_DONTNEED = 4
 
-    if madvise_advice == MADV_DONTNEED:
-        ql.mem.write(madvise_addr, b'\x00' * madvise_length)
+    if advice == MADV_DONTNEED:
+        ql.mem.write(addr, b'\x00' * length)
 
-    regreturn = 0
-    return regreturn
+    return 0
 
 
-def ql_syscall_mprotect(ql, start, mlen, prot, *args, **kw):
-    regreturn = 0
-    ql.log.debug("mprotect(0x%x, 0x%x, %s) = %d" % (start, mlen, mmap_prot_mapping(prot), regreturn))
-
+def ql_syscall_mprotect(ql: Qiling, start: int, mlen: int, prot: int):
     try:
         ql.mem.protect(start, mlen, prot)
     except Exception as e:
-        ql.log.debug(e)
-        raise QlMemoryMappedError("Error: change protection at: %x - %x" % (start, start + mlen - 1))
+        ql.log.exception(e)
 
-    return regreturn
+        raise QlMemoryMappedError(f'Error: change protection at: {start:#x} - {start + mlen - 1:#x}')
+
+    return 0
 
 
-def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
-    MAP_ANONYMOUS = 32
-    MAP_SHARED = 1
+def syscall_mmap_impl(ql: Qiling, addr: int, mlen: int, prot: int, flags: int, fd: int, pgoffset: int, ver: int):
+    MAP_SHARED = 0x01
     MAP_FIXED = 0x10
-    api_name = None
+    MAP_ANONYMOUS = 0x20
 
-    if ver == 1:
-        api_name = "mmap"
-    elif ver == 2:
-        api_name = "mmap2"
-    elif ver == 0:
-        api_name = "old_mmap"
-    else:
-        raise QlMemoryMappedError("Error: unknown mmap syscall!")
+    api_name = {
+        0 : 'old_mmap',
+        1 : 'mmap',
+        2 : 'mmap2'
+    }[ver]
 
-    ql.log.debug("%s(0x%x, 0x%x, %s (0x%x), %s (0x%x), %x, 0x%x)" % (
-                 api_name, addr, mlen, mmap_prot_mapping(prot), prot, mmap_flag_mapping(flags), flags, fd, pgoffset))
+    # ql.log.debug(f'{api_name}({addr:#x}, {mlen:#x}, {mmap_prot_mapping(prot)} ({prot:#x}), {mmap_flag_mapping(flags)} ({flags:#x}), {fd:d}, {pgoffset:#x})')
 
     # FIXME
     # this is ugly patch, we might need to get value from elf parse,
@@ -148,6 +129,8 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
         ql.os.fd[fd]._mapped_offset = pgoffset
         ql.log.debug("mem write : " + hex(len(data)))
         ql.log.debug("mem mmap  : " + mem_info)
+
+        # FIXME: shouldn't we use ql.mem.map instead?
         ql.mem.add_mapinfo(mmap_base,
                            mmap_base + eff_mmap_size,
                            mem_p=UC_PROT_ALL,
@@ -158,52 +141,56 @@ def syscall_mmap_impl(ql, addr, mlen, prot, flags, fd, pgoffset, ver):
             ql.log.debug(e)
             raise QlMemoryMappedError("Error: trying to write memory: ")
 
-    ql.log.debug("%s(0x%x, 0x%x, 0x%x, 0x%x, %x, 0x%x) = 0x%x" %
-                 (api_name, addr, mlen, prot, flags, fd, pgoffset, mmap_base))
     return mmap_base
 
 
-def ql_syscall_old_mmap(ql, struct_mmap_args, *args, **kw):
+def ql_syscall_old_mmap(ql: Qiling, struct_mmap_args: int):
     # according to the linux kernel this is only for the ia32 compatibility
-    _struct = []
 
-    for offset in range(0, 0x18, 4):
-        data = ql.mem.read(struct_mmap_args + offset, 4)
-        _struct.append(int.from_bytes(data, 'little'))
+    def __read_int(address: int) -> int:
+        return ql.unpack32(ql.mem.read(address, 4))
 
-    mmap_addr, mmap_length, mmap_prot, mmap_flags, mmap_fd, mmap_offset = _struct
+    addr   = __read_int(struct_mmap_args + 0 * 4)
+    length = __read_int(struct_mmap_args + 1 * 4)
+    prot   = __read_int(struct_mmap_args + 2 * 4)
+    flags  = __read_int(struct_mmap_args + 3 * 4)
+    fd     = __read_int(struct_mmap_args + 4 * 4)
+    offset = __read_int(struct_mmap_args + 5 * 4)
 
-    return syscall_mmap_impl(ql, mmap_addr, mmap_length, mmap_prot, mmap_flags, mmap_fd, mmap_offset, 0)
+    return syscall_mmap_impl(ql, addr, length, prot, flags, fd, offset, 0)
 
 
-def ql_syscall_mmap(ql, mmap_addr, mmap_length, mmap_prot, mmap_flags, mmap_fd, mmap_pgoffset):
-    return syscall_mmap_impl(ql, mmap_addr, mmap_length, mmap_prot, mmap_flags, mmap_fd, mmap_pgoffset, 1)
+def ql_syscall_mmap(ql: Qiling, addr: int, length: int, prot: int, flags: int, fd: int, pgoffset: int):
+    return syscall_mmap_impl(ql, addr, length, prot, flags, fd, pgoffset, 1)
 
 
-def ql_syscall_mmap2(ql, mmap2_addr, mmap2_length, mmap2_prot, mmap2_flags, mmap2_fd, mmap2_pgoffset):
-    return syscall_mmap_impl(ql, mmap2_addr, mmap2_length, mmap2_prot, mmap2_flags, mmap2_fd, mmap2_pgoffset, 2)
+def ql_syscall_mmap2(ql: Qiling, addr: int, length: int, prot: int, flags: int, fd: int, pgoffset: int):
+    return syscall_mmap_impl(ql, addr, length, prot, flags, fd, pgoffset, 2)
 
-def ql_syscall_shmget(ql, key, size, shmflg, *args, **kwargs):
-    if (shmflg & IPC_CREAT) == 0:
-        if key not in ql.os._shms:
-            return ENOENT
-    else:
-        if (shmflg & IPC_EXCL) != 0:
+def ql_syscall_shmget(ql: Qiling, key: int, size: int, shmflg: int):
+    if shmflg & IPC_CREAT:
+        if shmflg & IPC_EXCL:
             if key in ql.os._shms:
                 return EEXIST
         else:
             #addr = ql.mem.map_anywhere(size)
             ql.os._shms[key] = (key, size)
             return key
+    else:
+        if key not in ql.os._shms:
+            return ENOENT
 
-def ql_syscall_shmat(ql, shmid, shmaddr, shmflg, *args, **kwargs):
+def ql_syscall_shmat(ql: Qiling, shmid: int, shmaddr: int, shmflg: int):
     # shmid == key
     # dummy implementation
     if shmid not in ql.os._shms:
         return EINVAL
+
     key, size = ql.os._shms[shmid]
+
     if shmaddr == 0:
         addr = ql.mem.map_anywhere(size)
     else:
         addr = ql.mem.map(shmaddr, size, info="[shm]")
+
     return addr

--- a/qiling/os/posix/syscall/poll.py
+++ b/qiling/os/posix/syscall/poll.py
@@ -1,11 +1,9 @@
-from multiprocessing import Process
+#!/usr/bin/env python3
+#
+# Cross Platform and Multi Architecture Advanced Binary Emulation Framework
+#
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
+from qiling import Qiling
 
-def ql_syscall_poll(ql, fds, nfds, timeout, *args, **kw):
+def ql_syscall_poll(ql: Qiling, fds: int, nfds: int, timeout: int):
     return 0

--- a/qiling/os/posix/syscall/prctl.py
+++ b/qiling/os/posix/syscall/prctl.py
@@ -3,22 +3,28 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from qiling import Qiling
+from qiling.arch.x86_const import FSMSR, GSMSR
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
+def ql_syscall_arch_prctl(ql: Qiling, code: int, addr: int):
+    ARCH_SET_GS = 0x1001
+    ARCH_SET_FS = 0x1002
+    ARCH_GET_FS = 0x1003
+    ARCH_GET_GS = 0x1004
 
-def ql_syscall_arch_prctl(ql, ARCHX, ARCH_SET_FS, *args, **kw):
-    FSMSR = 0xC0000100
-    ql.reg.msr(FSMSR, ARCH_SET_FS)
-    regreturn = 0
-    return regreturn
+    handlers = {
+        ARCH_SET_GS : lambda : ql.reg.msr(GSMSR, addr),
+        ARCH_SET_FS : lambda : ql.reg.msr(FSMSR, addr),
+        ARCH_GET_FS : lambda : ql.mem.write(addr, ql.pack64(ql.reg.msr(FSMSR))),
+        ARCH_GET_GS : lambda : ql.mem.write(addr, ql.pack64(ql.reg.msr(GSMSR)))
+    }
 
+    if code not in handlers:
+        raise NotImplementedError(f'prctl code {code:#x} not implemented')
 
-def ql_syscall_prctl(ql, option, arg1, arg2, arg3, arg4, arg5, *args, **kw):
-    regreturn = 0
-    return regreturn
+    handlers[code]()
+
+    return 0
+
+def ql_syscall_prctl(ql: Qiling, option: int, arg2: int, arg3: int, arg4: int, arg5: int):
+    return 0

--- a/qiling/os/posix/syscall/ptrace.py
+++ b/qiling/os/posix/syscall/ptrace.py
@@ -3,15 +3,7 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from qiling import Qiling
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-
-def ql_syscall_ptrace(ql, request, pid, addr, data, *args, **kw):
-    regreturn = 0
-    return regreturn
+def ql_syscall_ptrace(ql: Qiling, request: int, pid: int, addr: int, data: int):
+    return 0

--- a/qiling/os/posix/syscall/random.py
+++ b/qiling/os/posix/syscall/random.py
@@ -5,20 +5,16 @@
 
 import os
 
+from qiling import Qiling
 
-from qiling.const import *
-
-def ql_syscall_getrandom(ql, buf, buflen, flags,*args, **kw):
-    data = None
-    regreturn = None
+def ql_syscall_getrandom(ql: Qiling, buf: int, buflen: int, flags: int):
     try:
         data = os.urandom(buflen)
         ql.mem.write(buf, data)
-        regreturn = len(data)
     except:
-        regreturn = -1
+        retval = -1
+    else:
+        ql.log.debug(f'getrandom() CONTENT: {data.hex(" ")}')
+        retval = len(data)
 
-    if data:
-        ql.log.debug("getrandom() CONTENT:")
-        ql.log.debug(str(data))
-    return regreturn
+    return retval

--- a/qiling/os/posix/syscall/sched.py
+++ b/qiling/os/posix/syscall/sched.py
@@ -3,64 +3,59 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import types
+import os
 from multiprocessing import Process
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
+from qiling import Qiling
+from qiling.const import QL_ARCH, QL_OS
+from qiling.os.posix.const import THREAD_EVENT_CREATE_THREAD
 
-def ql_syscall_clone(ql, clone_flags, clone_child_stack, clone_parent_tidptr, clone_newtls, clone_child_tidptr, *args, **kw):
-   
-    CSIGNAL = 0x000000ff	
-    CLONE_VM = 0x00000100	
-    CLONE_FS = 0x00000200	
-    CLONE_FILES = 0x00000400	
-    CLONE_SIGHAND = 0x00000800	
-    CLONE_PIDFD = 0x00001000	
-    CLONE_PTRACE = 0x00002000	
-    CLONE_VFORK = 0x00004000	
-    CLONE_PARENT = 0x00008000	
-    CLONE_THREAD = 0x00010000	
-    CLONE_NEWNS = 0x00020000	
-    CLONE_SYSVSEM = 0x00040000	
-    CLONE_SETTLS = 0x00080000	
-    CLONE_PARENT_SETTID = 0x00100000	
-    CLONE_CHILD_CLEARTID = 0x00200000	
-    CLONE_DETACHED = 0x00400000	
-    CLONE_UNTRACED = 0x00800000	
-    CLONE_CHILD_SETTID = 0x01000000	
-    CLONE_NEWCGROUP = 0x02000000	
-    CLONE_NEWUTS = 0x04000000	
-    CLONE_NEWIPC = 0x08000000	
-    CLONE_NEWUSER = 0x10000000	
-    CLONE_NEWPID = 0x20000000	
-    CLONE_NEWNET = 0x40000000	
-    CLONE_IO = 0x80000000
+def ql_syscall_clone(ql: Qiling, flags: int, child_stack: int, parent_tidptr: int, newtls: int, child_tidptr: int):
+    CSIGNAL              = 0x000000ff
+    CLONE_VM             = 0x00000100
+    CLONE_FS             = 0x00000200
+    CLONE_FILES          = 0x00000400
+    CLONE_SIGHAND        = 0x00000800
+    CLONE_PIDFD          = 0x00001000
+    CLONE_PTRACE         = 0x00002000
+    CLONE_VFORK          = 0x00004000
+    CLONE_PARENT         = 0x00008000
+    CLONE_THREAD         = 0x00010000
+    CLONE_NEWNS          = 0x00020000
+    CLONE_SYSVSEM        = 0x00040000
+    CLONE_SETTLS         = 0x00080000
+    CLONE_PARENT_SETTID  = 0x00100000
+    CLONE_CHILD_CLEARTID = 0x00200000
+    CLONE_DETACHED       = 0x00400000
+    CLONE_UNTRACED       = 0x00800000
+    CLONE_CHILD_SETTID   = 0x01000000
+    CLONE_NEWCGROUP      = 0x02000000
+    CLONE_NEWUTS         = 0x04000000
+    CLONE_NEWIPC         = 0x08000000
+    CLONE_NEWUSER        = 0x10000000
+    CLONE_NEWPID         = 0x20000000
+    CLONE_NEWNET         = 0x40000000
+    CLONE_IO             = 0x80000000
 
-    # X8664 clone_flags, clone_child_stack, clone_parent_tidptr, clone_child_tidptr, clone_newtls
+    # X8664 flags, child_stack, parent_tidptr, child_tidptr, newtls
     if ql.archtype== QL_ARCH.X8664:
-        ori_clone_newtls = clone_child_tidptr
-        clone_child_tidptr = clone_newtls
-        clone_newtls = ori_clone_newtls
+        ori_newtls = child_tidptr
+        child_tidptr = newtls
+        newtls = ori_newtls
 
-    f_th = ql.os.thread_management.cur_thread	
+    f_th = ql.os.thread_management.cur_thread
     newtls = None
     set_child_tid_addr = None
 
     # Shared virtual memory
-    if clone_flags & CLONE_VM != CLONE_VM:
+    if not (flags & CLONE_VM):
         # FIXME: need a proper os.fork() for Windows
         if ql.platform == QL_OS.WINDOWS:
             try:
                 pid = Process()
-                pid = 0 
+                pid = 0
             except:
-                pid = -1  
+                pid = -1
         else:
             pid = os.fork()
 
@@ -70,60 +65,58 @@ def ql_syscall_clone(ql, clone_flags, clone_child_stack, clone_parent_tidptr, cl
             f_th.update_global_thread_id()
             f_th.new_thread_id()
 
-            if clone_flags & CLONE_SETTLS == CLONE_SETTLS:
-                f_th.set_thread_tls(clone_newtls)
+            if flags & CLONE_SETTLS == CLONE_SETTLS:
+                f_th.set_thread_tls(newtls)
 
-            if clone_flags & CLONE_CHILD_CLEARTID == CLONE_CHILD_CLEARTID:
-                f_th.set_clear_child_tid_addr(clone_child_tidptr)
+            if flags & CLONE_CHILD_CLEARTID == CLONE_CHILD_CLEARTID:
+                f_th.set_clear_child_tid_addr(child_tidptr)
 
-            if clone_child_stack != 0:
-                ql.arch.set_sp(clone_child_stack)
-            regreturn = 0
-        else:
-            regreturn = pid
-        
-        ql.log.debug("clone(new_stack = %x, flags = %x, tls = %x, ptidptr = %x, ctidptr = %x) = %d" % (clone_child_stack, clone_flags, clone_newtls, clone_parent_tidptr, clone_child_tidptr, regreturn))
+            if child_stack != 0:
+                ql.arch.set_sp(child_stack)
 
+        # ql.log.debug(f'clone(new_stack = {child_stack:#x}, flags = {flags:#x}, tls = {newtls:#x}, ptidptr = {parent_tidptr:#x}, ctidptr = {child_tidptr:#x}) = {regreturn:d}')
         ql.emu_stop()
-        return regreturn
 
-    if clone_flags & CLONE_CHILD_SETTID == CLONE_CHILD_SETTID:
-        set_child_tid_addr = clone_child_tidptr
+        return pid
+
+    if flags & CLONE_CHILD_SETTID == CLONE_CHILD_SETTID:
+        set_child_tid_addr = child_tidptr
 
     th = ql.os.thread_class.spawn(ql, ql.reg.arch_pc + 2, ql.os.exit_point, set_child_tid_addr = set_child_tid_addr)
     th.path = f_th.path
-    ql.log.debug(f"{str(th)} created.")
+    ql.log.debug(f'{str(th)} created')
 
-    if clone_flags & CLONE_PARENT_SETTID == CLONE_PARENT_SETTID:
-        ql.mem.write(clone_parent_tidptr, ql.pack32(th.id))
+    if flags & CLONE_PARENT_SETTID == CLONE_PARENT_SETTID:
+        ql.mem.write(parent_tidptr, ql.pack32(th.id))
 
     ctx = ql.save(reg=True, mem=False)
     # Whether to set a new tls
-    if clone_flags & CLONE_SETTLS == CLONE_SETTLS:
-        ql.log.debug(f"new_tls={hex(clone_newtls)}")
-        th.set_thread_tls(clone_newtls)
+    if flags & CLONE_SETTLS == CLONE_SETTLS:
+        ql.log.debug(f"new_tls={newtls:#x}")
+        th.set_thread_tls(newtls)
 
-    if clone_flags & CLONE_CHILD_CLEARTID == CLONE_CHILD_CLEARTID:
-        th.set_clear_child_tid_addr(clone_child_tidptr)
+    if flags & CLONE_CHILD_CLEARTID == CLONE_CHILD_CLEARTID:
+        th.set_clear_child_tid_addr(child_tidptr)
 
     # Set the stack and return value of the new thread
     # (the return value of the child thread is 0, and the return value of the parent thread is the tid of the child thread)
     # and save the current context.
     regreturn = 0
-    ql.reg.arch_sp = clone_child_stack
+    ql.reg.arch_sp = child_stack
 
     # We have to find next pc manually for some archs since the pc is current instruction (like `syscall`).
     if ql.archtype in (QL_ARCH.X8664, ):
         ql.reg.arch_pc += list(ql.disassembler.disasm_lite(bytes(ql.mem.read(ql.reg.arch_pc, 4)), ql.reg.arch_pc))[0][1]
         ql.log.debug(f"Fix pc for child thread to {hex(ql.reg.arch_pc)}")
+
     ql.os.set_syscall_return(0)
     th.save()
+
     if th is None or f_th is None:
         raise Exception()
-    ql.log.debug("Currently running pid is: %d; tid is: %d " % (
-    os.getpid(), ql.os.thread_management.cur_thread.id))
-    ql.log.debug("clone(new_stack = %x, flags = %x, tls = %x, ptidptr = %x, ctidptr = %x) = %d" % (
-    clone_child_stack, clone_flags, clone_newtls, clone_parent_tidptr, clone_child_tidptr, regreturn))
+
+    ql.log.debug(f'Currently running pid is: {os.getpid():d}; tid is: {ql.os.thread_management.cur_thread.id:d}')
+    # ql.log.debug(f'clone(new_stack = {child_stack:#x}, flags = {flags:#x}, tls = {newtls:#x}, ptidptr = {parent_tidptr:#x}, ctidptr = {child_tidptr:#x}) = {regreturn:d}')
 
     # Restore the stack and return value of the parent process
     ql.restore(ctx)
@@ -134,12 +127,10 @@ def ql_syscall_clone(ql, clone_flags, clone_child_stack, clone_parent_tidptr, cl
     f_th.stop_event = THREAD_EVENT_CREATE_THREAD
     f_th.stop_return_val = th
 
-    ql.log.debug("Currently running pid is: %d; tid is: %d " % (
-    os.getpid(), ql.os.thread_management.cur_thread.id))
-    ql.log.debug("clone(new_stack = %x, flags = %x, tls = %x, ptidptr = %x, ctidptr = %x) = %d" % (
-    clone_child_stack, clone_flags, clone_newtls, clone_parent_tidptr, clone_child_tidptr, regreturn))
+    ql.log.debug(f'Currently running pid is: {os.getpid():d}; tid is: {ql.os.thread_management.cur_thread.id:d}')
+    # ql.log.debug(f'clone(new_stack = {child_stack:#x}, flags = {flags:#x}, tls = {newtls:#x}, ptidptr = {parent_tidptr:#x}, ctidptr = {child_tidptr:#x}) = {regreturn:d}')
 
     return regreturn
 
-def ql_syscall_sched_yield(ql, *args, **kw):
+def ql_syscall_sched_yield(ql: Qiling):
     return 0

--- a/qiling/os/posix/syscall/sendfile.py
+++ b/qiling/os/posix/syscall/sendfile.py
@@ -3,21 +3,15 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from qiling import Qiling
+from qiling.os.posix.const import NR_OPEN
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-
-def ql_syscall_sendfile64(ql, sendfile64_out_fd, sendfile64_in_fd, sendfile64_offest, sendfile64_count, *args, **kw):
-    if 0 <= sendfile64_out_fd < NR_OPEN and 0 <= sendfile64_in_fd < NR_OPEN \
-            and ql.os.fd[sendfile64_out_fd] != 0 and ql.os.fd[sendfile64_in_fd] != 0:
-        ql.os.fd[sendfile64_in_fd].lseek(ql.unpack32(ql.mem.read(sendfile64_offest, 4)))
-        buf = ql.os.fd[sendfile64_in_fd].read(sendfile64_count)
-        regreturn = ql.os.fd[sendfile64_out_fd].write(buf)
+def ql_syscall_sendfile64(ql: Qiling, out_fd: int, in_fd: int, offest: int, count: int):
+    if (0 <= out_fd < NR_OPEN and ql.os.fd[out_fd] != 0) and (0 <= in_fd < NR_OPEN and ql.os.fd[in_fd] != 0):
+        ql.os.fd[in_fd].lseek(ql.unpack32(ql.mem.read(offest, 4)))
+        buf = ql.os.fd[in_fd].read(count)
+        regreturn = ql.os.fd[out_fd].write(buf)
     else:
         regreturn = -1
+
     return regreturn

--- a/qiling/os/posix/syscall/signal.py
+++ b/qiling/os/posix/syscall/signal.py
@@ -3,45 +3,29 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from qiling import Qiling
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-
-def ql_syscall_rt_sigaction(ql, rt_sigaction_signum, rt_sigaction_act, rt_sigaction_oldact, *args, **kw):
-    if rt_sigaction_oldact != 0:
-        if ql.os.sigaction_act[rt_sigaction_signum] == 0:
-            ql.mem.write(rt_sigaction_oldact, b'\x00' * 20)
+def ql_syscall_rt_sigaction(ql: Qiling, signum: int, act: int, oldact: int):
+    if oldact:
+        if ql.os.sigaction_act[signum] == 0:
+            data = b'\x00' * 20
         else:
-            data = b''
-            for key in ql.os.sigaction_act[rt_sigaction_signum]:
-                data += ql.pack32(key)
-            ql.mem.write(rt_sigaction_oldact, data)
+            data = b''.join(ql.pack32(key) for key in ql.os.sigaction_act[signum])
 
-    if rt_sigaction_act != 0:
-        data = []
-        for key in range(5):
-            data.append(ql.unpack32(ql.mem.read(rt_sigaction_act + 4 * key, 4)))
-        ql.os.sigaction_act[rt_sigaction_signum] = data
+        ql.mem.write(oldact, data)
 
-    regreturn = 0
-    return regreturn
+    if act:
+        ql.os.sigaction_act[signum] = [ql.unpack32(ql.mem.read(act + 4 * key, 4)) for key in range(5)]
+
+    return 0
 
 
-def ql_syscall_rt_sigprocmask(ql, rt_sigprocmask_how, rt_sigprocmask_nset, rt_sigprocmask_oset, rt_sigprocmask_sigsetsize, *args, **kw):
-    SIG_BLOCK = 0x0
-    SIG_UNBLOCK = 0x1
+def ql_syscall_rt_sigprocmask(ql: Qiling, how: int, nset: int, oset: int, sigsetsize: int):
+    # SIG_BLOCK = 0x0
+    # SIG_UNBLOCK = 0x1
 
-    if rt_sigprocmask_how == SIG_BLOCK:
-        pass
-
-    regreturn = 0
-    return regreturn
+    return 0
 
 
-def ql_syscall_signal(ql, sig, __sighandler_t, *args, **kw):
-    regreturn = 0
-    return regreturn
+def ql_syscall_signal(ql: Qiling, sig: int, sighandler: int):
+    return 0

--- a/qiling/os/posix/syscall/socket.py
+++ b/qiling/os/posix/syscall/socket.py
@@ -3,63 +3,62 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import struct, ipaddress
+import ctypes
+import ipaddress
+import sys
+import socket
+import struct
 
 from unicorn.unicorn import UcError
 
-
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
+from qiling import Qiling
+from qiling.const import QL_ARCH, QL_VERBOSE
+from qiling.os.posix.const_mapping import socket_type_mapping, socket_level_mapping, socket_domain_mapping, socket_ip_option_mapping, socket_option_mapping
 from qiling.os.posix.const import *
-from qiling.exception import *
-
-import ctypes
+from qiling.os.posix.filestruct import ql_socket
 
 class msghdr(ctypes.Structure):
     _fields_ = [
-        ("msg_name"      , ctypes.c_uint64),
-        ("msg_namelen"   , ctypes.c_int32 ),
-        ("msg_iov"       , ctypes.c_uint64),
-        ("msg_iovlen"    , ctypes.c_int32 ),
-        ("msg_control"   , ctypes.c_uint64),
-        ("msg_controllen", ctypes.c_int32 ),
-        ("msg_flags"     , ctypes.c_int32 )
+        ('msg_name'      , ctypes.c_uint64),
+        ('msg_namelen'   , ctypes.c_int32 ),
+        ('msg_iov'       , ctypes.c_uint64),
+        ('msg_iovlen'    , ctypes.c_int32 ),
+        ('msg_control'   , ctypes.c_uint64),
+        ('msg_controllen', ctypes.c_int32 ),
+        ('msg_flags'     , ctypes.c_int32 )
     ]
 
     _pack_ = 8
 
     @classmethod
-    def load(self, ql, addr):
+    def load(cls, ql: Qiling, addr: int):
         data = ql.mem.read(addr, ctypes.sizeof(msghdr))
         return msghdr.from_buffer(data)
 
 class cmsghdr(ctypes.Structure):
     _fields_ = [
-        ("cmsg_len"     , ctypes.c_int32),
-        ("cmsg_level"   , ctypes.c_int32),
-        ("cmsg_type"    , ctypes.c_int32),        
+        ('cmsg_len'  , ctypes.c_int32),
+        ('cmsg_level', ctypes.c_int32),
+        ('cmsg_type' , ctypes.c_int32),
     ]
 
     _pack_ = 8
 
     @classmethod
-    def load(self, ql, addr):
+    def load(cls, ql: Qiling, addr: int):
         data = ql.mem.read(addr, ctypes.sizeof(cmsghdr))
         return cmsghdr.from_buffer(data)
 
 class iovec(ctypes.Structure):
     _fields_ = [
-        ("iov_base"  , ctypes.c_uint64),
-        ("iov_len"   , ctypes.c_uint64),
+        ('iov_base', ctypes.c_uint64),
+        ('iov_len' , ctypes.c_uint64),
     ]
 
     _pack_ = 8
 
     @classmethod
-    def load(self, ql, addr):
+    def load(cls, ql: Qiling, addr: int):
         data = ql.mem.read(addr, ctypes.sizeof(iovec))
         return iovec.from_buffer(data)
 
@@ -68,7 +67,7 @@ def ql_bin_to_ip(ip):
     return ipaddress.ip_address(ip).compressed
 
 
-def ql_syscall_socket(ql, socket_domain, socket_type, socket_protocol, *args, **kw):
+def ql_syscall_socket(ql: Qiling, socket_domain, socket_type, socket_protocol):
     idx = -1
     for i in range(NR_OPEN):
         if ql.os.fd[i] == 0:
@@ -114,7 +113,7 @@ def ql_syscall_socket(ql, socket_domain, socket_type, socket_protocol, *args, **
     return regreturn
 
 
-def ql_syscall_connect(ql, connect_sockfd, connect_addr, connect_addrlen, *args, **kw):
+def ql_syscall_connect(ql: Qiling, connect_sockfd, connect_addr, connect_addrlen):
     AF_UNIX = 1
     AF_INET = 2
     sock_addr = ql.mem.read(connect_addr, connect_addrlen)
@@ -151,17 +150,14 @@ def ql_syscall_connect(ql, connect_sockfd, connect_addr, connect_addrlen, *args,
     return regreturn
 
 
-def ql_syscall_getsockopt(ql, sockfd, level, optname, optval_addr, optlen_addr, *args, **kw):
-    if not (0 <= sockfd < NR_OPEN) or\
-            ql.os.fd[sockfd] == 0:
+def ql_syscall_getsockopt(ql: Qiling, sockfd, level, optname, optval_addr, optlen_addr):
+    if not (0 <= sockfd < NR_OPEN) or ql.os.fd[sockfd] == 0:
         return -EBADF
-    
-    
+
     try:
         optlen = min(ql.unpack32s(ql.mem.read(optlen_addr, 4)), 1024)
         if optlen < 0:
             return -EINVAL
-
 
         try:
             emu_level = level
@@ -211,11 +207,11 @@ def ql_syscall_getsockopt(ql, sockfd, level, optname, optval_addr, optlen_addr, 
         ql.mem.write(optval_addr, optval)
     except UcError:
         return -EFAULT
-    
+
     return 0
 
 
-def ql_syscall_setsockopt(ql, sockfd, level, optname, optval_addr, optlen, *args, **kw):
+def ql_syscall_setsockopt(ql: Qiling, sockfd, level, optname, optval_addr, optlen):
     if not (0 <= sockfd < NR_OPEN) or\
             ql.os.fd[sockfd] == 0:
         return -EBADF
@@ -281,17 +277,19 @@ def ql_syscall_setsockopt(ql, sockfd, level, optname, optval_addr, optlen, *args
     return regreturn
 
 
-def ql_syscall_shutdown(ql, shutdown_fd, shutdown_how, *args, **kw):
+def ql_syscall_shutdown(ql: Qiling, shutdown_fd, shutdown_how):
     if 0 <= shutdown_fd < NR_OPEN and ql.os.fd[shutdown_fd] != 0:
         try:
             ql.os.fd[shutdown_fd].shutdown(shutdown_how)
-            regreturn = 0
         except:
             regreturn = -1
+        else:
+            regreturn = 0
+
     return regreturn
 
 
-def ql_syscall_bind(ql, bind_fd, bind_addr, bind_addrlen,  *args, **kw):
+def ql_syscall_bind(ql: Qiling, bind_fd, bind_addr, bind_addrlen):
     regreturn = 0
 
     if ql.archtype == QL_ARCH.X8664:
@@ -340,7 +338,7 @@ def ql_syscall_bind(ql, bind_fd, bind_addr, bind_addrlen,  *args, **kw):
     return regreturn
 
 
-def ql_syscall_getsockname(ql, sockfd, addr, addrlenptr, *args, **kw):
+def ql_syscall_getsockname(ql: Qiling, sockfd, addr, addrlenptr):
     if 0 <= sockfd < NR_OPEN and ql.os.fd[sockfd] != 0:
         host, port = ql.os.fd[sockfd].getsockname()
         data = struct.pack("<h", int(ql.os.fd[sockfd].family))
@@ -355,10 +353,10 @@ def ql_syscall_getsockname(ql, sockfd, addr, addrlenptr, *args, **kw):
         regreturn = -1
 
     ql.log.debug("getsockname(%d, 0x%x, 0x%x) = %d" % (sockfd, addr, addrlenptr, regreturn))
-    return regreturn  
+    return regreturn
 
 
-def ql_syscall_getpeername(ql, sockfd, addr, addrlenptr, *args, **kw):
+def ql_syscall_getpeername(ql: Qiling, sockfd, addr, addrlenptr):
     if 0 <= sockfd < NR_OPEN and ql.os.fd[sockfd] != 0:
         host, port = ql.os.fd[sockfd].getpeername()
         data = struct.pack("<h", int(ql.os.fd[sockfd].family))
@@ -373,10 +371,10 @@ def ql_syscall_getpeername(ql, sockfd, addr, addrlenptr, *args, **kw):
         regreturn = -1
 
     ql.log.debug("getpeername(%d, 0x%x, 0x%x) = %d" % (sockfd, addr, addrlenptr, regreturn))
-    return regreturn  
+    return regreturn
 
 
-def ql_syscall_listen(ql, listen_sockfd, listen_backlog, *args, **kw):
+def ql_syscall_listen(ql: Qiling, listen_sockfd, listen_backlog):
     if 0 <= listen_sockfd < NR_OPEN and ql.os.fd[listen_sockfd] != 0:
         try:
             ql.os.fd[listen_sockfd].listen(listen_backlog)
@@ -390,7 +388,7 @@ def ql_syscall_listen(ql, listen_sockfd, listen_backlog, *args, **kw):
     return regreturn
 
 
-def ql_syscall_accept(ql, accept_sockfd, accept_addr, accept_addrlen, *args, **kw):
+def ql_syscall_accept(ql: Qiling, accept_sockfd, accept_addr, accept_addrlen):
     def inet_addr(ip):
         ret = b''
         tmp = ip.split('.')
@@ -430,7 +428,7 @@ def ql_syscall_accept(ql, accept_sockfd, accept_addr, accept_addrlen, *args, **k
     return regreturn
 
 
-def ql_syscall_recv(ql, recv_sockfd, recv_buf, recv_len, recv_flags, *args, **kw):
+def ql_syscall_recv(ql: Qiling, recv_sockfd, recv_buf, recv_len, recv_flags):
     if 0 <= recv_sockfd < NR_OPEN and ql.os.fd[recv_sockfd] != 0:
         tmp_buf = ql.os.fd[recv_sockfd].recv(recv_len, recv_flags)
         if tmp_buf:
@@ -443,12 +441,12 @@ def ql_syscall_recv(ql, recv_sockfd, recv_buf, recv_len, recv_flags, *args, **kw
     return regreturn
 
 
-def ql_syscall_send(ql, send_sockfd, send_buf, send_len, send_flags, *args, **kw):
+def ql_syscall_send(ql: Qiling, send_sockfd, send_buf, send_len, send_flags):
     regreturn = 0
     if 0 <= send_sockfd < NR_OPEN and ql.os.fd[send_sockfd] != 0:
         try:
             ql.log.debug("debug send() start")
-            tmp_buf = ql.mem.read(send_buf, send_len)  
+            tmp_buf = ql.mem.read(send_buf, send_len)
             ql.log.debug("fd is " + str(send_sockfd))
             ql.log.debug("send() CONTENT:")
             ql.log.debug("%s" % str(tmp_buf))
@@ -465,13 +463,13 @@ def ql_syscall_send(ql, send_sockfd, send_buf, send_len, send_flags, *args, **kw
     return regreturn
 
 
-def ql_syscall_recvmsg(ql, sockfd, msg_addr, flags, *args, **kw):    
+def ql_syscall_recvmsg(ql: Qiling, sockfd, msg_addr, flags):
     regreturn = 0
     if  0 <= sockfd < NR_OPEN and ql.os.fd[sockfd] != 0:
         msg = msghdr.load(ql, msg_addr)
 
         try:
-            data, ancdata, mflags, addr = ql.os.fd[sockfd].recvmsg(msg.msg_namelen, msg.msg_controllen, flags)            
+            data, ancdata, mflags, addr = ql.os.fd[sockfd].recvmsg(msg.msg_namelen, msg.msg_controllen, flags)
 
             # TODO: handle the addr
 
@@ -481,7 +479,7 @@ def ql_syscall_recvmsg(ql, sockfd, msg_addr, flags, *args, **kw):
                 vec = iovec.load(ql, iovec_addr)
                 size = min(vec.iov_len, len(data) - has_written)
                 ql.mem.write(
-                    vec.iov_base, 
+                    vec.iov_base,
                     data[has_written: has_written + size]
                 )
                 iovec_addr += ctypes.sizeof(iovec)
@@ -493,13 +491,13 @@ def ql_syscall_recvmsg(ql, sockfd, msg_addr, flags, *args, **kw):
                 cmsg.cmsg_level = cmsg_level
                 cmsg.cmsg_type = cmsg_type
                 cmsg_data_addr = cmsg_addr + ctypes.sizeof(cmsghdr)
-                
+
                 ql.mem.write(cmsg_data_addr, cmsg_data)
                 ql.mem.write(cmsg_addr, bytes(cmsg))
 
                 cmsg_addr += cmsg.cmsg_len
 
-            msg.msg_flags = mflags            
+            msg.msg_flags = mflags
             ql.mem.write(msg_addr, bytes(msg))
 
             regreturn = len(data)
@@ -510,11 +508,11 @@ def ql_syscall_recvmsg(ql, sockfd, msg_addr, flags, *args, **kw):
 
     return regreturn
 
-def ql_syscall_recvfrom(ql, recvfrom_sockfd, recvfrom_buf, recvfrom_len, recvfrom_flags, recvfrom_addr, recvfrom_addrlen, *args, **kw):
+def ql_syscall_recvfrom(ql: Qiling, recvfrom_sockfd, recvfrom_buf, recvfrom_len, recvfrom_flags, recvfrom_addr, recvfrom_addrlen):
     # For x8664, recvfrom() is called finally when calling recv() in TCP communications
     SOCK_STREAM = 1
     if ql.os.fd[recvfrom_sockfd].socktype == SOCK_STREAM:
-        return ql_syscall_recv(ql, recvfrom_sockfd, recvfrom_buf, recvfrom_len, recvfrom_flags, *args, **kw)
+        return ql_syscall_recv(ql, recvfrom_sockfd, recvfrom_buf, recvfrom_len, recvfrom_flags)
     else:
         if 0 <= recvfrom_sockfd < NR_OPEN and ql.os.fd[recvfrom_sockfd] != 0:
             tmp_buf, tmp_addr = ql.os.fd[recvfrom_sockfd].recvfrom(recvfrom_len, recvfrom_flags)
@@ -543,11 +541,11 @@ def ql_syscall_recvfrom(ql, recvfrom_sockfd, recvfrom_buf, recvfrom_len, recvfro
         return regreturn
 
 
-def ql_syscall_sendto(ql, sendto_sockfd, sendto_buf, sendto_len, sendto_flags, sendto_addr, sendto_addrlen, *args, **kw):
+def ql_syscall_sendto(ql: Qiling, sendto_sockfd, sendto_buf, sendto_len, sendto_flags, sendto_addr, sendto_addrlen):
     # For x8664, sendto() is called finally when calling send() in TCP communications
     SOCK_STREAM = 1
     if ql.os.fd[sendto_sockfd].socktype == SOCK_STREAM:
-        return ql_syscall_send(ql, sendto_sockfd, sendto_buf, sendto_len, sendto_flags, *args, **kw)
+        return ql_syscall_send(ql, sendto_sockfd, sendto_buf, sendto_len, sendto_flags)
     else:
         regreturn = 0
         if 0 <= sendto_sockfd < NR_OPEN and ql.os.fd[sendto_sockfd] != 0:

--- a/qiling/os/posix/syscall/stat.py
+++ b/qiling/os/posix/syscall/stat.py
@@ -3,16 +3,14 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.os.posix.stat import *
-from qiling.os.posix.const import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-import struct
 import os
 import ctypes
+from typing import Callable
+
+from qiling import Qiling
+from qiling.const import QL_OS, QL_ARCH, QL_ENDIAN
+from qiling.os.posix.const import NR_OPEN, EBADF
+from qiling.os.posix.stat import Stat, Lstat
 
 # Caveat: Never use types like ctypes.c_long whose size differs across platforms.
 
@@ -879,7 +877,7 @@ class QNXARMStat64(ctypes.Structure):
 
     _pack_ = 8
 
-def get_stat64_struct(ql):
+def get_stat64_struct(ql: Qiling):
     if ql.archbit == 64:
         ql.log.warning(f"Trying to stat64 on a 64bit system with {ql.ostype} and {ql.archtype}!")
     if ql.ostype == QL_OS.LINUX:
@@ -896,7 +894,7 @@ def get_stat64_struct(ql):
     ql.log.warning(f"Unrecognized arch && os with {ql.archtype} and {ql.ostype} for stat64! Fallback to Linux x86.")
     return LinuxX86Stat64()
 
-def get_stat_struct(ql):
+def get_stat_struct(ql: Qiling):
     if ql.ostype == QL_OS.FREEBSD:
         if ql.archtype == QL_ARCH.X8664 or ql.archbit == 64:
             return FreeBSDX8664Stat()
@@ -935,108 +933,100 @@ def get_stat_struct(ql):
     ql.log.warning(f"Unrecognized arch && os with {ql.archtype} and {ql.ostype} for stat! Fallback to Linux x86.")
     return LinuxX86Stat()
 
-def pack_stat_struct(ql, info):
-    stat = get_stat_struct(ql)
+def __common_pack_stat_struct(stat, info) -> bytes:
     for field, _ in stat._fields_:
         val = stat.__getattribute__(field)
+
         if isinstance(val, ctypes.Array):
             stat.__setattr__(field, (0,) * len(val))
         else:
             stat.__setattr__(field, int(info[field]))
+
     return bytes(stat)
 
-def pack_stat64_struct(ql, info):
-    stat64 = get_stat64_struct(ql)
-    for field, _ in stat64._fields_:
-        val = stat64.__getattribute__(field)
-        if isinstance(val, ctypes.Array):
-            stat64.__setattr__(field, (0,) * len(val))
-        else:
-            stat64.__setattr__(field, int(info[field]))
-    return bytes(stat64)
 
-def statFamily(ql, path, ptr, name, stat_func, struct_func):
-    file = (ql.mem.string(path))
-    real_path = ql.os.path.transform_to_real_path(file)
+def pack_stat_struct(ql: Qiling, info):
+    stat = get_stat_struct(ql)
+
+    return __common_pack_stat_struct(stat, info)
+
+def pack_stat64_struct(ql: Qiling, info):
+    stat = get_stat64_struct(ql)
+
+    return __common_pack_stat_struct(stat, info)
+
+def statFamily(ql: Qiling, path: int, ptr: int, name: str, stat_func, struct_func: Callable):
+    file_path = ql.os.utils.read_cstring(path)
+    real_path = ql.os.path.transform_to_real_path(file_path)
     regreturn = 0
+
     try:
         info = stat_func(real_path)
     except OSError as e:
-        ql.log.debug(f'{name}("{file}", {hex(ptr)}) read/write fail')
+        ql.log.debug(f'{name}("{file_path}", {ptr:#x}) read/write fail')
         return -e.errno
     else:
         buf = struct_func(ql, info)
         ql.mem.write(ptr, buf)
-        ql.log.debug(f'{name}("{file}", {hex(ptr)}) write completed')
+        ql.log.debug(f'{name}("{file_path}", {ptr:#x}) write completed')
         return regreturn
 
-def ql_syscall_chmod(ql, filename, mode, null1, null2, null3, null4):
-    regreturn = 0
-    filename = ql.mem.string(filename)
-    ql.log.debug("chmod(%s,%d) = %d" % (filename, mode, regreturn))
-    return regreturn
+def ql_syscall_chmod(ql: Qiling, filename: int, mode: int):
+    ql.log.debug(f'chmod("{ql.os.utils.read_cstring(filename)}", {mode:d}) = 0')
 
-def ql_syscall_fchmod(ql, fd, mode, *args, **kw):
-    if not (0 < fd < NR_OPEN) or\
-            ql.os.fd[fd] == 0:
+    return 0
+
+def ql_syscall_fchmod(ql: Qiling, fd: int, mode: int):
+    if not (0 < fd < NR_OPEN) or ql.os.fd[fd] == 0:
         return -EBADF
 
-    regreturn = 0    
-    ql.log.debug("fchmod(%d, %d) = %d" % (fd, mode, regreturn))
-    return regreturn
+    return 0
 
-def ql_syscall_fstatat64(ql, fstatat64_dirfd, fstatat64_path, fstatat64_buf_ptr, fstatat64_flag, *args, **kw):
+def ql_syscall_fstatat64(ql: Qiling, dirfd: int, path: int, buf_ptr: int, flag: int):
     # FIXME: dirfd(relative path) not implement.
-    fstatat64_path = ql.mem.string(fstatat64_path)
+    file_path = ql.os.utils.read_cstring(path)
+    real_path = ql.os.path.transform_to_real_path(file_path)
+    relative_path = ql.os.path.transform_to_relative_path(file_path)
 
-    real_path = ql.os.path.transform_to_real_path(fstatat64_path)
-    relative_path = ql.os.path.transform_to_relative_path(fstatat64_path)
+    if os.path.exists(real_path):
+        buf = pack_stat64_struct(ql, Stat(real_path))
+        ql.mem.write(buf_ptr, buf)
 
-    regreturn = -1
-    if os.path.exists(real_path) == True:
-        fstatat64_info = Stat(real_path)
-        fstatat64_buf = pack_stat64_struct(ql, fstatat64_info)
-        ql.mem.write(fstatat64_buf_ptr, fstatat64_buf)
         regreturn = 0
-
-    if regreturn == 0:
-        ql.log.debug("Directory Found: %s" % relative_path)
     else:
-        ql.log.debug("Directory Not Found: %s" % relative_path)
-
-    return regreturn
-
-def ql_syscall_newfstatat(ql, newfstatat_dirfd, newfstatat_path, newfstatat_buf_ptr, newfstatat_flag, *args, **kw):
-    # FIXME: dirfd(relative path) not implement.
-    newfstatat_path = ql.mem.string(newfstatat_path)
-
-    real_path = ql.os.path.transform_to_real_path(newfstatat_path)
-    relative_path = ql.os.path.transform_to_relative_path(newfstatat_path)
-
-    regreturn = -1
-    if os.path.exists(real_path) == True:
-        newfstatat_info = Stat(real_path)
-        newfstatat_buf = pack_stat_struct(ql, newfstatat_info)
-        ql.mem.write(newfstatat_buf_ptr, newfstatat_buf)
-        regreturn = 0
-
-    if regreturn == 0:
-        ql.log.debug("Directory Found: %s" % relative_path)
-    else:
-        ql.log.debug("Directory Not Found: %s" % relative_path)
-
-    return regreturn
-
-def ql_syscall_fstat64(ql, fstat64_fd, fstat64_buf_ptr, *args, **kw):
-    if not hasattr(ql.os.fd[fstat64_fd], "fstat"):
         regreturn = -1
-    elif ql.os.fd[fstat64_fd].fstat() == -1:
+
+    ql.log.debug(f'Directory {"found" if regreturn == 0 else "not found"}: {relative_path}')
+
+    return regreturn
+
+def ql_syscall_newfstatat(ql: Qiling, dirfd: int, path: int, buf_ptr: int, flag: int):
+    # FIXME: dirfd(relative path) not implement.
+    file_path = ql.os.utils.read_cstring(path)
+    real_path = ql.os.path.transform_to_real_path(file_path)
+    relative_path = ql.os.path.transform_to_relative_path(file_path)
+
+    if os.path.exists(real_path):
+        buf = pack_stat_struct(ql, Stat(real_path))
+        ql.mem.write(buf_ptr, buf)
+
         regreturn = 0
-    elif 0 <= fstat64_fd < NR_OPEN and ql.os.fd[fstat64_fd] != 0:
-        user_fileno = fstat64_fd
-        fstat64_info = ql.os.fd[user_fileno].fstat()
-        fstat64_buf = pack_stat64_struct(ql, fstat64_info)
-        ql.mem.write(fstat64_buf_ptr, fstat64_buf)
+    else:
+        regreturn = -1
+
+    ql.log.debug(f'Directory {"found" if regreturn == 0 else "not found"}: {relative_path}')
+
+    return regreturn
+
+def ql_syscall_fstat64(ql: Qiling, fd, buf_ptr):
+    if not hasattr(ql.os.fd[fd], "fstat"):
+        regreturn = -1
+    elif ql.os.fd[fd].fstat() == -1:
+        regreturn = 0
+    elif 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
+        buf = pack_stat64_struct(ql, ql.os.fd[fd].fstat())
+        ql.mem.write(buf_ptr, buf)
+
         regreturn = 0
     else:
         regreturn = -1
@@ -1045,15 +1035,19 @@ def ql_syscall_fstat64(ql, fstat64_fd, fstat64_buf_ptr, *args, **kw):
         ql.log.debug("fstat64 write completed")
     else:
         ql.log.debug("fstat64 read/write fail")
+
     return regreturn
 
 
-def ql_syscall_fstat(ql, fstat_fd, fstat_buf_ptr, *args, **kw):
-    if 0 <= fstat_fd < NR_OPEN and ql.os.fd[fstat_fd] != 0 and hasattr(ql.os.fd[fstat_fd], "fstat"):
-        user_fileno = fstat_fd
-        fstat_info = ql.os.fd[user_fileno].fstat()
-        fstat_buf = pack_stat_struct(ql, fstat_info)
-        ql.mem.write(fstat_buf_ptr, fstat_buf)
+def ql_syscall_fstat(ql: Qiling, fd, buf_ptr):
+    if not hasattr(ql.os.fd[fd], "fstat"):
+        regreturn = -1
+    # elif ql.os.fd[fd].fstat() == -1:
+    #     regreturn = 0
+    elif 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
+        buf = pack_stat_struct(ql,  ql.os.fd[fd].fstat())
+        ql.mem.write(buf_ptr, buf)
+
         regreturn = 0
     else:
         regreturn = -1
@@ -1062,96 +1056,95 @@ def ql_syscall_fstat(ql, fstat_fd, fstat_buf_ptr, *args, **kw):
         ql.log.debug("fstat write completed")
     else:
         ql.log.debug("fstat read/write fail")
+
     return regreturn
 
 
 # int stat(const char *path, struct stat *buf);
-def ql_syscall_stat(ql, stat_path, stat_buf_ptr, *args, **kw):
-    return statFamily(ql, stat_path, stat_buf_ptr, "stat", Stat, pack_stat_struct)
+def ql_syscall_stat(ql: Qiling, path: int, buf_ptr: int):
+    return statFamily(ql, path, buf_ptr, "stat", Stat, pack_stat_struct)
 
 
 # int stat64(const char *path, struct stat64 *buf);
-def ql_syscall_stat64(ql, stat64_path, stat64_buf_ptr, *args, **kw):
-    return statFamily(ql, stat64_path, stat64_buf_ptr, "stat64", Stat, pack_stat64_struct)
+def ql_syscall_stat64(ql: Qiling, path: int, buf_ptr: int):
+    return statFamily(ql, path, buf_ptr, "stat64", Stat, pack_stat64_struct)
 
 
-def ql_syscall_lstat(ql, lstat_path, lstat_buf_ptr, *args, **kw):
-    return statFamily(ql, lstat_path, lstat_buf_ptr, "lstat", Lstat, pack_stat64_struct)
+def ql_syscall_lstat(ql: Qiling, path: int, buf_ptr: int):
+    return statFamily(ql, path, buf_ptr, "lstat", Lstat, pack_stat64_struct)
 
 
-def ql_syscall_lstat64(ql, lstat64_path, lstat64_buf_ptr, *args, **kw):
-    return statFamily(ql, lstat64_path, lstat64_buf_ptr, "lstat64", Lstat, pack_stat64_struct)
+def ql_syscall_lstat64(ql: Qiling, path: int, buf_ptr: int):
+    return statFamily(ql, path, buf_ptr, "lstat64", Lstat, pack_stat64_struct)
 
 
-def ql_syscall_mknodat(ql, dirfd, pathname, mode, dev, *args, **kw):
+def ql_syscall_mknodat(ql: Qiling, dirfd: int, pathname: int, mode: int, dev: int):
     # FIXME: dirfd(relative path) not implement.
-    file_path = ql.mem.string(pathname)
+    file_path = ql.os.utils.read_cstring(pathname)
     real_path = ql.os.path.transform_to_real_path(file_path)
-    ql.log.debug("mknodat(%d, %s, 0%o, %d)" % (dirfd, real_path, mode, dev))
+    regreturn = 0
+
     try:
         os.mknod(real_path, mode, dev)
-        regreturn = 0
     except:
         regreturn = -1
+
     return regreturn
 
 
-def ql_syscall_mkdir(ql, pathname, mode, *args, **kw):
-    file_path = ql.mem.string(pathname)
+def ql_syscall_mkdir(ql: Qiling, pathname: int, mode: int):
+    file_path = ql.os.utils.read_cstring(pathname)
     real_path = ql.os.path.transform_to_real_path(file_path)
-    ql.log.debug("mkdir(%s, 0%o)" % (real_path, mode))
+    regreturn = 0
+
     try:
         if not os.path.exists(real_path):
             os.mkdir(real_path, mode)
-        regreturn = 0
     except:
         regreturn = -1
+
     return regreturn
 
-def ql_syscall_rmdir(ql, pathname, *args, **kw):
-    file_path = ql.mem.string(pathname)
+def ql_syscall_rmdir(ql: Qiling, pathname: int):
+    file_path = ql.os.utils.read_cstring(pathname)
     real_path = ql.os.path.transform_to_real_path(file_path)
-    ql.log.debug("rmdir(%s)" % (real_path))
+    regreturn = 0
+
     try:
         if os.path.exists(real_path):
             os.rmdir(real_path)
-        regreturn = 0
     except:
         regreturn = -1
+
     return regreturn
 
-def ql_syscall_fstatfs(ql, fd, buf, *args, **kw):
-    data = b"0" * (12*8)  # for now, just return 0s
-    regreturn = None
+def ql_syscall_fstatfs(ql: Qiling, fd: int, buf: int):
+    data = b"0" * (12 * 8)  # for now, just return 0s
+    regreturn = 0
+
     try:
         ql.mem.write(buf, data)
-        regreturn = 0
     except:
         regreturn = -1
-
-    ql.log.info("fstatfs(0x%x, 0x%x) = %d" % (fd, buf, regreturn))
 
     if data:
         ql.log.debug("fstatfs() CONTENT:")
         ql.log.debug(str(data))
+
     return regreturn
 
-def ql_syscall_statfs(ql, path, buf, *args, **kw):
-    data = b"0" * (12*8)  # for now, just return 0s
-    regreturn = None
+def ql_syscall_statfs(ql: Qiling, path: int, buf: int):
+    data = b"0" * (12 * 8)  # for now, just return 0s
+    regreturn = 0
+
     try:
         ql.mem.write(buf, data)
-        regreturn = 0
     except:
         regreturn = -1
 
-    ql.log.info("statfs(0x%x, 0x%x) = %d" % (path, buf, regreturn))
-    
     return regreturn
 
-
-def ql_syscall_umask(ql, mode, *args, **kw):
+def ql_syscall_umask(ql: Qiling, mode: int):
     oldmask = os.umask(mode)
-    ql.log.debug("umask(0%o) return oldmask 0%o" % (mode, oldmask))
-    regreturn = oldmask
-    return regreturn
+
+    return oldmask

--- a/qiling/os/posix/syscall/sysctl.py
+++ b/qiling/os/posix/syscall/sysctl.py
@@ -3,15 +3,7 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-
-# def ql_syscall___sysctl(ql, sysctl_name, sysctl_namelen, sysctl_bytes_oldlenp, sysctl_size_oldlenp, sysctl_bytes_newlen, sysctl_size_newlen):
-#     regreturn = 0
-#     return regreturn
+# from qiling import Qiling
+#
+# def ql_syscall___sysctl(ql: Qiling, name, namelen, bytes_oldlenp, size_oldlenp, bytes_newlen, size_newlen):
+#     return 0

--- a/qiling/os/posix/syscall/sysinfo.py
+++ b/qiling/os/posix/syscall/sysinfo.py
@@ -3,37 +3,31 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import struct
+from qiling import Qiling
 
+def ql_syscall_sysinfo(ql: Qiling, info: int):
+    # TODO: the packing method for 'long' fields is set to ql.pack even though
+    # it is unclear whether it should match pointersize or be 64 bits anyway
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-
-def ql_syscall_sysinfo(ql, sysinfo_info, *args, **kw):
-
-    data = b''
-    data += struct.pack("QQQQQQQQQQHQQI",
-                       0x1234, # uptime
-                       0x2000, # loads (1 min)
-                       0x2000, # loads (5 min)
-                       0x2000, # loads (15 min)
-                       0x10000000, # total ram
-                       0x10000000, # free ram
-                       0x10000000, # shared memory
-                       0x0, # memory used by buffers
-                       0x0, # total swap
-                       0x0, # free swap
-                       0x1, # nb current processes
-                       0x0, # total high mem
-                       0x0, # available high mem
-                       0x1, # memory unit size
+    fields = (
+        (0x0000000000001234, ql.pack),   # uptime
+        (0x0000000000002000, ql.pack),   # loads (1 min)
+        (0x0000000000002000, ql.pack),   # loads (5 min)
+        (0x0000000000002000, ql.pack),   # loads (15 min)
+        (0x0000000010000000, ql.pack),   # total ram
+        (0x0000000010000000, ql.pack),   # free ram
+        (0x0000000010000000, ql.pack),   # shared memory
+        (0x0000000000000000, ql.pack),   # memory used by buffers
+        (0x0000000000000000, ql.pack),   # total swap
+        (0x0000000000000000, ql.pack),   # free swap
+        (0x0001,             ql.pack16), # nb current processes
+        (0x0000000000000000, ql.pack),   # total high mem
+        (0x0000000000000000, ql.pack),   # available high mem
+        (0x00000000,         ql.pack32)  # memory unit size
     )
 
-    regreturn = 0
-    #ql.mem.write(sysinfo_info, data)
-    return regreturn
+    data = b''.join(pmethod(val) for val, pmethod in fields)
+
+    ql.mem.write(info, data.ljust(64, b'\x00'))
+
+    return 0

--- a/qiling/os/posix/syscall/time.py
+++ b/qiling/os/posix/syscall/time.py
@@ -3,96 +3,57 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+import os
 import time
+import gevent
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
+from qiling import Qiling
 
-def ql_syscall_time(ql, *args, **kw):
-    regreturn = int(time.time())
-    return regreturn
+def ql_syscall_time(ql: Qiling):
+    return int(time.time())
 
-def ql_syscall_clock_nanosleep_time64(ql, nanosleep_clk_id, nanosleep_flags, nanosleep_req, nanosleep_rem, *args, **kw):
-    def _sched_sleep(cur_thread):
-        gevent.sleep(tv_sec)
-
+def __sleep_common(ql: Qiling, req: int, rem: int) -> int:
     n = ql.pointersize
 
-    tv_sec = ql.unpack(ql.mem.read(nanosleep_req, n))
-    tv_sec += ql.unpack(ql.mem.read(nanosleep_req + n, n)) / 1000000000
+    tv_sec = ql.unpack(ql.mem.read(req, n))
+    tv_sec += ql.unpack(ql.mem.read(req + n, n)) / 1000000000
 
-    if ql.os.thread_management == None:
-        time.sleep(tv_sec)
-    else:
+    if ql.os.thread_management:
+        def _sched_sleep(cur_thread):
+            gevent.sleep(tv_sec)
+
         ql.emu_stop()
         ql.os.thread_management.cur_thread.sched_cb = _sched_sleep
+
+        # FIXME: this seems to be incomplete
         th = ql.os.thread_management.cur_thread
-
-    regreturn = 0
-    return regreturn
-
-
-def ql_syscall_nanosleep(ql, nanosleep_req, nanosleep_rem, *args, **kw):
-    def _sched_sleep(cur_thread):
-        gevent.sleep(tv_sec)
-
-    n = ql.pointersize
-
-    tv_sec = ql.unpack(ql.mem.read(nanosleep_req, n))
-    tv_sec += ql.unpack(ql.mem.read(nanosleep_req + n, n)) / 1000000000
-
-    if ql.os.thread_management == None:
-        time.sleep(tv_sec)
     else:
-        ql.emu_stop()
-        ql.os.thread_management.cur_thread.sched_cb = _sched_sleep
-        th = ql.os.thread_management.cur_thread
-
-    regreturn = 0
-    return regreturn
-
-def ql_syscall_clock_nanosleep(ql, clock_nanosleep_clockid, clock_nanosleep_flags, clock_nanosleep_req, clock_nanosleep_remain, *args, **kw):
-    def _sched_sleep(cur_thread):
-        gevent.sleep(tv_sec)
-
-    n = ql.pointersize
-
-    tv_sec = ql.unpack(ql.mem.read(clock_nanosleep_req, n))
-    tv_sec += ql.unpack(ql.mem.read(clock_nanosleep_req + n, n)) / 1000000000
-
-    if ql.os.thread_management == None:
         time.sleep(tv_sec)
-    else:
-        ql.emu_stop()
-        ql.os.thread_management.cur_thread.sched_cb = _sched_sleep
-        th = ql.os.thread_management.cur_thread
 
-    regreturn = 0
-    return regreturn
+    return 0
 
+def ql_syscall_clock_nanosleep_time64(ql: Qiling, clk_id: int, flags: int, req: int, rem: int):
+    return __sleep_common(ql, req, rem)
 
-def ql_syscall_setitimer(ql, setitimer_which, setitimer_new_value, setitimer_old_value, *args, **kw):
+def ql_syscall_nanosleep(ql: Qiling, req: int, rem: int):
+    return __sleep_common(ql, req, rem)
+
+def ql_syscall_clock_nanosleep(ql: Qiling, clockid: int, flags: int, req: int, rem: int):
+    return __sleep_common(ql, req, rem)
+
+def ql_syscall_setitimer(ql: Qiling, which: int, new_value: int, old_value: int):
     # TODO:The system provides each process with three interval timers, each decrementing in a distinct time domain.
     # When any timer expires, a signal is sent to the process, and the timer (potentially) restarts.
     # But I haven’t figured out how to send a signal yet.
-    regreturn = 0
-    return regreturn
 
+    return 0
 
-def ql_syscall_times(ql, times_tbuf, *args, **kw):
-    tmp_times = os.times()
-    if times_tbuf != 0:
-        tmp_buf = b''
-        tmp_buf += ql.pack32(int(tmp_times.user * 1000))
-        tmp_buf += ql.pack32(int(tmp_times.system * 1000))
-        tmp_buf += ql.pack32(int(tmp_times.children_user * 1000))
-        tmp_buf += ql.pack32(int(tmp_times.children_system * 1000))
-        ql.mem.write(times_tbuf, tmp_buf)
-    regreturn = int(tmp_times.elapsed * 100)
-    return regreturn
+def ql_syscall_times(ql: Qiling, tbuf: int):
+    times = os.times()
 
+    if tbuf:
+        fields = (times.user, times.system, times.children_user, times.children_system)
+
+        ql.mem.write(tbuf, b''.join(ql.pack32(int(f * 1000)) for f in fields))
+
+    return int(times.elapsed * 100)

--- a/qiling/os/posix/syscall/types.py
+++ b/qiling/os/posix/syscall/types.py
@@ -3,22 +3,16 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from qiling import Qiling
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-
-def ql_syscall_gettid(ql, *args, **kw):
+def ql_syscall_gettid(ql: Qiling):
     if ql.os.thread_management:
-      th = ql.os.thread_management.cur_thread
-      regreturn = th.id
+        th = ql.os.thread_management.cur_thread
+        regreturn = th.id
     else:
-      # thread_management is None only if it is a single-threaded process.
-      # In single-threaded process, the thread ID is equal to the process ID
-      # per Posix documentation.
-      regreturn = ql.os.pid
+        # thread_management is None only if it is a single-threaded process.
+        # In single-threaded process, the thread ID is equal to the process ID
+        # per Posix documentation.
+        regreturn = ql.os.pid
+
     return regreturn

--- a/qiling/os/posix/syscall/uio.py
+++ b/qiling/os/posix/syscall/uio.py
@@ -3,53 +3,40 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from qiling import Qiling
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-
-def ql_syscall_writev(ql, writev_fd, writev_vec, writev_vien, *args, **kw):
+def ql_syscall_writev(ql: Qiling, fd: int, vec: int, vlen: int):
     regreturn = 0
     size_t_len = ql.pointersize
-    iov = ql.mem.read(writev_vec, writev_vien * size_t_len * 2)
-    ql.log.debug("writev() CONTENT:")
+    iov = ql.mem.read(vec, vlen * size_t_len * 2)
+    ql.log.debug('writev() CONTENT:')
 
-    for i in range(writev_vien):
+    for i in range(vlen):
         addr = ql.unpack(iov[i * size_t_len * 2 : i * size_t_len * 2 + size_t_len])
         l = ql.unpack(iov[i * size_t_len * 2 + size_t_len : i * size_t_len * 2 + size_t_len * 2])
         regreturn += l
+
         buf = ql.mem.read(addr, l)
         ql.log.debug(buf)
 
-        if hasattr(ql.os.fd[writev_fd], "write"):
-            ql.os.fd[writev_fd].write(buf)
+        if hasattr(ql.os.fd[fd], 'write'):
+            ql.os.fd[fd].write(buf)
 
     return regreturn
 
 
-def ql_syscall_readv(ql, fd, vec, vlen, *args, **kw):
+def ql_syscall_readv(ql: Qiling, fd: int, vec: int, vlen: int):
     regreturn = 0
     size_t_len = ql.pointersize
     iov = ql.mem.read(vec, vlen * size_t_len * 2)
-    ql.log.debug("readv() CONTENT:")
+    ql.log.debug('readv() CONTENT:')
 
     for i in range(vlen):
-        addr = ql.unpack(
-            iov[i * size_t_len * 2 : i * size_t_len * 2 + size_t_len]
-        )
-        l = ql.unpack(
-            iov[
-                i * size_t_len * 2
-                + size_t_len : i * size_t_len * 2
-                + size_t_len * 2
-            ]
-        )
+        addr = ql.unpack(iov[i * size_t_len * 2 : i * size_t_len * 2 + size_t_len])
+        l = ql.unpack(iov[i * size_t_len * 2 + size_t_len : i * size_t_len * 2 + size_t_len * 2])
         regreturn += l
-        if hasattr(ql.os.fd[fd], "read"):
+
+        if hasattr(ql.os.fd[fd], 'read'):
             data = ql.os.fd[fd].read(l)
             ql.log.debug(data)
             ql.mem.write(addr, data)

--- a/qiling/os/posix/syscall/uio.py
+++ b/qiling/os/posix/syscall/uio.py
@@ -17,7 +17,7 @@ def ql_syscall_writev(ql: Qiling, fd: int, vec: int, vlen: int):
         regreturn += l
 
         buf = ql.mem.read(addr, l)
-        ql.log.debug(buf)
+        ql.log.debug(f'{buf.decode()!r}')
 
         if hasattr(ql.os.fd[fd], 'write'):
             ql.os.fd[fd].write(buf)
@@ -38,7 +38,7 @@ def ql_syscall_readv(ql: Qiling, fd: int, vec: int, vlen: int):
 
         if hasattr(ql.os.fd[fd], 'read'):
             data = ql.os.fd[fd].read(l)
-            ql.log.debug(data)
+            ql.log.debug(f'{data.decode()!r}')
             ql.mem.write(addr, data)
 
     return regreturn

--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -248,7 +248,7 @@ def ql_syscall_read(ql: Qiling, fd, buf: int, length: int):
             data = ql.os.fd[fd].read(length)
             ql.mem.write(buf, data)
 
-            ql.log.debug(f'read() CONTENT: {data}')
+            ql.log.debug(f'read() CONTENT: {repr(data.decode())}')
             regreturn = len(data)
         except:
             regreturn = -EBADF
@@ -263,7 +263,7 @@ def ql_syscall_write(ql: Qiling, fd: int, buf: int, count: int):
         data = ql.mem.read(buf, count)
 
         if data:
-            ql.log.debug(f'write() CONTENT: {data}')
+            ql.log.debug(f'write() CONTENT: {repr(data.decode())}')
 
         if hasattr(ql.os.fd[fd], 'write'):
             ql.os.fd[fd].write(data)

--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -248,7 +248,7 @@ def ql_syscall_read(ql: Qiling, fd, buf: int, length: int):
             data = ql.os.fd[fd].read(length)
             ql.mem.write(buf, data)
 
-            ql.log.debug(f'read() CONTENT: {repr(data.decode())}')
+            ql.log.debug(f'read() CONTENT: {data.decode()!r}')
             regreturn = len(data)
         except:
             regreturn = -EBADF
@@ -263,7 +263,7 @@ def ql_syscall_write(ql: Qiling, fd: int, buf: int, count: int):
         data = ql.mem.read(buf, count)
 
         if data:
-            ql.log.debug(f'write() CONTENT: {repr(data.decode())}')
+            ql.log.debug(f'write() CONTENT: {data.decode()!r}')
 
         if hasattr(ql.os.fd[fd], 'write'):
             ql.os.fd[fd].write(data)

--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -3,22 +3,22 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import stat, itertools, pathlib, ctypes
+import os
+import stat
+import itertools
+import pathlib
 
+from typing import Iterator
 from multiprocessing import Process
 
-
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
+from qiling import Qiling
+from qiling.const import QL_ARCH, QL_OS, QL_VERBOSE
+from qiling.os.posix.filestruct import ql_pipe
 from qiling.os.posix.const import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-from qiling.os.posix.stat import *
+from qiling.os.posix.stat import Stat
 from qiling.core_hooks import QlCoreHooks
 
-def ql_syscall_exit(ql, exit_code, *args, **kw):
+def ql_syscall_exit(ql: Qiling, code: int):
     if ql.os.child_processes == True:
         os._exit(0)
 
@@ -26,16 +26,17 @@ def ql_syscall_exit(ql, exit_code, *args, **kw):
         def _sched_cb_exit(cur_thread):
             ql.log.debug(f"[Thread {cur_thread.get_id()}] Terminated")
             cur_thread.stop()
-            cur_thread.exit_code = exit_code
+            cur_thread.exit_code = code
+
         td = ql.os.thread_management.cur_thread
         ql.emu_stop()
         td.sched_cb = _sched_cb_exit
     else:
-        ql.os.exit_code = exit_code
+        ql.os.exit_code = code
         ql.os.stop()
 
 
-def ql_syscall_exit_group(ql, exit_code, *args, **kw):
+def ql_syscall_exit_group(ql: Qiling, code: int):
     if ql.os.child_processes == True:
         os._exit(0)
 
@@ -43,338 +44,338 @@ def ql_syscall_exit_group(ql, exit_code, *args, **kw):
         def _sched_cb_exit(cur_thread):
             ql.log.debug(f"[Thread {cur_thread.get_id()}] Terminated")
             cur_thread.stop()
-            cur_thread.exit_code = exit_code
+            cur_thread.exit_code = code
+
         td = ql.os.thread_management.cur_thread
         ql.emu_stop()
         td.sched_cb = _sched_cb_exit
     else:
-        ql.os.exit_code = exit_code
+        ql.os.exit_code = code
         ql.os.stop()
 
 
-def ql_syscall_alarm(ql, alarm_seconds, *args, **kw):
+def ql_syscall_alarm(ql: Qiling, seconds: int):
     return 0
 
 
-def ql_syscall_issetugid(ql, *args, **kw):
+def ql_syscall_issetugid(ql: Qiling):
     return 0
 
 
-def ql_syscall_getuid(ql, *args, **kw):
+def ql_syscall_getuid(ql: Qiling):
     return 0
 
 
-def ql_syscall_getuid32(ql, *args, **kw):
+def ql_syscall_getuid32(ql: Qiling):
     return 0
 
 
-def ql_syscall_getgid32(ql, *args, **kw):
+def ql_syscall_getgid32(ql: Qiling):
     return 0
 
 
-def ql_syscall_geteuid(ql, *args, **kw):
+def ql_syscall_geteuid(ql: Qiling):
     return 0
 
 
-def ql_syscall_getegid(ql, *args, **kw):
+def ql_syscall_getegid(ql: Qiling):
     return 0
 
 
-def ql_syscall_getgid(ql, *args, **kw):
+def ql_syscall_getgid(ql: Qiling):
     return 0
 
 
-def ql_syscall_setgroups(ql, gidsetsize, grouplist, *args, **kw):
+def ql_syscall_setgroups(ql: Qiling, gidsetsize: int, grouplist: int):
     return 0
 
 
-def ql_syscall_setgid(ql, *args, **kw):
+def ql_syscall_setgid(ql: Qiling):
     return 0
 
 
-def ql_syscall_setgid32(ql, *args, **kw):
-    return 0   
-
-
-def ql_syscall_setuid(ql, *args, **kw):
+def ql_syscall_setgid32(ql: Qiling):
     return 0
 
-def ql_syscall_setresuid(ql, *args, **kw):
+
+def ql_syscall_setuid(ql: Qiling):
     return 0
 
-def ql_syscall_setresgid(ql, *args, **kw):
+def ql_syscall_setresuid(ql: Qiling):
     return 0
 
-def ql_syscall_capget(ql, hdrp, datap, *args, **kw):
+def ql_syscall_setresgid(ql: Qiling):
     return 0
 
-def ql_syscall_capset(ql, hdrp, datap, *args, **kw):
+def ql_syscall_capget(ql: Qiling, hdrp: int, datap: int):
     return 0
 
-def ql_syscall_kill(ql, pid, sig, *args, **kw):
+def ql_syscall_capset(ql: Qiling, hdrp: int, datap: int):
     return 0
 
-def ql_syscall_faccessat(ql, faccessat_dfd, faccessat_filename, faccessat_mode, *args, **kw):
+def ql_syscall_kill(ql: Qiling, pid: int, sig: int):
+    return 0
 
-    access_path = ql.mem.string(faccessat_filename)
+def ql_syscall_faccessat(ql: Qiling, dfd: int, filename: int, mode: int):
+    access_path = ql.os.utils.read_cstring(filename)
     real_path = ql.os.path.transform_to_real_path(access_path)
-    relative_path = ql.os.path.transform_to_relative_path(access_path)
 
-    regreturn = -1
-    if os.path.exists(real_path) == False:
+    if not os.path.exists(real_path):
         regreturn = -1
+
     elif stat.S_ISFIFO(Stat(real_path).st_mode):
         regreturn = 0
+
     else:
         regreturn = -1
 
     if regreturn == -1:
-        ql.log.debug("File Not Found or Skipped: %s" % access_path)
+        ql.log.debug(f'File not found or skipped: {access_path}')
     else:
-        ql.log.debug("File Found: %s" % access_path)
+        ql.log.debug(f'File found: {access_path}')
+
     return regreturn
 
 
-def ql_syscall_lseek(ql, lseek_fd, lseek_ofset, lseek_origin, *args, **kw):
-    lseek_ofset = ql.unpacks(ql.pack(lseek_ofset))
-    regreturn = 0
+def ql_syscall_lseek(ql: Qiling, fd: int, offset: int, lseek_origin: int):
+    if 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
+        offset = ql.unpacks(ql.pack(offset))
 
-    if 0 <= lseek_fd < NR_OPEN and ql.os.fd[lseek_fd] != 0:        
         try:
-            regreturn = ql.os.fd[lseek_fd].lseek(lseek_ofset, lseek_origin)
+            regreturn = ql.os.fd[fd].lseek(offset, lseek_origin)
         except OSError:
             regreturn = -1
+        else:
+            regreturn = 0
     else:
         regreturn = -EBADF
 
-    ql.log.debug("lseek(fd = %d, ofset = 0x%x, origin = 0x%x) = %d" % (lseek_fd, lseek_ofset, lseek_origin, regreturn))
+    # ql.log.debug("lseek(fd = %d, ofset = 0x%x, origin = 0x%x) = %d" % (lseek_fd, lseek_ofset, lseek_origin, regreturn))
+
     return regreturn
 
 
-def ql_syscall__llseek(ql, fd, offset_high, offset_low, result, whence, *args, **kw):
-    offset = offset_high << 32 | offset_low
+def ql_syscall__llseek(ql: Qiling, fd: int, offset_high: int, offset_low: int, result: int, whence: int):
+    offset = (offset_high << 32) | offset_low
     origin = whence
-    regreturn = 0
+
     try:
         ret = ql.os.fd[fd].lseek(offset, origin)
     except OSError:
         regreturn = -1
-    #regreturn = 0 if ret >= 0 else -1
-    if regreturn == 0:
+    else:
         ql.mem.write(result, ql.pack64(ret))
+        regreturn = 0
 
-    ql.log.debug("_llseek(%d, 0x%x, 0x%x, 0x%x) = %d" % (fd, offset_high, offset_low, origin, regreturn))
+    # ql.log.debug("_llseek(%d, 0x%x, 0x%x, 0x%x) = %d" % (fd, offset_high, offset_low, origin, regreturn))
+
     return regreturn
 
 
-def ql_syscall_brk(ql, brk_input, *args, **kw):
-    # current brk_address will be modified if brk_input is not NULL(zero)
+def ql_syscall_brk(ql: Qiling, inp: int):
+    # current brk_address will be modified if inp is not NULL(zero)
     # otherwise, just return current brk_address
 
-    if brk_input != 0:
-        new_brk_addr = ((brk_input + 0xfff) // 0x1000) * 0x1000
+    if inp:
+        new_brk_addr = ((inp + 0xfff) // 0x1000) * 0x1000
 
-        if brk_input > ql.loader.brk_address: # increase current brk_address if brk_input is greater
+        if inp > ql.loader.brk_address: # increase current brk_address if inp is greater
             ql.mem.map(ql.loader.brk_address, new_brk_addr - ql.loader.brk_address, info="[brk]")
 
-        elif brk_input < ql.loader.brk_address: # shrink current bkr_address to brk_input if its smaller
+        elif inp < ql.loader.brk_address: # shrink current bkr_address to inp if its smaller
             ql.mem.unmap(new_brk_addr, ql.loader.brk_address - new_brk_addr)
 
         ql.loader.brk_address = new_brk_addr
 
-    regreturn = ql.loader.brk_address
-
-    ql.log.debug("brk return(0x%x)" % regreturn)
-    return regreturn
+    return ql.loader.brk_address
 
 
-def ql_syscall_access(ql, access_path, access_mode, *args, **kw):
-    path = (ql.mem.string(access_path))
+def ql_syscall_access(ql: Qiling, path: int, mode: int):
+    file_path = ql.os.utils.read_cstring(path)
+    real_path = ql.os.path.transform_to_real_path(file_path)
+    relative_path = ql.os.path.transform_to_relative_path(file_path)
 
-    real_path = ql.os.path.transform_to_real_path(path)
-    relative_path = ql.os.path.transform_to_relative_path(path)
+    regreturn = 0 if os.path.exists(real_path) else -1
 
-    if os.path.exists(real_path) == False:
-        regreturn = -1
-    else:
-        regreturn = 0
+    # ql.log.debug("access(%s, 0x%x) = %d " % (relative_path, access_mode, regreturn))
 
-    ql.log.debug("access(%s, 0x%x) = %d " % (relative_path, access_mode, regreturn))
     if regreturn == 0:
-        ql.log.debug("File found: %s" % relative_path)
+        ql.log.debug(f'File found: {relative_path}')
     else:
-        ql.log.debug("No such file or directory")
+        ql.log.debug(f'No such file or directory: {relative_path}')
 
     return regreturn
 
 
-def ql_syscall_close(ql, close_fd, *args, **kw):
-    regreturn = -1
-    if 0 <= close_fd < NR_OPEN and ql.os.fd[close_fd] != 0:
-        ql.os.fd[close_fd].close()
-        ql.os.fd[close_fd] = 0
+def ql_syscall_close(ql: Qiling, fd: int):
+    if 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
+        ql.os.fd[fd].close()
+        ql.os.fd[fd] = 0
         regreturn = 0
+    else:
+        regreturn = -1
+
     return regreturn
 
 
-def ql_syscall_pread64(ql, read_fd, read_buf, read_len, read_offt, *args, **kw):
-    data = None
-
+def ql_syscall_pread64(ql: Qiling, fd: int, buf: int, length: int, offt: int):
     # https://chromium.googlesource.com/linux-syscall-support/+/2c73abf02fd8af961e38024882b9ce0df6b4d19b
     # https://chromiumcodereview.appspot.com/10910222
     if ql.archtype == QL_ARCH.MIPS:
-        read_offt = ql.unpack64(ql.mem.read(ql.reg.arch_sp + 0x10, size=0x08))
+        offt = ql.unpack64(ql.mem.read(ql.reg.arch_sp + 0x10, 8))
 
-    if 0 <= read_fd < NR_OPEN and ql.os.fd[read_fd] != 0:
+    if 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
         try:
-            pos = ql.os.fd[read_fd].tell()
-            ql.os.fd[read_fd].lseek(read_offt)
-            data = ql.os.fd[read_fd].read(read_len)
-            ql.os.fd[read_fd].lseek(pos)
-            ql.mem.write(read_buf, data)
+            pos = ql.os.fd[fd].tell()
+            ql.os.fd[fd].lseek(offt)
+
+            data = ql.os.fd[fd].read(length)
+            ql.os.fd[fd].lseek(pos)
+
+            ql.mem.write(buf, data)
             regreturn = len(data)
         except:
             regreturn = -1
     else:
         regreturn = -1
+
     return regreturn
 
 
-def ql_syscall_read(ql, read_fd, read_buf, read_len, *args, **kw):
-    data = None
-    if 0 <= read_fd < NR_OPEN and ql.os.fd[read_fd] != 0:
+def ql_syscall_read(ql: Qiling, fd, buf: int, length: int):
+    if 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
         try:
-            data = ql.os.fd[read_fd].read(read_len)
-            ql.mem.write(read_buf, data)
+            data = ql.os.fd[fd].read(length)
+            ql.mem.write(buf, data)
+
+            ql.log.debug(f'read() CONTENT: {data}')
             regreturn = len(data)
         except:
             regreturn = -EBADF
     else:
         regreturn = -EBADF
 
-    if data:
-        ql.log.debug("read() CONTENT:")
-        ql.log.debug("%s" % data)
     return regreturn
 
 
-def ql_syscall_write(ql, write_fd, write_buf, write_count, *args, **kw):
-    regreturn = 0
-    buf = None
-
+def ql_syscall_write(ql: Qiling, fd: int, buf: int, count: int):
     try:
-        buf = ql.mem.read(write_buf, write_count)
-        if buf:
-            ql.log.debug("write() CONTENT:")
-            ql.log.debug("%s" % buf)
+        data = ql.mem.read(buf, count)
 
-        if hasattr(ql.os.fd[write_fd], "write"):
-            ql.os.fd[write_fd].write(buf)
+        if data:
+            ql.log.debug(f'write() CONTENT: {data}')
+
+        if hasattr(ql.os.fd[fd], 'write'):
+            ql.os.fd[fd].write(data)
         else:
-            ql.log.warning("write(fd = %d, buf = %x, count = %i) failed due to write_fd" % (write_fd, write_buf, write_count))
+            ql.log.warning(f'write failed since fd {fd:d} does not have a write method')
 
-        regreturn = write_count
+        regreturn = count
 
     except:
         regreturn = -1
+
         if ql.verbose >= QL_VERBOSE.DEBUG:
             raise
-    #if buf:
-    #    ql.log.info(buf.decode(errors='ignore'))
+
     return regreturn
 
 
-def ql_syscall_readlink(ql, path_name, path_buff, path_buffsize, *args, **kw):
-    pathname = (ql.mem.read(path_name, 0x100).split(b'\x00'))[0]
-    pathname = str(pathname, 'utf-8', errors="ignore")
-
+def ql_syscall_readlink(ql: Qiling, path_name: int, path_buff: int, path_buffsize: int):
+    pathname = ql.os.utils.read_cstring(path_name)
+    # pathname = str(pathname, 'utf-8', errors="ignore")
     real_path = ql.os.path.transform_to_link_path(pathname)
     relative_path = ql.os.path.transform_to_relative_path(pathname)
 
-    if os.path.exists(real_path) == False:
+    if not os.path.exists(real_path):
         regreturn = -1
-    elif relative_path == '/proc/self/exe':
-        FILEPATH = ql.path
-        localpath = os.path.abspath(FILEPATH)
+
+    elif relative_path == r'/proc/self/exe':
+        localpath = os.path.abspath(ql.path)
         localpath = bytes(localpath, 'utf-8') + b'\x00'
+
         ql.mem.write(path_buff, localpath)
-        regreturn = (len(localpath)-1)
+        regreturn = len(localpath) - 1
+
     else:
-        regreturn = 0x0
+        regreturn = 0
 
     ql.log.debug("readlink(%s, 0x%x, 0x%x) = %d" % (relative_path, path_buff, path_buffsize, regreturn))
+
     return regreturn
 
 
-def ql_syscall_getcwd(ql, path_buff, path_buffsize, *args, **kw):
+def ql_syscall_getcwd(ql: Qiling, path_buff: int, path_buffsize: int):
     localpath = ql.os.path.transform_to_relative_path('./')
     localpath = bytes(localpath, 'utf-8') + b'\x00'
-    ql.mem.write(path_buff, localpath)
-    regreturn = (len(localpath))
 
-    pathname = (ql.mem.read(path_buff, 0x100).split(b'\x00'))[0]
-    pathname = str(pathname, 'utf-8', errors="ignore")
+    ql.mem.write(path_buff, localpath)
+    regreturn = len(localpath)
+
+    pathname = ql.os.utils.read_cstring(path_buff)
+    # pathname = str(pathname, 'utf-8', errors="ignore")
 
     ql.log.debug("getcwd(%s, 0x%x) = %d" % (pathname, path_buffsize, regreturn))
+
     return regreturn
 
 
-def ql_syscall_chdir(ql, path_name, *args, **kw):
-    regreturn = 0
-    pathname = ql.mem.string(path_name)
-
+def ql_syscall_chdir(ql: Qiling, path_name: int):
+    pathname = ql.os.utils.read_cstring(path_name)
     real_path = ql.os.path.transform_to_real_path(pathname)
     relative_path = ql.os.path.transform_to_relative_path(pathname)
 
     if os.path.exists(real_path) and os.path.isdir(real_path):
-        if ql.os.thread_management != None:
+        if ql.os.thread_management:
             ql.os.thread_management.cur_thread.path.cwd = relative_path
         else:
             ql.os.path.cwd = relative_path
+
+        regreturn = 0
         ql.log.debug("chdir(%s) = %d"% (relative_path, regreturn))
     else:
         regreturn = -1
-        ql.log.warning("chdir(%s) = %d : Not Found" % (relative_path, regreturn))
+        ql.log.warning("chdir(%s) = %d : not found" % (relative_path, regreturn))
+
     return regreturn
 
 
-def ql_syscall_readlinkat(ql, readlinkat_dfd, readlinkat_path, readlinkat_buf, readlinkat_bufsiz, *args, **kw):
-    pathname = (ql.mem.read(readlinkat_path, 0x100).split(b'\x00'))[0]
-    pathname = str(pathname, 'utf-8', errors="ignore")
-
+def ql_syscall_readlinkat(ql: Qiling, dfd: int, path: int, buf: int, bufsize: int):
+    pathname = ql.os.utils.read_cstring(path)
+    # pathname = str(pathname, 'utf-8', errors="ignore")
     real_path = ql.os.path.transform_to_link_path(pathname)
     relative_path = ql.os.path.transform_to_relative_path(pathname)
 
-    if os.path.exists(real_path) == False:
+    if not os.path.exists(real_path):
         regreturn = -1
-    elif relative_path == '/proc/self/exe':
-        FILEPATH = ql.path
-        localpath = os.path.abspath(FILEPATH)
+
+    elif relative_path == r'/proc/self/exe':
+        localpath = os.path.abspath(ql.path)
         localpath = bytes(localpath, 'utf-8') + b'\x00'
-        ql.mem.write(readlinkat_buf, localpath)
-        regreturn = (len(localpath)-1)
+
+        ql.mem.write(buf, localpath)
+        regreturn = len(localpath) -1
     else:
-        regreturn = 0x0
+        regreturn = 0
+
     return regreturn
 
 
-def ql_syscall_getpid(ql, *args, **kw):
-    regreturn= 0x512
-    return regreturn
+def ql_syscall_getpid(ql: Qiling):
+    return 0x512
 
 
-def ql_syscall_getppid(ql, *args, **kw):
-    regreturn= 0x1024
-    return regreturn
+def ql_syscall_getppid(ql: Qiling):
+    return 0x1024
 
 
-def ql_syscall_vfork(ql, *args, **kw):
+def ql_syscall_vfork(ql: Qiling):
     if ql.platform == QL_OS.WINDOWS:
         try:
             pid = Process()
-            pid = 0 
+            pid = 0
         except:
-            pid = -1  
+            pid = -1
     else:
         pid = os.fork()
 
@@ -385,120 +386,112 @@ def ql_syscall_vfork(ql, *args, **kw):
     else:
         regreturn = pid
 
-    if ql.os.thread_management != None:
+    if ql.os.thread_management:
         ql.emu_stop()
+
     return regreturn
 
 
-def ql_syscall_fork(ql, *args, **kw):
-    return ql_syscall_vfork(ql, *args, **kw)
+def ql_syscall_fork(ql: Qiling):
+    return ql_syscall_vfork(ql)
 
-def ql_syscall_setsid(ql, *args, **kw):
-    regreturn = os.getpid()
-    return regreturn
+def ql_syscall_setsid(ql: Qiling):
+    return os.getpid()
 
 
-def ql_syscall_execve(ql, execve_pathname, execve_argv, execve_envp, *args, **kw):
-    pathname = ql.mem.string(execve_pathname)
-    real_path = ql.os.path.transform_to_real_path(pathname)
-    relative_path = ql.os.path.transform_to_relative_path(pathname)
+def ql_syscall_execve(ql: Qiling, pathname: int, argv: int, envp: int):
+    file_path = ql.os.utils.read_cstring(pathname)
+    real_path = ql.os.path.transform_to_real_path(file_path)
 
-    word_size = 8 if (ql.archtype== QL_ARCH.ARM64) or (ql.archtype== QL_ARCH.X8664) else 4
-    unpack = ql.unpack64 if (ql.archtype== QL_ARCH.ARM64) or (ql.archtype== QL_ARCH.X8664) else ql.unpack32
+    def __read_str_array(addr: int) -> Iterator[str]:
+        if addr:
+            while True:
+                elem = ql.mem.read_ptr(addr)
 
-    argv = []
-    if execve_argv != 0:
-        while True:
-            argv_addr = unpack(ql.mem.read(execve_argv, word_size))
-            if argv_addr == 0:
-                break
-            argv.append(ql.mem.string(argv_addr))
-            execve_argv += word_size
+                if elem == 0:
+                    break
+
+                yield ql.os.utils.read_cstring(elem)
+                addr += ql.pointersize
+
+    args = [s for s in __read_str_array(argv)]
 
     env = {}
-    if execve_envp != 0:
-        while True:
-            env_addr = unpack(ql.mem.read(execve_envp, word_size))
-            if env_addr == 0:
-                break
-            env_str = ql.mem.string(env_addr)
-            idx = env_str.index('=')
-            key = env_str[ : idx]
-            val = env_str[idx + 1 : ]
-            env[key] = val
-            execve_envp += word_size
+    for s in __read_str_array(envp):
+        k, _, v = s.partition('=')
+        env[k] = v
 
     ql.emu_stop()
 
-    ql.log.debug("execve(%s, [%s], [%s])"% (pathname, ', '.join(argv), ', '.join([key + '=' + value for key, value in env.items()])))
+    ql.log.debug(f'execve({file_path}, [{", ".join(args)}], [{", ".join(f"{k}={v}" for k, v in env.items())}])')
 
-    ql.loader.argv      = argv
-    ql.loader.env       = env
-    ql._path             = real_path
-
-    ql.mem.map_info     = []
+    ql.loader.argv = args
+    ql.loader.env = env
+    ql._path = real_path
+    ql.mem.map_info = []
     ql.clear_ql_hooks()
+
     # Clean debugger to prevent port conflicts
     ql.debugger = None
 
     if ql.code:
-        return     
+        return
 
-    ql._uc               = ql.arch.init_uc
+    ql._uc = ql.arch.init_uc
     QlCoreHooks.__init__(ql, ql._uc)
+
     ql.os.load()
     ql.loader.run()
     ql.run()
 
 
-def ql_syscall_dup(ql, dup_oldfd, *args, **kw):
+def ql_syscall_dup(ql: Qiling, oldfd: int):
     regreturn = -EBADF
-    if dup_oldfd in range(0, 256):
-        if ql.os.fd[dup_oldfd] != 0:
-            regreturn = -EMFILE
-            newfd = ql.os.fd[dup_oldfd].dup()
-            for idx, val in enumerate(ql.os.fd):
+
+    if oldfd in range(256):
+        if ql.os.fd[oldfd] != 0:
+            newfd = ql.os.fd[oldfd].dup()
+
+            for i, val in enumerate(ql.os.fd):
                 if val == 0:
-                    ql.os.fd[idx] = newfd
-                    regreturn = idx
+                    ql.os.fd[i] = newfd
+                    regreturn = i
                     break
+            else:
+                regreturn = -EMFILE
 
     return regreturn
 
 
-def ql_syscall_dup2(ql, dup2_oldfd, dup2_newfd, *args, **kw):
-    if 0 <= dup2_newfd < NR_OPEN and 0 <= dup2_oldfd < NR_OPEN:
-        if ql.os.fd[dup2_oldfd] != 0:
-            ql.os.fd[dup2_newfd] = ql.os.fd[dup2_oldfd].dup()
-            regreturn = dup2_newfd
-        else:
-            regreturn = -EBADF
-    else:
-        regreturn = -EBADF
-    return regreturn
+def ql_syscall_dup2(ql: Qiling, fd: int, newfd: int):
+    if 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
+        if 0 <= newfd < NR_OPEN:
+            ql.os.fd[newfd] = ql.os.fd[fd].dup()
+            return newfd
+
+    return -EBADF
 
 
-def ql_syscall_dup3(ql, dup3_oldfd, dup3_newfd, dup3_flags, null2, null3, null4):
-    if 0 <= dup3_newfd < NR_OPEN and 0 <= dup3_oldfd < NR_OPEN:
-        if ql.os.fd[dup3_oldfd] != 0:
-            ql.os.fd[dup3_newfd] = ql.os.fd[dup3_oldfd].dup()
-            regreturn = dup3_newfd
-        else:
-            regreturn = -1
-    else:
-        regreturn = -1
-    return regreturn
+def ql_syscall_dup3(ql: Qiling, fd, newfd: int, flags: int):
+    if 0 <= fd < NR_OPEN and ql.os.fd[fd] != 0:
+        if 0 <= newfd < NR_OPEN:
+            ql.os.fd[newfd] = ql.os.fd[fd].dup()
+            return newfd
 
-def ql_syscall_set_tid_address(ql, set_tid_address_tidptr, *args, **kw):
-    if ql.os.thread_management == None:
-        regreturn = os.getpid()
-    else:
-        ql.os.thread_management.cur_thread.set_clear_child_tid_addr(set_tid_address_tidptr)
+    return -1
+
+def ql_syscall_set_tid_address(ql: Qiling, tidptr: int):
+    if ql.os.thread_management:
+        ql.os.thread_management.cur_thread.set_clear_child_tid_addr(tidptr)
+
         regreturn = ql.os.thread_management.cur_thread.id
+    else:
+        regreturn = os.getpid()
+
     return regreturn
 
 
-def ql_syscall_pipe(ql, pipe_pipefd, *args, **kw):
+def ql_syscall_pipe(ql: Qiling, pipefd: int):
     rd, wd = ql_pipe.open()
 
     idx1 = -1
@@ -508,38 +501,41 @@ def ql_syscall_pipe(ql, pipe_pipefd, *args, **kw):
         if ql.os.fd[i] == 0:
             idx1 = i
             break
+
     if idx1 == -1:
         regreturn = -1
     else:
-        idx2 = -1
         for i in range(NR_OPEN):
             if ql.os.fd[i] == 0 and i != idx1:
                 idx2 = i
                 break
+
         if idx2 == -1:
             regreturn = -1
         else:
             ql.os.fd[idx1] = rd
             ql.os.fd[idx2] = wd
+
             if ql.archtype== QL_ARCH.MIPS:
                 ql.reg.v1 = idx2
                 regreturn = idx1
             else:
-                ql.mem.write(pipe_pipefd, ql.pack32(idx1) + ql.pack32(idx2))
+                ql.mem.write(pipefd + 0, ql.pack32(idx1))
+                ql.mem.write(pipefd + 4, ql.pack32(idx2))
                 regreturn = 0
 
-    ql.log.debug("pipe(%x, [%d, %d]) = %d" % (pipe_pipefd, idx1, idx2, regreturn))
+    ql.log.debug("pipe(%x, [%d, %d]) = %d" % (pipefd, idx1, idx2, regreturn))
+
     return regreturn
 
 
-def ql_syscall_nice(ql, nice_inc, *args, **kw):
-    regreturn = 0
-    return regreturn
+def ql_syscall_nice(ql: Qiling, inc: int):
+    return 0
 
 
-def ql_syscall_truncate(ql, path, length, *args, **kw):
-    path = ql.mem.string(path)
-    real_path = ql.os.path.transform_to_real_path(path)
+def ql_syscall_truncate(ql: Qiling, path: int, length: int):
+    file_path = ql.os.utils.read_cstring(path)
+    real_path = ql.os.path.transform_to_real_path(file_path)
     st_size = Stat(real_path).st_size
 
     try:
@@ -547,80 +543,90 @@ def ql_syscall_truncate(ql, path, length, *args, **kw):
             os.truncate(real_path, length)
 
         else:
-            padding = (length - st_size)
-            with open(real_path, 'a+b') as fd:
-                fd.write(b'\x00'*padding)
+            padding = length - st_size
 
-        regreturn = 0
+            with open(real_path, 'a+b') as ofile:
+                ofile.write(b'\x00' * padding)
     except:
         regreturn = -1
+    else:
+        regreturn = 0
 
-    ql.log.debug('truncate(%s, 0x%x) = %d' % (path, length, regreturn))
+    ql.log.debug('truncate(%s, 0x%x) = %d' % (file_path, length, regreturn))
+
     return regreturn
 
 
-def ql_syscall_ftruncate(ql, ftrunc_fd, ftrunc_length, *args, **kw):
-    real_path = ql.os.fd[ftrunc_fd].name
+def ql_syscall_ftruncate(ql: Qiling, fd: int, length: int):
+    real_path = ql.os.fd[fd].name
     st_size = Stat(real_path).st_size
 
     try:
-        if st_size >= ftrunc_length:
-            os.truncate(real_path, ftrunc_length)
+        if st_size >= length:
+            os.truncate(real_path, length)
 
         else:
-            padding = (ftrunc_length - st_size)
-            with open(real_path, 'a+b') as fd:
-                fd.write(b'\x00'*padding)
+            padding = length - st_size
 
-        regreturn = 0
+            with open(real_path, 'a+b') as ofile:
+                ofile.write(b'\x00' * padding)
     except:
         regreturn = -1
+    else:
+        regreturn = 0
 
-    ql.log.debug("ftruncate(%d, 0x%x) = %d" % (ftrunc_fd, ftrunc_length, regreturn))
+    ql.log.debug("ftruncate(%d, 0x%x) = %d" % (fd, length, regreturn))
+
     return regreturn
 
 
-def ql_syscall_unlink(ql, unlink_pathname, *args, **kw):
-    pathname = ql.mem.string(unlink_pathname)
-    real_path = ql.os.path.transform_to_real_path(pathname)
+def ql_syscall_unlink(ql: Qiling, pathname: int):
+    file_path = ql.os.utils.read_cstring(pathname)
+    real_path = ql.os.path.transform_to_real_path(file_path)
+
     opened_fds = [getattr(ql.os.fd[i], 'name', None) for i in range(NR_OPEN) if ql.os.fd[i] != 0]
     path = pathlib.Path(real_path)
 
     if any((real_path not in opened_fds, path.is_block_device(), path.is_fifo(), path.is_socket(), path.is_symlink())):
         try:
             os.unlink(real_path)
-            regreturn = 0
         except FileNotFoundError:
             ql.log.debug('No such file or directory')
             regreturn = -1
         except:
             regreturn = -1
+        else:
+            regreturn = 0
+
     else:
         regreturn = -1
 
-    ql.log.debug("unlink(%s) = %d" % (pathname, regreturn))
+    ql.log.debug("unlink(%s) = %d" % (file_path, regreturn))
+
     return regreturn
 
 
-def ql_syscall_unlinkat(ql, fd, pathname, *args, **kw):
-    file_path = ql.mem.string(pathname)
+def ql_syscall_unlinkat(ql: Qiling, fd: int, pathname: int):
+    file_path = ql.os.utils.read_cstring(pathname)
     real_path = ql.os.path.transform_to_real_path(file_path)
-    
+
     try:
         dir_fd = ql.os.fd[fd].fileno()
     except:
-        dir_fd = None    
-    
-    regreturn = 0
+        dir_fd = None
+
     try:
         if dir_fd is None:
             os.unlink(real_path)
         else:
-            os.unlink(file_path, dir_fd=dir_fd)               
+            os.unlink(file_path, dir_fd=dir_fd)
     except OSError as e:
-        regreturn = -e.errno    
+        regreturn = -e.errno
+    else:
+        regreturn = 0
 
-    ql.log.debug("unlinkat(fd = %d, path = '%s') = %d" % (fd, file_path, regreturn))    
+    ql.log.debug("unlinkat(fd = %d, path = '%s') = %d" % (fd, file_path, regreturn))
+
     return regreturn
 
 # https://man7.org/linux/man-pages/man2/getdents.2.html
@@ -629,15 +635,13 @@ def ql_syscall_unlinkat(ql, fd, pathname, *args, **kw):
 #        unsigned long  d_off;     /* Offset to next linux_dirent */
 #        unsigned short d_reclen;  /* Length of this linux_dirent */
 #        char           d_name[];  /* Filename (null-terminated) */
-#                          /* length is actually (d_reclen - 2 -
-#                             offsetof(struct linux_dirent, d_name)) */
+#                                  /* length is actually (d_reclen - 2 - offsetof(struct linux_dirent, d_name)) */
 #        /*
 #        char           pad;       // Zero padding byte
-#        char           d_type;    // File type (only since Linux
-#                                  // 2.6.4); offset is (d_reclen - 1)
+#        char           d_type;    // File type (only since Linux 2.6.4); offset is (d_reclen - 1)
 #        */
 #    }
-
+#
 #    struct linux_dirent64 {
 #        ino64_t        d_ino;    /* 64-bit inode number */
 #        off64_t        d_off;    /* 64-bit offset to next structure */
@@ -645,18 +649,27 @@ def ql_syscall_unlinkat(ql, fd, pathname, *args, **kw):
 #        unsigned char  d_type;   /* File type */
 #        char           d_name[]; /* Filename (null-terminated) */
 #    };
-def ql_syscall_getdents(ql, fd, dirp, count, *args, **kw):
+def __getdents_common(ql: Qiling, fd: int, dirp: int, count: int, *, is_64: bool):
     # TODO: not sure what is the meaning of d_off, should not be 0x0
     # but works for the example code from linux manual.
     #
     # https://stackoverflow.com/questions/16714265/meaning-of-field-d-off-in-last-struct-dirent
+
     def _type_mapping(ent):
-        methods_constants_d = {'is_fifo': 0x1, 'is_char_device': 0x2, 'is_dir': 0x4, 'is_block_device': 0x6,
-                                'is_file': 0x8, 'is_symlink': 0xa, 'is_socket': 0xc}
+        methods_constants_d = {
+            'is_fifo'         : 0x1,
+            'is_char_device'  : 0x2,
+            'is_dir'          : 0x4,
+            'is_block_device' : 0x6,
+            'is_file'         : 0x8,
+            'is_symlink'      : 0xa,
+            'is_socket'       : 0xc
+        }
+
         ent_p = pathlib.Path(ent.path) if isinstance(ent, os.DirEntry) else ent
 
         for method, constant in methods_constants_d.items():
-            if getattr(ent_p, method, None)():
+            if getattr(ent_p, method)():
                 t = constant
                 break
         else:
@@ -664,7 +677,6 @@ def ql_syscall_getdents(ql, fd, dirp, count, *args, **kw):
 
         return bytes([t])
 
-    is_64 = "is_64" in kw
     if ql.os.fd[fd].tell() == 0:
         n = ql.pointersize
         total_size = 0
@@ -673,27 +685,35 @@ def ql_syscall_getdents(ql, fd, dirp, count, *args, **kw):
 
         for result in itertools.chain((pathlib.Path('.'), pathlib.Path('..')), results): # chain speical directories with the results
             d_ino = result.inode() if isinstance(result, os.DirEntry) else result.stat().st_ino
-            d_off = 0x0
+            d_off = 0
             d_name = (result.name if isinstance(result, os.DirEntry) else result._str).encode() + b'\x00'
             d_type = _type_mapping(result)
-            if not is_64:
-                d_reclen = len(d_name) + n*2 + 3
+            d_reclen = n + n + 2 + len(d_name) + 1
+
+            if is_64:
+                fields = (
+                    (ql.pack(d_ino), n),
+                    (ql.pack(d_off), n),
+                    (ql.pack16(d_reclen), 2),
+                    (d_type, 1),
+                    (d_name, len(d_name))
+                )
             else:
-                d_reclen = len(d_name) + 8*2 + 3
-            if not is_64:
-                ql.mem.write(dirp, ql.pack(d_ino))
-                ql.mem.write(dirp+n, ql.pack(d_off))
-                ql.mem.write(dirp+n*2, ql.pack16(d_reclen))
-                ql.mem.write(dirp+n*2+2, d_name)
-                ql.mem.write(dirp+n*2+2+len(d_name), d_type)
-            else:
-                ql.mem.write(dirp, ql.pack64(d_ino))
-                ql.mem.write(dirp + 8, ql.pack64(d_off))
-                ql.mem.write(dirp + 8*2, ql.pack16(d_reclen))
-                ql.mem.write(dirp + 8*2 + 2, d_type)
-                ql.mem.write(dirp + 8*2 + 3, d_name)
+                fields = (
+                    (ql.pack(d_ino), n),
+                    (ql.pack(d_off), n),
+                    (ql.pack16(d_reclen), 2),
+                    (d_name, len(d_name)),
+                    (d_type, 1)
+                )
+
+            p = dirp
+            for fval, flen in fields:
+                ql.mem.write(p, fval)
+                p += flen
 
             ql.log.debug(f"Write dir entries: {ql.mem.read(dirp, d_reclen)}")
+
             dirp += d_reclen
             total_size += d_reclen
             _ent_count += 1
@@ -703,9 +723,14 @@ def ql_syscall_getdents(ql, fd, dirp, count, *args, **kw):
     else:
         _ent_count = 0
         regreturn = 0
+
     ql.log.debug("%s(%d, /* %d entries */, 0x%x) = %d" % ("getdents64" if is_64 else "getdents", fd, _ent_count, count, regreturn))
+
     return regreturn
 
-    
-def ql_syscall_getdents64(ql, fd, dirp, count, *args, **kw):
-    return ql_syscall_getdents(ql, fd, dirp, count, is_64=True, *args, **kw)
+
+def ql_syscall_getdents(ql: Qiling, fd: int, dirp: int, count: int):
+    return __getdents_common(ql, fd, dirp, count, is_64=False)
+
+def ql_syscall_getdents64(ql: Qiling, fd: int, dirp: int, count: int):
+    return __getdents_common(ql, fd, dirp, count, is_64=True)

--- a/qiling/os/posix/syscall/utsname.py
+++ b/qiling/os/posix/syscall/utsname.py
@@ -3,23 +3,21 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from qiling import Qiling
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
+def ql_syscall_uname(ql: Qiling, buf: int):
+    UTSLEN = 65
 
-def ql_syscall_uname(ql, address, *args, **kw):
-    buf =  b''
-    buf += b'QilingOS'.ljust(65, b'\x00')
-    buf += b'ql_vm'.ljust(65, b'\x00')
-    buf += b'99.0-RELEASE'.ljust(65, b'\x00')
-    buf += b'QilingOS 99.0-RELEASE r1'.ljust(65, b'\x00')
-    buf += b'ql_processor'.ljust(65, b'\x00')
-    buf += b''.ljust(65, b'\x00')
-    ql.mem.write(address, buf)
-    regreturn = 0
-    return regreturn
+    fields = (
+        b'QilingOS',                 # sysname
+        b'ql_vm',                    # nodename
+        b'99.0-RELEASE',             # release
+        b'QilingOS 99.0-RELEASE r1', # version
+        b'ql_processor',             # machine
+        b''                          # domainname
+    )
+
+    for i, f in enumerate(fields):
+        ql.mem.write(buf + i * UTSLEN, f.ljust(UTSLEN, b'\x00'))
+
+    return 0

--- a/qiling/os/posix/syscall/wait.py
+++ b/qiling/os/posix/syscall/wait.py
@@ -3,26 +3,23 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+import os
 
-from qiling.const import *
-from qiling.os.linux.thread import *
-from qiling.const import *
-from qiling.os.posix.filestruct import *
-from qiling.os.filestruct import *
-from qiling.os.posix.const_mapping import *
-from qiling.exception import *
-from qiling.utils import *
+from qiling import Qiling
 from qiling.os.posix.const import ECHILD
 
+def ql_syscall_wait4(ql: Qiling, pid: int, wstatus: int, options: int, rusage: int):
+    # convert to signed (pid_t is 32bit)
+    pid = ql.unpack32s(ql.pack32(pid))
 
-def ql_syscall_wait4(ql, wait4_pid, wait4_wstatus, wait4_options, wait4_rusage, *args, **kw):
-    wait4_pid = ql.unpack32s(ql.pack32(wait4_pid))  # convert to signed (pid_t is 32bit)
     try:
-        spid, status, rusage = os.wait4(wait4_pid, wait4_options)
-        if wait4_wstatus != 0:
-            ql.mem.write(wait4_wstatus, ql.pack32(status))
-        regreturn = spid
-    except ChildProcessError:
-        regreturn = -ECHILD
-    return regreturn
+        spid, status, _ = os.wait4(pid, options)
 
+        if wstatus:
+            ql.mem.write(wstatus, ql.pack32(status))
+
+        retval = spid
+    except ChildProcessError:
+        retval = -ECHILD
+
+    return retval

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -512,7 +512,7 @@ def ql_resolve_logger_level(verbose: QL_VERBOSE):
 QL_INSTANCE_ID = 114514
 
 # TODO: qltool compatibility
-def ql_setup_logger(ql, log_file, console, filters, multithread, log_override, log_plain):
+def ql_setup_logger(ql, log_file: Optional[str], console: bool, filters: Optional[Sequence], log_override: Optional[logging.Logger], log_plain: bool):
     global QL_INSTANCE_ID
 
     # If there is an override for our logger, then use it.

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -9,7 +9,7 @@ thoughout the qiling framework
 """
 import importlib, os, copy, re, pefile, configparser, logging, sys
 from logging import LogRecord
-from typing import Container, Optional, Mapping
+from typing import Container, Optional, Mapping, Sequence
 from enum import EnumMeta
 
 from unicorn import UC_ERR_READ_UNMAPPED, UC_ERR_FETCH_UNMAPPED
@@ -498,16 +498,14 @@ def profile_setup(ostype, profile, ql):
     config.read(profiles)
     return config, debugmsg
 
-def ql_resolve_logger_level(verbose: QL_VERBOSE):
-    level = logging.INFO
-    if verbose == QL_VERBOSE.OFF:
-        level = logging.WARNING
-    elif verbose >= QL_VERBOSE.DEBUG:
-        level = logging.DEBUG
-    elif verbose >= QL_VERBOSE.DEFAULT:
-        level = logging.INFO
-    
-    return level
+def ql_resolve_logger_level(verbose: QL_VERBOSE) -> int:
+    return {
+        QL_VERBOSE.OFF     : logging.WARNING,
+        QL_VERBOSE.DEFAULT : logging.INFO,
+        QL_VERBOSE.DEBUG   : logging.DEBUG,
+        QL_VERBOSE.DISASM  : logging.DEBUG,
+        QL_VERBOSE.DUMP    : logging.DEBUG
+    }[verbose]
 
 QL_INSTANCE_ID = 114514
 
@@ -522,20 +520,22 @@ def ql_setup_logger(ql, log_file: Optional[str], console: bool, filters: Optiona
         # We should leave the root logger untouched.
         log = logging.getLogger(f"qiling{QL_INSTANCE_ID}")
         QL_INSTANCE_ID += 1
-        
+
         # Disable propagation to avoid duplicate output.
         log.propagate = False
         # Clear all handlers and filters.
         log.handlers = []
-        log.filters = []    
+        log.filters = []
 
         # Do we have console output?
         if console:
             handler = logging.StreamHandler()
+
             if not log_plain and not sys.platform == "win32":
                 formatter = QilingColoredFormatter(ql, FMT_STR)
             else:
                 formatter = QilingPlainFormatter(ql, FMT_STR)
+
             handler.setFormatter(formatter)
             log.addHandler(handler)
         else:


### PR DESCRIPTION
Changelog highlights:
- Instead of passing 6 parameters to each syscall, syscalls now get the exact number of arguments they need. As a result, all `*args` and `**kw` used to thwart unused parameters were removed from syscalls
- Generic syscalls parameters prefixed with syscall name were shorten (e.g. `open_fd` -> `fd`) to improve readability
- Fixed many styling issues, including cases of C code written in Python syntax
- Some syscalls were fixed and improved (e.g. `ql_syscall_arch_prctl`)
- Improved code readability (e.g. `ql_syscall_socketcall`)
- Duplicated logging messages were removed
- Added typing annotations
- Removed / trimmed imports

Notes:
- `socket` wasn't fully refactored due to its complexity