### PR TITLE
Change deprecated interfaces of IDA

### DIFF
--- a/qiling/extensions/idaplugin/qilingida.py
+++ b/qiling/extensions/idaplugin/qilingida.py
@@ -334,7 +334,7 @@ class IDA:
     @staticmethod
     def get_ql_arch_string():
         info = IDA.get_info_structure()
-        proc = info.get_procName().lower()
+        proc = info.procname.lower()
         result = None
         if proc == "metapc":
             result = "x86"
@@ -814,7 +814,7 @@ class QlEmuMisc:
             self.action_type = action
 
         def activate(self, ctx):
-            if ctx.form_type == BWN_DISASM:
+            if ctx.widget_type == BWN_DISASM:
                 self.action_handler.ql_handle_menu_action(self.action_type)
             return 1
 


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [ ] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

Just recreate a PR for part of #1095. 

Some minor fixes:
1. According to [IDA's IDAPython official documentation](https://hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide/), some of the old methods have changed names for a long time. In IDA v7.7, some methods are no longer available. Follow the documentation to change the method in `qiling/extensions/idaplugin/qilingida.py`.


