### PR TITLE
Fix bytes call hex() take argument & update some IDA methods

### DIFF
--- a/qiling/arch/utils.py
+++ b/qiling/arch/utils.py
@@ -36,8 +36,10 @@ class QlArchUtils:
         qd = ql.arch.create_disassembler()
 
         offset, name = self.get_offset_and_name(address)
-        log_data = f'{address:0{ql.archbit // 4}x} [{name:20s} + {offset:#08x}]  {tmp.hex(" "):30s}'
+        tmp_formated = ' '.join([f'{b:02X}' for b in tmp])
+        log_data = f'{address:0{ql.archbit // 4}x} [{name:20s} + {offset:#08x}]  {tmp_formated:30s}'
         log_insn = '\n> '.join(f'{insn.mnemonic:20s} {insn.op_str}' for insn in qd.disasm(tmp, address))
+        log_insn = '\n> ' + log_insn
 
         ql.log.info(log_data + log_insn)
 

--- a/qiling/extensions/idaplugin/qilingida.py
+++ b/qiling/extensions/idaplugin/qilingida.py
@@ -334,7 +334,7 @@ class IDA:
     @staticmethod
     def get_ql_arch_string():
         info = IDA.get_info_structure()
-        proc = info.get_procName().lower()
+        proc = info.procname.lower()
         result = None
         if proc == "metapc":
             result = "x86"
@@ -814,7 +814,7 @@ class QlEmuMisc:
             self.action_type = action
 
         def activate(self, ctx):
-            if ctx.form_type == BWN_DISASM:
+            if ctx.widget_type == BWN_DISASM:
                 self.action_handler.ql_handle_menu_action(self.action_type)
             return 1
 

--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -241,7 +241,7 @@ class QlOs:
             pc_info = ' (unreachable)'
         else:
             self.ql.log.error('Hexdump:')
-            self.ql.log.error(data.hex(' '))
+            self.ql.log.error(' '.join([f'{b:02X}' for b in data or []]))
 
             self.ql.log.error('Disassembly:')
             self.ql.arch.utils.disassembler(self.ql, pc, 64)

--- a/qiling/os/posix/syscall/random.py
+++ b/qiling/os/posix/syscall/random.py
@@ -14,7 +14,8 @@ def ql_syscall_getrandom(ql: Qiling, buf: int, buflen: int, flags: int):
     except:
         retval = -1
     else:
-        ql.log.debug(f'getrandom() CONTENT: {data.hex(" ")}')
+        data_formated = ' '.join([f'{b:02X}' for b in data])
+        ql.log.debug(f'getrandom() CONTENT: {data_formated}')
         retval = len(data)
 
     return retval


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [ ] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

Some minor fixes:
1. Bytes call hex() should not take arguments. For formating the hex byte separate with blank space, use `' '.join()` to do it.
2. `qiling/arch/utils.py` line 42: `log_insn = '\n> '.join(f'{insn.mnemonic:20s} {insn.op_str}' for insn in qd.disasm(tmp, address))`  The first output command should also add `\n> `
3. According to [IDA's IDAPython official documentation](https://hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide/), some of the old methods have changed names for a long time. In IDA v7.7, some methods are no longer available. Follow the documentation to change the method in `qiling/extensions/idaplugin/qilingida.py`.

Env:
Win10 x64
Pyhton 3.7.9 x64
IDA 7.7
