### PR TITLE
Support file operations and upxed PE file on Windows

### DIFF
--- a/examples/src/windows/file_upx.c
+++ b/examples/src/windows/file_upx.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+int main()
+{
+    FILE *f;
+    const char *filename = "test.bin";
+    unsigned char buf[5] = {1, 2, 3, 4, 5};
+    f = fopen(filename, "wb");
+    fwrite(buf, 1, 5, f);
+    fclose(f);
+    f = fopen(filename, "rb");
+    fread(buf, 1, 5, f);
+    fclose(f);
+    remove(filename);
+    return 0;
+}

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -3,7 +3,7 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import os, pefile, pickle, secrets, traceback
+import os, pefile, pickle, traceback
 from typing import Any, MutableMapping, Optional, Mapping, Sequence
 
 from qiling import Qiling
@@ -78,7 +78,8 @@ class Process():
             path = os.path.join(self.ql.rootfs, self.ql.dlls, dll_name)
 
         if not os.path.exists(path):
-            raise QlErrorFileNotFound("Cannot find dll in %s" % path)
+            self.ql.log.error("Cannot find dll in %s" % path)
+            return 0
 
         # If the dll is already loaded
         if dll_name in self.dlls:
@@ -257,9 +258,13 @@ class Process():
 
         # we must set an heap, will try to retrieve this value. Is ok to be all \x00
         process_heap = self.ql.os.heap.alloc(0x100)
-        peb_data = PEB(self.ql, base=peb_addr, process_heap=process_heap,
-                       number_processors=self.ql.os.profile.getint("HARDWARE",
-                                                                   "number_processors"))
+        process_parameters = self.ql.os.heap.alloc(0x100)
+        peb_data = PEB(
+            self.ql,
+            base=peb_addr,
+            process_heap=process_heap,
+            process_parameters=process_parameters,
+            number_processors=self.ql.os.profile.getint("HARDWARE", "number_processors"))
         peb_data.LdrAddress = peb_addr + peb_data.size
         peb_data.write(peb_addr)
         self.structure_last_addr += peb_data.size
@@ -603,19 +608,6 @@ class QlLoaderPE(QlLoader, Process):
             self.pe.parse_data_directories()
             data = bytearray(self.pe.get_memory_mapped_image())
             self.ql.mem.write(self.pe_image_address, bytes(data))
