### PR TITLE
Add vm_context to EVM hooks

### DIFF
--- a/qiling/arch/evm/vm/exec.py
+++ b/qiling/arch/evm/vm/exec.py
@@ -50,13 +50,13 @@ class EVMExecutor:
 
             if dis_insn.is_hook_code:
                 for h in dis_insn.callback_list.hook_code_list:
-                    h.call(self.vm_context.state.ql)
+                    h.call(self.vm_context.state.ql, self.vm_context)
             if dis_insn.is_hook_insn:
                 for h in dis_insn.callback_list.hook_insn_list:
-                    h.call(self.vm_context.state.ql)
+                    h.call(self.vm_context.state.ql, self.vm_context)
             if dis_insn.is_hook_addr:
                 for h in dis_insn.callback_list.hook_addr_dict[pc]:
-                    h.call(self.vm_context.state.ql)
+                    h.call(self.vm_context.state.ql, self.vm_context)
 
         except KeyError:
             opcode_fn = InvalidOpcode(opcode)

--- a/tests/test_evm.py
+++ b/tests/test_evm.py
@@ -36,7 +36,7 @@ class EVMTest(unittest.TestCase):
         def hookinsn_test(ql, *argv):
             testcheck.visited_hookinsn = True
 
-        def hookaddr_test(ql):
+        def hookaddr_test(ql, *argv):
             testcheck.visited_hookaddr = True
 
         h0 = ql.hook_code(hookcode_test)


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [X] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [X] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [X] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

This PR allow the use of the `vm_context` variable inside hooks for the EVM arch.
This will allow users to access all the EVM properties like the PC, disassembler code, stack, memory and storage.