### PR TITLE
Fix for use before assignment of addr variable

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -642,6 +642,7 @@ class QlLoaderPE(QlLoader, Process):
                                 addr = self.import_address_table[dll_name][imp.name]
                             except KeyError:
                                 self.ql.log.debug("Error in loading function %s" % imp.name.decode())
+                                continue
                         else:
                             addr = self.import_address_table[dll_name][imp.ordinal]
 


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [X] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [X] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [X] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

I am seeing an UnboundLocalError when trying to execute a malware sample:

40d45fb455cf2db58dda6a57d437e626d5d7d86d4598d4afccab0ac7ff6d6b3e

```
Traceback (most recent call last):
  File "/app/src/main.py", line 224, in <module>
    main()
  File "/app/src/main.py", line 217, in main
    sqsLoop()
  File "/app/src/main.py", line 114, in sqsLoop
    trace_json = trace_exe(sample.name)
  File "/app/src/main.py", line 181, in trace_exe
    ql = Qiling([exe], QILING_ROOTFS_PATH, verbose=QL_VERBOSE.DEBUG, console=False, log_plain=True)
  File "/app/venv/lib64/python3.7/site-packages/qiling-1.2.4.1-py3.7.egg/qiling/core.py", line 223, in __init__
    self.loader.run()
  File "/app/venv/lib64/python3.7/site-packages/qiling-1.2.4.1-py3.7.egg/qiling/loader/pe.py", line 448, in run
    self.load()
  File "/app/venv/lib64/python3.7/site-packages/qiling-1.2.4.1-py3.7.egg/qiling/loader/pe.py", line 597, in load
    address = self.ql.pack32(addr)
UnboundLocalError: local variable 'addr' referenced before assignment
```

[File available at VirusTotal](https://www.virustotal.com/gui/file/40d45fb455cf2db58dda6a57d437e626d5d7d86d4598d4afccab0ac7ff6d6b3e) or if you like I can provide a copy. 