### PR TITLE
Added free syscall to msvcrt

### DIFF
--- a/qiling/os/windows/dlls/msvcrt.py
+++ b/qiling/os/windows/dlls/msvcrt.py
@@ -353,6 +353,11 @@ def hook_malloc(ql: Qiling, address: int, params):
     addr = ql.os.heap.alloc(size)
     return addr
 
+# void* free（void *address)
+@winsdkapi(cc=CDECL, replace_params={"address": POINTER})
+def hook_free(ql: Qiling, address: int, params):
+    address = params['address']
+    return ql.os.heap.free(address)
 
 # _onexit_t _onexit(
 #    _onexit_t function


### PR DESCRIPTION
Implemented a free syscall into msvcrt.py so it is possible to emulate windows code that is calling free() instead of a lower-level function like VirtualFree().


## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [ ] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
