### PR TITLE
Abstract calls to native functions

### DIFF
--- a/qiling/cc/__init__.py
+++ b/qiling/cc/__init__.py
@@ -70,6 +70,17 @@ class QlCC:
 
 		raise NotImplementedError
 
+	def reserve(self, nslots: int) -> None:
+		"""Reserve slots for function arguments.
+
+		This may be used to stage a new frame before executing a native function.
+
+		Args:
+			nslots: number of arg slots to reserve
+		"""
+
+		raise NotImplementedError
+
 	def unwind(self, nslots: int) -> int:
 		"""Unwind frame and return from function call.
 
@@ -149,3 +160,11 @@ class QlCommonBaseCC(QlCC):
 
 	def setReturnValue(self, value: int) -> None:
 		self.ql.reg.write(self._retreg, value)
+
+	def reserve(self, nslots: int) -> None:
+		assert nslots < len(self._argregs), 'too many slots'
+
+		# count how many slots should be reserved on the stack
+		si = self._argregs[:nslots].count(None)
+
+		self.ql.reg.arch_sp -= (self._shadow + si) * self._asize

--- a/qiling/cc/__init__.py
+++ b/qiling/cc/__init__.py
@@ -70,6 +70,15 @@ class QlCC:
 
 		raise NotImplementedError
 
+	def setReturnAddress(self, addr: int) -> None:
+		"""Set function return address.
+
+		Args:
+			addr: return address to set
+		"""
+
+		raise NotImplementedError
+
 	def reserve(self, nslots: int) -> None:
 		"""Reserve slots for function arguments.
 

--- a/qiling/cc/arm.py
+++ b/qiling/cc/arm.py
@@ -11,30 +11,31 @@ from unicorn.arm64_const import (
 from qiling import Qiling
 from . import QlCommonBaseCC
 
-class aarch64(QlCommonBaseCC):
+class QlArmBaseCC(QlCommonBaseCC):
+	"""Calling convention base class for ARM-based systems.
+	Supports arguments passing over registers and stack.
+	"""
+
+	@staticmethod
+	def getNumSlots(argbits: int) -> int:
+		return 1
+
+	def setReturnAddress(self, addr: int) -> None:
+		# TODO: do we need to update LR?
+		self.ql.arch.stack_push(addr)
+
+	def unwind(self, nslots: int) -> int:
+		# TODO: cleanup?
+		return self.ql.arch.stack_pop()
+
+class aarch64(QlArmBaseCC):
 	_argregs = (UC_ARM64_REG_X0, UC_ARM64_REG_X1, UC_ARM64_REG_X2, UC_ARM64_REG_X3, UC_ARM64_REG_X4, UC_ARM64_REG_X5, UC_ARM64_REG_X6, UC_ARM64_REG_X7) + (None, ) * 8
 
 	def __init__(self, ql: Qiling) -> None:
 		super().__init__(ql, UC_ARM64_REG_X0)
 
-	@staticmethod
-	def getNumSlots(argbits: int) -> int:
-		return 1
-
-	def unwind(self, nslots: int) -> int:
-		# TODO: cleanup?
-		return self.ql.arch.stack_pop()
-
-class aarch32(QlCommonBaseCC):
+class aarch32(QlArmBaseCC):
 	_argregs = (UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3) + (None, ) * 12
 
 	def __init__(self, ql: Qiling) -> None:
 		super().__init__(ql, UC_ARM_REG_R0)
-
-	@staticmethod
-	def getNumSlots(argbits: int) -> int:
-		return 1
-
-	def unwind(self, nslots: int) -> int:
-		# TODO: cleanup?
-		return self.ql.arch.stack_pop()

--- a/qiling/cc/intel.py
+++ b/qiling/cc/intel.py
@@ -25,6 +25,9 @@ class QlIntelBaseCC(QlCommonBaseCC):
 
 		super().__init__(ql, retreg)
 
+	def setReturnAddress(self, addr: int) -> None:
+		self.ql.arch.stack_push(addr)
+
 	def unwind(self, nslots: int) -> int:
 		# no cleanup; just pop out the return address
 		return self.ql.arch.stack_pop()

--- a/qiling/os/fcall.py
+++ b/qiling/os/fcall.py
@@ -173,3 +173,25 @@ class QlFunctionCall:
 		retaddr = -1 if passthru else self.cc.unwind(nslots)
 
 		return targs, retval, retaddr
+
+	def call_native(self, addr: int, args: Sequence[Tuple[Any, int]], ret: Optional[int]) -> None:
+		"""Call a native function after properly staging its arguments and return address.
+
+		Args:
+			addr: function entry point
+			args: a sequence of 2-tuples containing parameters types and values to pass to the function; may be empty
+			ret: return address; may be None
+		"""
+
+		# reserve slots for arguments
+		nslots = self.__count_slots(atype for atype, _ in args)
+		self.cc.reserve(nslots)
+
+		# set arguments values
+		self.writeParams(args)
+
+		if ret is not None:
+			self.cc.setReturnAddress(ret)
+
+		# call
+		self.ql.reg.arch_pc = addr


### PR DESCRIPTION
Users may now stage and call native functions without having to do manual frame setup.
This code abstracts away the need to create a new frame, write the arguments, set the return address and pc.

Example:
```python
from qiling.os.const import *
# ...
func_entry = 0xdeadc0de

ql.os.fcall.call_native(func_entry, (
    (POINTER, x),
    (POINTER, y),
    (POINTER, z)
), return_trap)
```

Notes:
- Only supports plain arguments types (i.e. integer values tagged with a `POINTER` type); will support complex types in the future
- Implemented needed methods for Intel and ARM architectures, not yet MIPS and RISC
- The user will have to hook the return address to do a proper cleanup, if needed