### PR TITLE
[+] fix windows multi-thread on x64 providing wrong parameters

### DIFF
--- a/qiling/os/windows/thread.py
+++ b/qiling/os/windows/thread.py
@@ -84,16 +84,17 @@ class QlWindowsThread(QlThread):
         stack_size = 1024
         new_stack = self.ql.os.heap.alloc(stack_size) + stack_size
         
+        self.saved_context = self.ql.reg.save()
+
+        # set return address, parameters
         if self.ql.archtype == QL_ARCH.X86:
             self.ql.mem.write(new_stack - 4, self.ql.pack32(self.ql.os.thread_manager.THREAD_RET_ADDR))
             self.ql.mem.write(new_stack, self.ql.pack32(func_params))
         elif self.ql.archtype == QL_ARCH.X8664:
             self.ql.mem.write(new_stack - 8, self.ql.pack64(self.ql.os.thread_manager.THREAD_RET_ADDR))
-            self.ql.mem.write(new_stack, self.ql.pack64(func_params))
+            self.saved_context["rcx"] = func_params
 
-        # set eip, ebp, esp
-        self.saved_context = self.ql.reg.save()
-
+        # set eip/rip, ebp/rbp, esp/rsp
         if self.ql.archtype == QL_ARCH.X86:
             self.saved_context["eip"] = func_addr
             self.saved_context["ebp"] = new_stack - 4


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

On Windows x64 platform, the multi-thread function is not correct

Since param is passed by rcx register instead of stack

This MR fixed it

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
