### PR TITLE
qltool info: show extended version information

### DIFF
--- a/qiling/__init__.py
+++ b/qiling/__init__.py
@@ -1,2 +1,78 @@
 from .core import Qiling
 from .__version__ import __version__
+
+def __git_info():
+    """Retrieve git information of the current Qiling code base.
+    """
+
+    import os
+
+    gitdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), r'..', r'.git')
+    head_path = 'HEAD'
+
+    try:
+        with open(os.path.join(gitdir, head_path), 'r') as head_file:
+            head_info = head_file.readline().rstrip()
+
+        branch_path = os.path.join(gitdir, head_info.split('ref:', 1)[-1].lstrip())
+
+        with open(os.path.join(gitdir, branch_path), 'r') as branch_file:
+            commit = branch_file.readline().rstrip()
+
+        branch = os.path.basename(branch_path)
+    except OSError:
+        branch = None
+        commit = None
+
+    return {
+        'branch' : branch or 'unknown',
+        'commit' : commit or 'unknown'
+    }
+
+def __platform_info():
+    """Retrieve hosting platform information.
+    """
+
+    import platform
+
+    return {
+        'system'  : platform.system(),
+        'release' : platform.release(),
+        'machine' : platform.machine(),
+        'python'  : platform.python_version()
+    }
+
+def __libs_info(modules):
+    """Retrieve Python dependencies information.
+    """
+
+    def __module_ver(mname: str):
+        """Query a module's version by name.
+        """
+
+        import importlib
+
+        try:
+            m = importlib.import_module(mname)
+        except ModuleNotFoundError:
+            v = None
+        else:
+            v = getattr(m, '__version__')
+
+        return v
+
+    return dict((mname, __module_ver(mname) or 'unknown') for mname in modules)
+
+def ql_extended_info():
+    """Collect extended information to help troubleshoot Qiling issues.
+    """
+
+    return {
+        'git'      : __git_info(),
+        'platform' : __platform_info(),
+        'libs'     : __libs_info((
+            'unicorn',
+            'capstone',
+            'keystone'
+        ))
+    }

--- a/qltool
+++ b/qltool
@@ -10,7 +10,7 @@ import ast
 import pickle
 import unicorn
 
-from qiling import Qiling
+from qiling import Qiling, ql_extended_info
 from qiling.arch import utils as arch_utils
 from qiling.debugger.qdb import QlQdb
 from qiling.utils import arch_convert
@@ -166,6 +166,20 @@ def handle_examples(parser: argparse.ArgumentParser):
 
     parser.exit(0, __ql_examples)
 
+def handle_info(parser: argparse.ArgumentParser):
+    info = ql_extended_info()
+
+    git  = info['git']
+    plat = info['platform']
+    libs = info['libs']
+
+    __ql_info = f"""Qiling {ql_version} on {plat['system']} {plat['release']} ({plat['machine']}), with Python {plat['python']}
+commit: {git['commit']} ({git['branch']})
+libs: {', '.join(f'{k}={v}' for k, v in libs.items())}
+"""
+
+    parser.exit(0, __ql_info)
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', action='version', version=f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
@@ -191,6 +205,9 @@ if __name__ == '__main__':
 
     # set "examples" subcommand
     expl_parser = commands.add_parser('examples', help='show examples and exit', add_help=False)
+
+    # set "info" subcommand
+    info_parser = commands.add_parser('info', help='show extended version info', add_help=False)
 
     comm_parser = run_parser
 
@@ -224,6 +241,9 @@ if __name__ == '__main__':
 
     if options.subcommand == 'examples':
         handle_examples(parser)
+
+    if options.subcommand == 'info':
+        handle_info(parser)
 
     if options.debug_stop and options.verbose not in (QL_VERBOSE.DEBUG, QL_VERBOSE.DUMP):
         parser.error('the debug_stop option requires verbose to be set to either "debug" or "dump"')

--- a/qltool
+++ b/qltool
@@ -8,7 +8,6 @@ import os
 import sys
 import ast
 import pickle
-import unicorn
 
 from qiling import Qiling, ql_extended_info
 from qiling.arch import utils as arch_utils
@@ -182,7 +181,7 @@ libs: {', '.join(f'{k}={v}' for k, v in libs.items())}
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--version', action='version', version=f'qltool for Qiling {ql_version}, using Unicorn {unicorn.__version__}')
+    parser.add_argument('--version', action='version', version=f'qltool for Qiling {ql_version}')
 
     commands = parser.add_subparsers(title='sub commands', description='select execution mode', dest='subcommand')
 

--- a/qltool
+++ b/qltool
@@ -183,7 +183,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', action='version', version=f'qltool for Qiling {ql_version}')
 
-    commands = parser.add_subparsers(title='sub commands', description='select execution mode', dest='subcommand')
+    commands = parser.add_subparsers(title='sub commands', description='select execution mode', dest='subcommand', required=True)
 
     # set "run" subcommand options
     run_parser = commands.add_parser('run', help='run a program')
@@ -232,11 +232,6 @@ if __name__ == '__main__':
     comm_parser.add_argument('--coverage-format', default='drcov', choices=cov_utils.factory.formats, help='code coverage file format')
     comm_parser.add_argument('--json', action='store_true', help='print a json report of the emulation')
     options = parser.parse_args()
-
-    # subparser argument required=True is not supported in python 3.6
-    # manually check whether the user did not specify a subcommand (execution mode)
-    if not options.subcommand:
-        parser.error('please select execution mode')
 
     if options.subcommand == 'examples':
         handle_examples(parser)


### PR DESCRIPTION
Added a new `qltool` command that emits extended version information about Qiling and its hosting environment. Whenever a user encounters an error, pasting the output of this command as part of the bug report would help troubleshooting it.

Command: `./qltool info`
Expected output:
```
Qiling 1.4.1-dev on Linux 5.4.72-microsoft-standard-WSL2 (x86_64), with Python 3.8.10
commit: 978299a4e14977c946f3c85273bafea2dac27468 (show-version)
libs: unicorn=2.0.0, capstone=4.0.2, keystone=0.9.2
```

IMO showing extended info on-demand is a cleaner practice, comparing to a banner displayed by default when a program executes.