### PR TITLE
Fix bytes api misuse bug

### DIFF
--- a/qiling/os/uefi/bs.py
+++ b/qiling/os/uefi/bs.py
@@ -499,7 +499,7 @@ def hook_SetMem(ql: Qiling, address: int, params):
 	size = params["Size"]
 
 	byteorder = 'little' if ql.archendian == QL_ENDIAN.EL else 'big'
-	ql.mem.write(buffer, value.to_bytes(1, byteorder=byteorder) * size)
+	ql.mem.write(buffer, bytes([value]) * size)
 
 @dxeapi(params = {
 	"Type"			: UINT,		# UINT32


### PR DESCRIPTION
This pr is about fix SetMem api in UEFI Boot Services. The signature of `SetMem` is `SetMem(void *buffer,  size_t size, uint8 value)`. And the behavior is fill value to memory between buffer and buffer+size. Current implementation use `bytes(value) * size` to generate memory content. But the `bytes(value)` will generate `b'\x00' * value` rather than byte version of `value`. So I and @elicn  discussed, and determined to change it to `bytes(chr(value))` which follow the right behavior.

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
