### PR TITLE
Minor improvements to memory module

### DIFF
--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -204,18 +204,18 @@ class QlMemoryManager:
         """
 
         for lbound, ubound, perms, label, data in mem_dict['ram']:
-            self.ql.log.debug(f'To restore mapping: {lbound:#08x} {ubound:#08x} {label}')
+            self.ql.log.debug(f'restoring memory range: {lbound:#08x} {ubound:#08x} {label}')
 
             size = ubound - lbound
             if not self.is_mapped(lbound, size):
                 self.ql.log.debug(f'mapping {lbound:#08x} {ubound:#08x}, mapsize = {size:#x}')
                 self.map(lbound, size, perms, label)
 
-            self.ql.log.debug(f'writing {lbound:#08x}, size = {size:#x}, write_size = {len(data):#x}')
+            self.ql.log.debug(f'writing {len(data):#x} bytes at {lbound:#08x}')
             self.write(lbound, data)
-        
+
         for lbound, ubound, perms, label, read_cb, write_cb in mem_dict['mmio']:
-            self.ql.log.debug(f"To restore mmio mapping: {lbound:#08x} {ubound:#08x} {label}")
+            self.ql.log.debug(f"restoring mmio range: {lbound:#08x} {ubound:#08x} {label}")
 
             #TODO: Handle overlapped MMIO?
             self.map_mmio(lbound, ubound - lbound, read_cb, write_cb, info=label)
@@ -309,6 +309,7 @@ class QlMemoryManager:
 
         self.del_mapinfo(addr, addr + size)
         self.ql.uc.mem_unmap(addr, size)
+
         if (addr, addr + size) in self.mmio_cbs:
             del self.mmio_cbs[(addr, addr+size)]
 

--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -187,12 +187,12 @@ class QlMemoryManager:
             "mmio" : []
         }
 
-        for lbound, ubound, perm, label, mmio in self.map_info:
-            if not mmio:
+        for lbound, ubound, perm, label, is_mmio in self.map_info:
+            if is_mmio:
+                mem_dict['mmio'].append((lbound, ubound, perm, label, *self.mmio_cbs[(lbound, ubound)]))
+            else:
                 data = self.read(lbound, ubound - lbound)
                 mem_dict['ram'].append((lbound, ubound, perm, label, bytes(data)))
-            else:
-                mem_dict['mmio'].append((lbound, ubound, perm, label, *self.mmio_cbs[(lbound, ubound)]))
 
         return mem_dict
 

--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -288,7 +288,8 @@ class QlMemoryManager:
 
         assert begin < end, 'search arguments do not make sense'
 
-        ranges = [(max(begin, lbound), min(ubound, end)) for lbound, ubound, _, _, _ in self.map_info if not (end < lbound or ubound < begin)]
+        # narrow the search down to relevant ranges; mmio ranges are excluded due to potential read size effects
+        ranges = [(max(begin, lbound), min(ubound, end)) for lbound, ubound, _, _, is_mmio in self.map_info if not (end < lbound or ubound < begin or is_mmio)]
         results = []
 
         for lbound, ubound in ranges:


### PR DESCRIPTION
Highlights:
- Updated stale annotations, comments and debug messages per mmio mapping functionality
- Enhanced and simplified `map_mmio`
- Excluded mmio ranges from search to avoid potential read side effects
- `pagesize` is now controlable (instead of fixed `0x1000`) to make the memory module easier to adapt to obscure archs and OS in the future