### PR TITLE
[*] fix NtQueryInformationProcess ZwQueryInformationProcess return value

### DIFF
--- a/qiling/os/windows/dlls/ntdll.py
+++ b/qiling/os/windows/dlls/ntdll.py
@@ -93,7 +93,7 @@ def _QueryInformationProcess(ql: Qiling, address: int, params):
 def hook_ZwQueryInformationProcess(ql: Qiling, address: int, params):
     # TODO have no idea if is cdecl or stdcall
 
-    _QueryInformationProcess(ql, address, params)
+    return _QueryInformationProcess(ql, address, params)
 
 # __kernel_entry NTSTATUS NtQueryInformationProcess(
 #   IN HANDLE           ProcessHandle,
@@ -112,7 +112,7 @@ def hook_ZwQueryInformationProcess(ql: Qiling, address: int, params):
 def hook_NtQueryInformationProcess(ql: Qiling, address: int, params):
     # TODO have no idea if is cdecl or stdcall
 
-    _QueryInformationProcess(ql, address, params)
+    return _QueryInformationProcess(ql, address, params)
 
 def _QuerySystemInformation(ql: Qiling, address: int, params):
     siClass = params["SystemInformationClass"]


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

ZwQueryInformationProcess, NtQueryInformationProcess have return value

But qiling did not provide the return value (forward the return value from the internal function)

This MR fixed it

Reference: https://docs.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntquerysysteminformation

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
