### PR TITLE
Rewrite package data reading

### DIFF
--- a/.github/workflows/giteesync.yml
+++ b/.github/workflows/giteesync.yml
@@ -5,6 +5,7 @@
  jobs:
    deploy:
      runs-on: ubuntu-latest
+     if: github.repository_owner == 'qilingframework'
      steps:
      - uses: actions/checkout@v2
        with:

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -54,6 +54,7 @@
 - danielmoos
 - sigeryang
 - bet4it
+- nullableVoidPtr
 
 
 #### Legacy Core Developers

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-recursive-include qiling/debugger/gdb/xml *
-recursive-include qiling/extensions/windows_sdk/defs *
-recursive-include qiling/profiles *
-include qiling/os/uefi/guids.csv
-include qiling/arch/evm/analysis/signatures.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-include qiling/debugger/gdb/xml *
 recursive-include qiling/extensions/windows_sdk/defs *
 recursive-include qiling/profiles *
 include qiling/os/uefi/guids.csv
+include qiling/arch/evm/analysis/signatures.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ recursive-include qiling/debugger/gdb/xml *
 recursive-include qiling/extensions/windows_sdk/defs *
 recursive-include qiling/profiles *
 include qiling/os/uefi/guids.csv
-include qiling/os/qnx/syspage.bin

--- a/qiling/arch/evm/analysis/signatures.py
+++ b/qiling/arch/evm/analysis/signatures.py
@@ -1,4 +1,4 @@
-import os
+import pkgutil
 import re
 import logging
 import json
@@ -92,9 +92,8 @@ def analysis_func_sign(insns:list, engine_num=1):
 class signatures_engine_1:
     @staticmethod
     def find_signature(sign):
-        path = os.path.split(os.path.realpath(__file__))[0] + '/signatures.json'
-        with open(path) as data_file:
-            data = json.load(data_file)
+        data = pkgutil.get_data(__package__, 'signatures.json').decode()
+        data = json.load(data)
 
         list_name = [name for name, hexa in data.items() if hexa == sign]
 

--- a/qiling/arch/evm/analysis/signatures.py
+++ b/qiling/arch/evm/analysis/signatures.py
@@ -1,4 +1,5 @@
-import pkgutil
+import inspect
+from pathlib import Path
 import re
 import logging
 import json
@@ -92,8 +93,9 @@ def analysis_func_sign(insns:list, engine_num=1):
 class signatures_engine_1:
     @staticmethod
     def find_signature(sign):
-        data = pkgutil.get_data(__package__, 'signatures.json').decode()
-        data = json.load(data)
+        path = Path(inspect.getfile(inspect.getframe())).parent / 'signatures.json'
+        with path.open('r') as data_file:
+            data = json.load(data_file)
 
         list_name = [name for name, hexa in data.items() if hexa == sign]
 

--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -7,6 +7,7 @@
 # documentation: according to https://sourceware.org/gdb/current/onlinedocs/gdb/Remote-Protocol.html#Remote-Protocol
 
 import struct, os, socket
+import pkgutil
 from binascii import unhexlify
 from typing import Iterator, Literal
 
@@ -481,15 +482,15 @@ class QlGdb(QlDebugger, object):
                     else:    
                         self.send("PacketSize=47ff;QPassSignals+;QProgramSignals+;QStartupWithShell+;QEnvironmentHexEncoded+;QEnvironmentReset+;QEnvironmentUnset+;QSetWorkingDir+;QCatchSyscalls+;qXfer:libraries-svr4:read+;augmented-libraries-svr4-read+;qXfer:auxv:read+;qXfer:siginfo:read+;qXfer:siginfo:write+;qXfer:features:read+;QStartNoAckMode+;qXfer:osdata:read+;multiprocess+;fork-events+;vfork-events+;exec-events+;QNonStop+;QDisableRandomization+;qXfer:threads:read+;ConditionalTracepoints+;TraceStateVariables+;TracepointSource+;DisconnectedTracing+;FastTracepoints+;StaticTracepoints+;InstallInTrace+;qXfer:statictrace:read+;qXfer:traceframe-info:read+;EnableDisableTracepoints+;QTBuffer:size+;tracenz+;ConditionalBreakpoints+;BreakpointCommands+;QAgent+;Qbtrace:bts+;Qbtrace-conf:bts:size+;Qbtrace:pt+;Qbtrace-conf:pt:size+;Qbtrace:off+;qXfer:btrace:read+;qXfer:btrace-conf:read+;swbreak+;hwbreak+;qXfer:exec-file:read+;vContSupported+;QThreadEvents+;no-resumed+")
                 elif subcmd.startswith('Xfer:features:read'):
-                    xfercmd_file    = subcmd.split(':')[3]
-                    xfercmd_abspath = os.path.dirname(os.path.abspath(__file__))
-                    xml_folder      = self.ql.arch.type.name.lower()
-                    xfercmd_file    = os.path.join(xfercmd_abspath,"xml",xml_folder, xfercmd_file)                        
-
-                    if os.path.exists(xfercmd_file) and self.ql.os.type is not QL_OS.WINDOWS:
-                        with open(xfercmd_file, 'r') as f:
-                            file_contents = f.read()
+                    if self.ql.os.type is not QL_OS.WINDOWS:
+                        try:
+                            xfercmd_file     = subcmd.split(':')[3]
+                            xml_folder       = self.ql.arch.type.name.lower()
+                            file_contents    = pkgutil.get_data(__package__, f"xml/{xml_folder}/{xfercmd_file}").decode()
                             self.send("l%s" % file_contents)
+                        except:
+                            self.ql.log.info("gdb> Platform is not supported by xml or xml file not found: %s\n" % (xfercmd_file))
+                            self.send("l")
                     else:
                         self.ql.log.info("gdb> Platform is not supported by xml or xml file not found: %s\n" % (xfercmd_file))
                         self.send("l")

