### PR TITLE
fix format error

### DIFF
--- a/qiling/os/posix/syscall/ioctl.py
+++ b/qiling/os/posix/syscall/ioctl.py
@@ -81,7 +81,7 @@ def ql_syscall_ioctl(ql: Qiling, fd: int, cmd: int, arg: int):
     if isinstance(ql.os.fd[fd], ql_socket) and cmd in (SIOCGIFADDR, SIOCGIFNETMASK):
         try:
             tmp_arg = ql.mem.read(arg, 64)
-            ql.log.debug(f'query network card : {tmp_arg:s}')
+            ql.log.debug(f'query network card : {bytes(tmp_arg)}')
 
             data = ql.os.fd[fd].ioctl(cmd, bytes(tmp_arg))
             ql.mem.write(arg, data)


### PR DESCRIPTION
fix https://github.com/qilingframework/qiling/issues/1045

The error in `ioctl()` from `check_network()` hung up the httpd service.
```
init_core_dump(v2);
v3 = puts("\n\nYes:\n\n      ****** WeLoveLinux****** \n\n Welcome to ...");
sub_30A5C(v3);
while ( check_network(v21) <= 0 )
  sleep(1u);
```