### PR TITLE
gdb bugfix

### DIFF
--- a/qiling/arch/x86.py
+++ b/qiling/arch/x86.py
@@ -20,7 +20,7 @@ class QlArchIntel(QlArch):
     def get_reg_bit(self, register: int) -> int:
         # all regs in reg_map_misc are 16 bits except of eflags
         if register == UC_X86_REG_EFLAGS:
-            return self.ql.archbit
+            return 32
 
         regmaps = (
             (reg_map_8, 8),


### PR DESCRIPTION
Fixing #929 

Bug root cause: considering the flags register size as native (i.e. 32 bits on x86 and 64 on x64), however it should always be considered as 32 bits regardless.