--- a/qiling/os/uefi/__init__.py
+++ b/qiling/os/uefi/__init__.py
@@ -1,17 +1,14 @@
 import csv
 from typing import Mapping
-from os import path
+import pkgutil
 
 def __init_guids_db() -> Mapping[str, str]:
     """Initialize GUIDs dictionary from a local database.
     """
 
-    csv_path = path.dirname(path.abspath(__file__))
-    csv_path = path.join(csv_path, 'guids.csv')
+    guids_file = pkgutil.get_data(__package__, 'guids.csv').decode()
+    guids_reader = csv.reader(guids_file.splitlines())
 
-    with open(csv_path) as guids_file:
-        guids_reader = csv.reader(guids_file)
-
-        return dict(tuple(entry) for entry in guids_reader)
+    return dict(tuple(entry) for entry in guids_reader)
 
 guids_db = __init_guids_db()

--- a/qiling/os/uefi/__init__.py
+++ b/qiling/os/uefi/__init__.py
@@ -1,14 +1,17 @@
 import csv
 from typing import Mapping
-import pkgutil
+import inspect
+from pathlib import Path
 
 def __init_guids_db() -> Mapping[str, str]:
     """Initialize GUIDs dictionary from a local database.
     """
 
-    guids_file = pkgutil.get_data(__package__, 'guids.csv').decode()
-    guids_reader = csv.reader(guids_file.splitlines())
+    csv_path = Path(inspect.getfile(inspect.currentframe())).parent / 'guids.csv'
 
-    return dict(tuple(entry) for entry in guids_reader)
+    with csv_path.open('r') as guids_file:
+        guids_reader = csv.reader(guids_file)
+
+        return dict(tuple(entry) for entry in guids_reader)
 
 guids_db = __init_guids_db()

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -420,8 +420,11 @@ def profile_setup(ostype: QL_OS, filename: Optional[str]):
 
         config = ConfigParser(converters={'int': int_converter})
 
-        os_profile = pkgutil.get_data(__package__, f'profiles/{ostype.name.lower()}.ql').decode()
-        config.read_string(os_profile)
+        try:
+            os_profile = pkgutil.get_data(__package__, f'profiles/{ostype.name.lower()}.ql').decode()
+            config.read_string(os_profile)
+        except FileNotFoundError as e:
+            pass
 
         if filename:
             config.read(filename)

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -9,7 +9,7 @@ thoughout the qiling framework
 """
 
 from functools import partial
-import importlib, os
+import importlib, pkgutil, os
 
 from configparser import ConfigParser
 from types import ModuleType
@@ -415,19 +415,16 @@ def profile_setup(ostype: QL_OS, filename: Optional[str]):
             config = {}
 
     else:
-        qiling_home = os.path.dirname(os.path.abspath(__file__))
-        os_profile = os.path.join(qiling_home, 'profiles', f'{ostype.name.lower()}.ql')
-
-        profiles = [os_profile]
-
-        if filename:
-            profiles.append(filename)
-
         # patch 'getint' to convert integers of all bases
         int_converter = partial(int, base=0)
 
         config = ConfigParser(converters={'int': int_converter})
-        config.read(profiles)
+
+        os_profile = pkgutil.get_data(__package__, f'profiles/{ostype.name.lower()}.ql').decode()
+        config.read_string(os_profile)
+
+        if filename:
+            config.read(filename)
 
     return config
 

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -9,7 +9,8 @@ thoughout the qiling framework
 """
 
 from functools import partial
-import importlib, pkgutil, os
+from pathlib import Path
+import importlib, inspect, os
 
 from configparser import ConfigParser
 from types import ModuleType
@@ -415,19 +416,19 @@ def profile_setup(ostype: QL_OS, filename: Optional[str]):
             config = {}
 
     else:
+        qiling_home = Path(inspect.getfile(inspect.currentframe())).parent
+        os_profile = qiling_home / 'profiles' / f'{ostype.name.lower()}.ql'
+
+        profiles = [os_profile]
+
+        if filename:
+            profiles.append(filename)
+
         # patch 'getint' to convert integers of all bases
         int_converter = partial(int, base=0)
 
         config = ConfigParser(converters={'int': int_converter})
-
-        try:
-            os_profile = pkgutil.get_data(__package__, f'profiles/{ostype.name.lower()}.ql').decode()
-            config.read_string(os_profile)
-        except FileNotFoundError as e:
-            pass
-
-        if filename:
-            config.read(filename)
+        config.read(profiles)
 
     return config
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,12 @@ setup(
 
     packages=find_packages(),
     scripts=['qltool'],
-    include_package_data=True,
+    package_data={
+        'qiling': ['profiles/*.ql'],
+        'qiling.debugger.gdb': ['xml/*/*'],
+        'qiling.os.uefi': ['guids.csv'],
+        'qiling.arch.evm.analysis': ['signatures.json']
+    },
     install_requires=requirements,
     extras_require=extras,
 )


### PR DESCRIPTION
## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.

### Extra tests?

- [x] No extra tests are needed for this PR.

### Changelog?

- [x] This PR doesn't need to update Changelog.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

Using `__file__` to load internal resources is not recommended, as it may not work with import hooks or Python Eggs. Here, I am using the standard `pkgutil` (a wrapper around another standard library, `importlib.resources`) to retrieve load the data.

Note: `pkgutil.get_data` unfortunately returns `bytes` not strings or a file object, so I have to decode it first before passing it on. The alternative here is to use `importlib.resources.files` which returns a `Path` object (so, `ilr.files("qiling") / "profiles" / f"{os}.ql"`) which you can then call `open()` to return a `TextIO`, but it is only supported in 3.9.