### PR TITLE
fix(memory): remove misused region bound check of unmap_all

### DIFF
--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -419,8 +419,7 @@ class QlMemoryManager:
         """
 
         for begin, end, _ in self.ql.uc.mem_regions():
-            if begin and end:
-                self.unmap(begin, end - begin + 1)
+            self.unmap(begin, end - begin + 1)
 
     def is_available(self, addr: int, size: int) -> bool:
         """Query whether the memory range starting at `addr` and is of length of `size` bytes


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

If `self.ql.uc.mem_regions()` works properly, there is no need to check `begin` and `and`. Moreover, `begin=0` is a false negative.

closes #1141