### PR TITLE
Fix ql_open_flag_mapping for Linux binary emulation on Windows

### DIFF
--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -533,6 +533,24 @@ freebsd_x86_open_flags = {
     'O_LARGEFILE': None
 }
 
+windows_x86_open_flags = {
+    'O_RDONLY': 0x0,
+    'O_WRONLY': 0x1,
+    'O_RDWR': 0x2,
+    'O_NONBLOCK': None,
+    'O_APPEND': 0x8,
+    'O_ASYNC': None,
+    'O_SYNC': None,
+    'O_NOFOLLOW': None,
+    'O_CREAT': 0x100,
+    'O_TRUNC': 0x200,
+    'O_EXCL': 0x400,
+    'O_NOCTTY': None,
+    'O_DIRECTORY': None,
+    'O_BINARY': 0x8000,
+    'O_LARGEFILE': None
+}
+
 qnx_arm64_open_flags = {
     'O_RDONLY'    : 0x00000,
     'O_WRONLY'    : 0x00001,

--- a/qiling/os/posix/const_mapping.py
+++ b/qiling/os/posix/const_mapping.py
@@ -64,6 +64,8 @@ def ql_open_flag_mapping(ql: Qiling, flags):
             f = macos_x86_open_flags
     elif ql.ostype == QL_OS.FREEBSD:
         f = freebsd_x86_open_flags
+    elif ql.ostype == QL_OS.WINDOWS:
+        f = windows_x86_open_flags
     elif ql.ostype == QL_OS.QNX:
         f = qnx_arm64_open_flags
 
@@ -73,6 +75,8 @@ def ql_open_flag_mapping(ql: Qiling, flags):
         t = macos_x86_open_flags
     elif ql.platform_os == QL_OS.FREEBSD:
         t = freebsd_x86_open_flags
+    elif ql.platform_os == QL_OS.WINDOWS:
+        t = windows_x86_open_flags
 
     if f == t:
         return flags


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
Linux binary emulation on Windows fails with the following error because windows_open_flags was removed from qiling/os/posix/const_mapping.py with the commit https://github.com/qilingframework/qiling/commit/de6a17baef7cbd48a50161579256524ba5d2bed3 . This pull request resurrects windows_open_flags  as windows_x86_open_flags to fix the error. I tested with the latest dev branch of Qiling Framework and Unicorn Engine 2.0.0rc5.post1.

```powershell
PS X:\qiling-test\qiling> py.exe -3 .\qltool run -f .\examples\rootfs\x8664_linux\bin\x8664_hello --rootfs .\examples\rootfs\x8664_linux
[=]     brk(inp = 0x0) = 0x555555758000
[=]     uname(buf = 0x80000000d980) = 0x0
[=]     access(path = 0x7ffff7df6082, mode = 0x0) = -0x1 (EPERM)
[=]     access(path = 0x7ffff7df8dd0, mode = 0x4) = -0x1 (EPERM)
[x]     Syscall ERROR: ql_syscall_openat DEBUG: 'O_RDONLY'
Traceback (most recent call last):
  File "X:\qiling-test\qiling\qiling\os\posix\posix.py", line 222, in load_syscall
    retval = syscall_hook(self.ql, *params)
  File "X:\qiling-test\qiling\qiling\os\posix\syscall\fcntl.py", line 100, in ql_syscall_openat
    flags = ql_open_flag_mapping(ql, flags)
  File "X:\qiling-test\qiling\qiling\os\posix\const_mapping.py", line 80, in ql_open_flag_mapping
    return flag_mapping(flags, open_flags_name, f, t)
  File "X:\qiling-test\qiling\qiling\os\posix\const_mapping.py", line 40, in flag_mapping
    if mapping_from[n] is None or mapping_to[n] is None:
KeyError: 'O_RDONLY'
Traceback (most recent call last):
  File "X:\qiling-test\qiling\qltool", line 256, in <module>
    ql.run(timeout=options.timeout)
  File "X:\qiling-test\qiling\qiling\core.py", line 728, in run
    self.os.run()
  File "X:\qiling-test\qiling\qiling\os\linux\linux.py", line 143, in run
    self.ql.emu_start(self.ql.loader.entry_point, entry_address, self.ql.timeout)
  File "X:\qiling-test\qiling\qiling\core.py", line 882, in emu_start
    raise self._internal_exception
  File "X:\qiling-test\qiling\qiling\utils.py", line 159, in wrapper
    return func(*args, **kw)
  File "X:\qiling-test\qiling\qiling\core_hooks.py", line 71, in _hook_insn_cb
    ret = hook.call(ql, *args[:-1])
  File "X:\qiling-test\qiling\qiling\core_hooks_types.py", line 25, in call
    return self.callback(ql, *args)
  File "X:\qiling-test\qiling\qiling\os\linux\linux.py", line 104, in hook_syscall
    return self.load_syscall()
  File "X:\qiling-test\qiling\qiling\os\posix\posix.py", line 240, in load_syscall
    raise e
  File "X:\qiling-test\qiling\qiling\os\posix\posix.py", line 222, in load_syscall
    retval = syscall_hook(self.ql, *params)
  File "X:\qiling-test\qiling\qiling\os\posix\syscall\fcntl.py", line 100, in ql_syscall_openat
    flags = ql_open_flag_mapping(ql, flags)
  File "X:\qiling-test\qiling\qiling\os\posix\const_mapping.py", line 80, in ql_open_flag_mapping
    return flag_mapping(flags, open_flags_name, f, t)
  File "X:\qiling-test\qiling\qiling\os\posix\const_mapping.py", line 40, in flag_mapping
    if mapping_from[n] is None or mapping_to[n] is None:
KeyError: 'O_RDONLY'
PS X:\qiling-test\qiling>
```

Though the error above can be fixed with this pull request, another error `unicorn.unicorn.UcError: Invalid memory read (UC_ERR_READ_UNMAPPED)` occurs as follows. It seems to be another issue and similar to the issue #974 . I am not able to fix this error because I am not familiar with internals of Qiling Framework and Unicorn Engine. 😭

```powershell
PS X:\qiling-test\qiling> py.exe -3 .\qltool run -f .\examples\rootfs\x8664_linux\bin\x8664_hello --rootfs .\examples\rootfs\x8664_linux -v debug
[+]     Profile: Default
[+]     Map GDT at 0x30000 with GDT_LIMIT=4096
[+]     Write to 0x30018 for new entry b'\x00\xf0\x00\x00\x00\xfeO\x00'
[+]     Write to 0x30028 for new entry b'\x00\xf0\x00\x00\x00\x96O\x00'
[+]     Mapped 0x555555554000-0x555555555000
[+]     Mapped 0x555555754000-0x555555756000
[+]     mem_start : 0x0
[+]     mem_end   : 0x202000
[+]     Interpreter path: examples\rootfs\x8664_linux\lib64\ld-linux-x86-64.so.2
[+]     Interpreter addr: 0x7ffff7dd5000
[+]     Interpreter size: 0x22a000
[+]     mmap_address is : 0x7fffb7dd6000
[+]     rel name b'_ITM_deregisterTMCloneTable'
[+]     rel name b'__libc_start_main'
[+]     rel name b'__gmon_start__'
[+]     rel name b'_ITM_registerTMCloneTable'
[+]     rel name b'__cxa_finalize'
[+]     rel name b'puts'
[+]     syscall hooked 0x7ffff7df0ec7: ql_syscall_brk()
[+]     0x00007ffff7df0ec7: brk(inp = 0x0) = 0x555555758000
[+]     syscall hooked 0x7ffff7df2015: ql_syscall_uname()
[+]     0x00007ffff7df2015: uname(buf = 0x80000000d980) = 0x0
[+]     syscall hooked 0x7ffff7de47dc: ql_syscall_access()
[+]     No such file or directory: \etc\ld.so.nohwcap
[+]     0x00007ffff7de47dc: access(path = 0x7ffff7df6082, mode = 0x0) = -0x1 (EPERM)
[+]     syscall hooked 0x7ffff7df1e25: ql_syscall_access()
[+]     No such file or directory: \etc\ld.so.preload
[+]     0x00007ffff7df1e25: access(path = 0x7ffff7df8dd0, mode = 0x4) = -0x1 (EPERM)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /etc/ld.so.cache, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x7ffff7df6428, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64-linux-gnu/tls/i686/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64-linux-gnu/tls/i686/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64-linux-gnu/tls/i686/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64-linux-gnu/tls/i686", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64-linux-gnu/tls/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64-linux-gnu/tls/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64-linux-gnu/tls/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64-linux-gnu/tls", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64-linux-gnu/i686/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64-linux-gnu/i686/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64-linux-gnu/i686/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64-linux-gnu/i686", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64-linux-gnu/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64-linux-gnu/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64-linux-gnu/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64-linux-gnu", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/tls/i686/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/usr/lib/x86_64-linux-gnu/tls/i686/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/tls/i686/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/usr/lib/x86_64-linux-gnu/tls/i686", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/tls/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/usr/lib/x86_64-linux-gnu/tls/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/tls/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/usr/lib/x86_64-linux-gnu/tls", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/i686/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/usr/lib/x86_64-linux-gnu/i686/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/i686/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/usr/lib/x86_64-linux-gnu/i686", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/usr/lib/x86_64-linux-gnu/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/usr/lib/x86_64-linux-gnu", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/tls/i686/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/tls/i686/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/tls/i686/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/tls/i686", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/tls/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/tls/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/tls/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/tls", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/i686/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/i686/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/i686/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/i686", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/x86_64/libc.so.6, mode = 0o0) = -2
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1c03: ql_syscall_stat()
[+]     stat("/lib/x86_64", 0x80000000d3d0) read/write fail
[+]     0x00007ffff7df1c03: stat(path = 0x80000000d310, buf_ptr = 0x80000000d3d0) = -0x2 (ENOENT)
[+]     syscall hooked 0x7ffff7df1cdb: ql_syscall_openat()
[+]     openat(fd = 4294967196, path = /lib/libc.so.6, mode = 0o0) = 3
[+]     0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d310, flags = 0x80000, mode = 0x0) = 0x3
[+]     syscall hooked 0x7ffff7df1da2: ql_syscall_read()
[+]     read() CONTENT: b'\x7fELF\x02\x01\x01\x03\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00>\x00\x01\x00\x00\x00\xb0\x1c\x02\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00\x90\xe9\x1e\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x008\x00\n\x00@\x00I\x00H\x00\x06\x00\x00\x00\x04\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x000\x02\x00\x00\x00\x00\x00\x000\x02\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00P\xdd\x1b\x00\x00\x00\x00\x00P\xdd\x1b\x00\x00\x00\x00\x00P\xdd\x1b\x00\x00\x00\x00\x00\x1c\x00\x00\x00\x00\x00\x00\x00\x1c\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa0j\x1e\x00\x00\x00\x00\x00\xa0j\x1e\x00\x00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x01\x00\x00\x00\x06\x00\x00\x00 v\x1e\x00\x00\x00\x00\x00 v>\x00\x00\x00\x00\x00 v>\x00\x00\x00\x00\x00@R\x00\x00\x00\x00\x00\x00\xc0\x94\x00\x00\x00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x02\x00\x00\x00\x06\x00\x00\x00\x80\xab\x1e\x00\x00\x00\x00\x00\x80\xab>\x00\x00\x00\x00\x00\x80\xab>\x00\x00\x00\x00\x00\xe0\x01\x00\x00\x00\x00\x00\x00\xe0\x01\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00p\x02\x00\x00\x00\x00\x00\x00p\x02\x00\x00\x00\x00\x00\x00p\x02\x00\x00\x00\x00\x00\x00D\x00\x00\x00\x00\x00\x00\x00D\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x04\x00\x00\x00 v\x1e\x00\x00\x00\x00\x00 v>\x00\x00\x00\x00\x00 v>\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x90\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00P\xe5td\x04\x00\x00\x00l\xdd\x1b\x00\x00\x00\x00\x00l\xdd\x1b\x00\x00\x00\x00\x00l\xdd\x1b\x00\x00\x00\x00\x00\xdcY\x00\x00\x00\x00\x00\x00\xdcY\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00Q\xe5td\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00R\xe5td\x04\x00\x00\x00 v\x1e\x00\x00\x00\x00\x00 v>\x00\x00\x00\x00\x00 v>\x00\x00\x00\x00\x00\xe09\x00\x00\x00\x00\x00\x00\xe09\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x14\x00\x00\x00\x03\x00\x00\x00GNU\x00\xb4\x17\xc0\xba|\xc5\xcf\x06\xd1\xd1\xbe\xd6e,\xed\xb9%<`\xd0\x04\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00GNU\x00\x00\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf3\x03\x00\x00\n\x00\x00\x00\x00\x01\x00\x00\x0e\x00\x00\x00\x000\x10D\xa0 \x02\x01\x88\x03\xe6\x90\xc5E\x8c\x00\xc4\x00X\x00\x07\x84\x00p\xc2\x80\x00\r\x8a\x0cA\x04\x10\x00\x88@2\x08*@\x88T<- \x0e2H&\x84\xc0\x8c\x04\x08\x00\x02\x02\x0e\xa1\xac'
[+]     0x00007ffff7df1da2: read(fd = 0x3, buf = 0x80000000d538, length = 0x340) = 0x304
[+]     syscall hooked 0x7ffff7df1c41: ql_syscall_fstat()
[+]     fstat write completed
[+]     0x00007ffff7df1c41: fstat(fd = 0x3, buf_ptr = 0x80000000d3d0) = 0x0
[+]     syscall hooked 0x7ffff7df1f41: ql_syscall_mmap()
[+]     mmap - mapping needed for 0x7fffb7dd6000
[+]     mmap - addr range  0x7fffb7dd6000 - 0x7fffb81c6fff:
[+]     mem write : 0x304
[+]     mem mmap  : X:\qiling-test\qiling\examples\rootfs\x8664_linux\lib\libc.so.6
[+]     0x00007ffff7df1f41: mmap(addr = 0x0, length = 0x3f0ae0, prot = 0x5, flags = 0x802, fd = 0x3, pgoffset = 0x0) = 0x7fffb7dd6000
[+]     syscall hooked 0x7ffff7df1ff5: ql_syscall_mprotect()
[+]     0x00007ffff7df1ff5: mprotect(start = 0x7fffb7fbd000, mlen = 0x200000, prot = 0x0) = 0x0
[+]     syscall hooked 0x7ffff7df1f41: ql_syscall_mmap()
[+]     mmap - MAP_FIXED, mapping not needed
[+]     mem write : 0x1680
[+]     mem mmap  : X:\qiling-test\qiling\examples\rootfs\x8664_linux\lib\libc.so.6
[+]     0x00007ffff7df1f41: mmap(addr = 0x7fffb81bd000, length = 0x6000, prot = 0x3, flags = 0x812, fd = 0x3, pgoffset = 0x1e7000) = 0x7fffb81bd000
[+]     syscall hooked 0x7ffff7df1f41: ql_syscall_mmap()
[+]     mmap - MAP_FIXED, mapping not needed
[+]     0x00007ffff7df1f41: mmap(addr = 0x7fffb81c3000, length = 0x3ae0, prot = 0x3, flags = 0x32, fd = 0xffffffff, pgoffset = 0x0) = 0x7fffb81c3000
[+]     syscall hooked 0x7ffff7df1ed5: ql_syscall_close()
[+]     0x00007ffff7df1ed5: close(fd = 0x3) = 0x0
[x]     CPU Context:
[x]     ah      : 0x0
[x]     al      : 0x0
[x]     ch      : 0x0
[x]     cl      : 0x0
[x]     dh      : 0x0
[x]     dl      : 0x1
[x]     bh      : 0x44
[x]     bl      : 0x0
[x]     ax      : 0x0
[x]     cx      : 0x0
[x]     dx      : 0x1
[x]     bx      : 0x4400
[x]     sp      : 0xd9f0
[x]     bp      : 0xe930
[x]     si      : 0xedc0
[x]     di      : 0x4361
[x]     ip      : 0x6a92
[x]     eax     : 0x0
[x]     ecx     : 0x0
[x]     edx     : 0x1
[x]     ebx     : 0x55554400
[x]     esp     : 0xd9f0
[x]     ebp     : 0xf7ffe930
[x]     esi     : 0xf7ffedc0
[x]     edi     : 0x55554361
[x]     eip     : 0xf7de6a92
[x]     rax     : 0x0
[x]     rbx     : 0x555555554400
[x]     rcx     : 0x0
[x]     rdx     : 0x1
[x]     rsi     : 0x7ffff7ffedc0
[x]     rdi     : 0x555555554361
[x]     rbp     : 0x7ffff7ffe930
[x]     rsp     : 0x80000000d9f0
[x]     r8      : 0x0
[x]     r9      : 0x0
[x]     r10     : 0x32
[x]     r11     : 0x3ec860
[x]     r12     : 0x80000000dfd0
[x]     r13     : 0x9691a75
[x]     r14     : 0x7ffff7df5840
[x]     r15     : 0x0
[x]     rip     : 0x7ffff7de6a92
[x]     cr0     : 0x11
[x]     cr1     : 0x0
[x]     cr2     : 0x0
[x]     cr3     : 0x0
[x]     cr4     : 0x0
[x]     cr8     : 0x0
[x]     st0     : 0x0
[x]     st1     : 0x0
[x]     st2     : 0x0
[x]     st3     : 0x0
[x]     st4     : 0x0
[x]     st5     : 0x0
[x]     st6     : 0x0
[x]     st7     : 0x0
[x]     ef      : 0x80
[x]     cs      : 0x1b
[x]     ss      : 0x28
[x]     ds      : 0x28
[x]     es      : 0x28
[x]     fs      : 0x0
[x]     gs      : 0x0
[x]     r8b     : 0x0
[x]     r9b     : 0x0
[x]     r10b    : 0x32
[x]     r11b    : 0x60
[x]     r12b    : 0xd0
[x]     r13b    : 0x75
[x]     r14b    : 0x40
[x]     r15b    : 0x0
[x]     r8w     : 0x0
[x]     r9w     : 0x0
[x]     r10w    : 0x32
[x]     r11w    : 0xc860
[x]     r12w    : 0xdfd0
[x]     r13w    : 0x1a75
[x]     r14w    : 0x5840
[x]     r15w    : 0x0
[x]     r8d     : 0x0
[x]     r9d     : 0x0
[x]     r10d    : 0x32
[x]     r11d    : 0x3ec860
[x]     r12d    : 0xdfd0
[x]     r13d    : 0x9691a75
[x]     r14d    : 0xf7df5840
[x]     r15d    : 0x0
[x]     fsbase  : 0x0
[x]     gsbase  : 0x6000000
[x]     Hexdump:
[x]     48 8b 05 a7 5c 21 00 4c
[x]     Disassembly:
[=]     00007ffff7de6a92 [ld-linux-x86-64.so.2 + 0x011a92]  48 8b 05 a7 5c 21 00 4c 8b 20 48 8d 05 4c ef 00 00 4d 85 e4 4c 0f 44 e0 48 8b 45 68 48 8b 40 08 48 89 44 24 08 48 8d 05 a2 5c 21 00 f6 00 10 0f 85 b9 01 00 00 48 8b 85 68 01 00 00 48 85 c0 0fmov                  rax, qword ptr [rip + 0x215ca7]
> mov                  r12, qword ptr [rax]
> lea                  rax, [rip + 0xef4c]
> test                 r12, r12
> cmove                r12, rax
> mov                  rax, qword ptr [rbp + 0x68]
> mov                  rax, qword ptr [rax + 8]
> mov                  qword ptr [rsp + 8], rax
> lea                  rax, [rip + 0x215ca2]
> test                 byte ptr [rax], 0x10
> jne                  0x7ffff7de6c80
> mov                  rax, qword ptr [rbp + 0x168]
> test                 rax, rax
[x]     PC = 0x00007ffff7de6a92

[=]     Memory map:
[=]     Start      End        Perm    Label          Image
[=]     00030000 - 00031000   rwx     [GDT]
[=]     06000000 - 07400000   rwx     [GS]
[=]     555555554000 - 555555555000   r-x     .\examples\rootfs\x8664_linux\bin\x8664_hello   .\examples\rootfs\x8664_linux\bin\x8664_hello
[=]     555555754000 - 555555756000   rw-     .\examples\rootfs\x8664_linux\bin\x8664_hello   .\examples\rootfs\x8664_linux\bin\x8664_hello
[=]     555555756000 - 555555758000   rwx     [hook_mem]
[=]     7fffb7dd6000 - 7fffb7fbd000   r-x     [mmap] X:\qiling-test\qiling\examples\rootfs\x8664_linux\lib\libc.so.6
[=]     7fffb7fbd000 - 7fffb81bd000   ---     [mmap] X:\qiling-test\qiling\examples\rootfs\x8664_linux\lib\libc.so.6
[=]     7fffb81bd000 - 7fffb81c3000   rw-     [mmap] X:\qiling-test\qiling\examples\rootfs\x8664_linux\lib\libc.so.6
[=]     7fffb81c3000 - 7fffb81c7000   rw-     [mmap] X:\qiling-test\qiling\examples\rootfs\x8664_linux\lib\libc.so.6
[=]     7ffff7dd5000 - 7ffff7fff000   rwx     X:\qiling-test\qiling\examples\rootfs\x8664_linux\lib64\ld-linux-x86-64.so.2
[=]     7ffffffde000 - 80000000e000   rwx     [stack]
[=]     ffffffffff600000 - ffffffffff601000   rwx     [vsyscall]
Traceback (most recent call last):
  File "X:\qiling-test\qiling\qltool", line 256, in <module>
    ql.run(timeout=options.timeout)
  File "X:\qiling-test\qiling\qiling\core.py", line 728, in run
    self.os.run()
  File "X:\qiling-test\qiling\qiling\os\linux\linux.py", line 143, in run
    self.ql.emu_start(self.ql.loader.entry_point, entry_address, self.ql.timeout)
  File "X:\qiling-test\qiling\qiling\core.py", line 879, in emu_start
    self.uc.emu_start(begin, end, timeout, count)
  File "C:\Users\nobut\AppData\Local\Programs\Python\Python39\lib\site-packages\unicorn\unicorn.py", line 465, in emu_start
    raise UcError(status)
unicorn.unicorn.UcError: Invalid memory read (UC_ERR_READ_UNMAPPED)
PS X:\qiling-test\qiling>
```