### PR TITLE
Add EVM ABI helpers, fix EVM DBG stack view

### DIFF
--- a/qiling/arch/evm/abi.py
+++ b/qiling/arch/evm/abi.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 
-from eth_abi import encode_abi
+from eth_abi import encode_abi, decode_abi, encode_single, decode_single
+from eth_utils.abi import collapse_if_tuple
+from eth_utils import function_signature_to_4byte_selector, function_abi_to_4byte_selector, decode_hex, encode_hex
 from .vm.utils import bytecode_to_bytes
 
 
 class QlArchEVMABI:
     @staticmethod
     def convert(datatypes:list, values:list) -> str:
+        return QlArchEVMABI.encode_params(datatypes, values)
+
+    @staticmethod
+    def encode_params(datatypes:list, values:list) -> str:
         for idx, item in enumerate(datatypes):
             if item == 'address':
                 if isinstance(values[idx], int):
@@ -15,3 +21,26 @@ class QlArchEVMABI:
                     values[idx] = bytecode_to_bytes(values[idx])
         
         return encode_abi(datatypes, values).hex()
+
+    @staticmethod
+    def decode_params(datatypes:list, value:str) -> list:
+        return decode_abi(datatypes, value)
+
+    @staticmethod
+    def encode_function_call(abi:str, params:list) -> str:
+        abi = abi.replace(' ', '')
+        if '(' not in abi or ')' not in abi:
+            raise ValueError(f'Function signature must contain "(" and ")": {abi}')
+        signature = function_signature_to_4byte_selector(abi)
+        inputs = abi[abi.index('('):]
+        params = encode_single(inputs, params)
+        return encode_hex(signature + params)
+
+    @staticmethod
+    def encode_function_call_abi(abi:dict, params:list) -> str:
+        signature = function_abi_to_4byte_selector(abi)
+        inputs = ",".join(
+            [collapse_if_tuple(abi_input) for abi_input in abi.get("inputs", [])]
+        )
+        params = encode_single(f"({inputs})", params)
+        return encode_hex(signature + params)

--- a/qiling/arch/evm/vm/dbgcui.py
+++ b/qiling/arch/evm/vm/dbgcui.py
@@ -59,10 +59,12 @@ def hexdump(src, length=16, sep='.', minrows=8, start=0, prevsrc="", to_list=Fal
         return result
     return '\n'.join(result)
 
-def stackdump(src, length=16, minrows=8, start=0, to_list=False):
+def stackdump(src, minrows=8, to_list=False):
     result = []
 
-    for i in range(start, min(minrows, len(src))):
+    # only the last N elements should be printed
+    start = len(src) - min(minrows, len(src))
+    for i in range(min(minrows, len(src)) + start - 1, start - 1, -1):
         v_type = src[i][0]
         value = src[i][1]
         if v_type is bytes:


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [X] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [X] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [X] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [X] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

This PR adds some helper methods to deal with ABI encoding/decoding.
In particular I've renamed `convert` to `encode_params` while keeping backward compatibility, and I've added `decode_params`, `encode_function_call` and `encode_function_call_abi` functions.

This functions can be used to encode a contract function call and its parameter when the function prototype is known or when the ABI is available.
I've also added a new test for this functionality in the `tests/test_evm.py`. The relevant lines from 126 to 137 highlight the new feature.

Moreover I've fixed the display of the Stack in the EVM debugger.
When the stack was greater than 8, only the first 8 rows were displayed. Moreover the stack was growing top to bottom.
Now the stack displays the last 8 rows (the most recent and relevant ones) and grows bottom to top.

This can be tested with the following snippet as shown in the screenshot below:
```python
from qiling import *

if __name__ == '__main__':
    contract = '0x' + ('6001' * 10) + '60ff00'
    ql = Qiling(code=contract, archtype="evm")
    ql.debugger = True
    
    user1 = ql.arch.evm.create_account(balance=100*10**18)
    contract_addr = ql.arch.evm.create_account()
    msg0 = ql.arch.evm.create_message(user1, b'', code=ql.code, contract_address=contract_addr)
    ql.run(code=msg0)
```
![q](https://user-images.githubusercontent.com/686894/161396541-9e13c903-ee0d-4668-ab94-5a9948517390.png)