-            # setup IMAGE_LOAD_CONFIG_DIRECTORY
-            if self.pe.OPTIONAL_HEADER.DATA_DIRECTORY[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG']].VirtualAddress != 0:
-                SecurityCookie_rva = self.pe.DIRECTORY_ENTRY_LOAD_CONFIG.struct.SecurityCookie - self.pe.OPTIONAL_HEADER.ImageBase
-                SecurityCookie_value = default_security_cookie_value = self.ql.mem.read(self.pe_image_address+SecurityCookie_rva, self.ql.pointersize)
-                while SecurityCookie_value == default_security_cookie_value:
-                    SecurityCookie_value = secrets.token_bytes(self.ql.pointersize)
-                    # rol     rcx, 10h (rcx: cookie)
-                    # test    cx, 0FFFFh
-                    SecurityCookie_value_array = bytearray(SecurityCookie_value)
-                    # Sanity question: We are always little endian, right?
-                    SecurityCookie_value_array[-2:] = b'\x00\x00'
-                    SecurityCookie_value = bytes(SecurityCookie_value_array)
-                self.ql.mem.write(self.pe_image_address+SecurityCookie_rva, SecurityCookie_value)
 
             # Add main PE to ldr_data_table
             mod_name = os.path.basename(self.path)

--- a/qiling/os/windows/dlls/kernel32/__init__.py
+++ b/qiling/os/windows/dlls/kernel32/__init__.py
@@ -18,6 +18,7 @@ from .winnls import *
 from .winnt import *
 from .wow64apiset import *
 from .interlockedapi import *
+from .consoleapi import *
 from .consoleapi2 import *
 from .consoleapi3 import *
 from .debugapi import *

--- a/qiling/os/windows/dlls/kernel32/consoleapi.py
+++ b/qiling/os/windows/dlls/kernel32/consoleapi.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+#
+# Cross Platform and Multi Architecture Advanced Binary Emulation Framework
+#
+
+from qiling import Qiling
+from qiling.os.windows.api import *
+from qiling.os.windows.fncc import *
+
+# BOOL WINAPI GetConsoleMode(
+#   _In_  HANDLE  hConsoleHandle,
+#   _Out_ LPDWORD lpMode
+# );
+@winsdkapi(cc=STDCALL, params={
+    'hConsoleHandle' : HANDLE,
+    'lpMode'         : LPDWORD
+})
+def hook_GetConsoleMode(ql: Qiling, address: int, params):
+    return 1

--- a/qiling/os/windows/dlls/kernel32/libloaderapi.py
+++ b/qiling/os/windows/dlls/kernel32/libloaderapi.py
@@ -63,9 +63,9 @@ def hook_GetModuleHandleExW(ql: Qiling, address: int, params):
     res = _GetModuleHandle(ql, address, params)
     dst = params["phModule"]
 
-    ql.mem.write(dst, ql.pack32(res))
+    ql.mem.write(dst, ql.pack(res))
 
-    return 1
+    return res
 
 # DWORD GetModuleFileNameA(
 #   HMODULE hModule,

--- a/qiling/os/windows/dlls/kernel32/winbase.py
+++ b/qiling/os/windows/dlls/kernel32/winbase.py
@@ -766,12 +766,3 @@ def hook_GetPrivateProfileStringA(ql: Qiling, address: int, params):
 })
 def hook_WritePrivateProfileStringA(ql: Qiling, address: int, params):
     pass
-
-# BOOL DeleteFileA(
-#   LPCSTR lpFileName
-# );
-@winsdkapi(cc=STDCALL, params={
-    'lpFileName' : LPCSTR
-})
-def hook_DeleteFileA(ql: Qiling, address: int, params):
-    return 1

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -87,6 +87,28 @@ class PETest(unittest.TestCase):
         self.assertTrue(QLWinSingleTest(_t).run())
 
 
+    def test_pe_win_x8664_file_upx(self):
+        def _t():
+            ql = Qiling(["../examples/rootfs/x8664_windows/bin/x8664_file_upx.exe"], "../examples/rootfs/x8664_windows",
+                        verbose=QL_VERBOSE.DEFAULT)
+            ql.run()
+            del ql
+            return True
+
+        self.assertTrue(QLWinSingleTest(_t).run())
+
+
+    def test_pe_win_x86_file_upx(self):
+        def _t():
+            ql = Qiling(["../examples/rootfs/x86_windows/bin/x86_file_upx.exe"], "../examples/rootfs/x86_windows",
+                        verbose=QL_VERBOSE.DEFAULT)
+            ql.run()
+            del ql
+            return True
+
+        self.assertTrue(QLWinSingleTest(_t).run())
+
+
     def test_pe_win_x86_uselessdisk(self):
         def _t():
             if 'QL_FAST_TEST' in os.environ:
@@ -98,7 +120,7 @@ class PETest(unittest.TestCase):
                 
                 def write(self, bs):
                     print(bs)
-                    return
+                    return len(bs)
 
                 def fstat(self):
                     return -1


### PR DESCRIPTION
<!--
We highly appreciate your interest and contribution to our project.
Before submiting your PR, please finish the checklist below.
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [x] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

Security cookie is inited by `___security_init_cookie`, we shouldn't change it by ourself, and this will prevent UPXed file to run.

`file_upx.c` is compiled by cl ( VS 2019 ) and compressed by UPX. The binary is provided in qilingframework/rootfs#26.

Rework of 97cd0b9e57ee45b9ca629fa6fb77011c47c6c0c8
Fix #751
Refer: #452, #836
