### PR TITLE
Fix memory exhaustion problem caused by the logger

### DIFF
--- a/qiling/log.py
+++ b/qiling/log.py
@@ -39,7 +39,7 @@ class QlBaseFormatter(logging.Formatter):
 
     def __init__(self, ql, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.ql = weakref.ref(ql)
+        self.ql = weakref.proxy(ql)
 
     def get_level_tag(self, level: str) -> str:
         return self.__level_tag[level]

--- a/qiling/log.py
+++ b/qiling/log.py
@@ -7,6 +7,7 @@ import copy
 import logging
 import os
 import re
+import weakref
 
 from typing import Optional, TextIO
 
@@ -38,7 +39,7 @@ class QlBaseFormatter(logging.Formatter):
 
     def __init__(self, ql, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.ql = ql
+        self.ql = weakref.ref(ql)
 
     def get_level_tag(self, level: str) -> str:
         return self.__level_tag[level]


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [X] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [X] The imports are arranged properly.
- [ ] Essential comments are added.
- [X] The reference of the new code is pointed out.

### Extra tests?

- [X] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [X] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
Hi!

This PR is a proposed fix for a memory exhaustion problem I found while creating multiple `Qiling` objects. Here's a snippet of code that triggers the bug:
```
import time
import qiling


with open('/usr/bin/true', 'rb') as f:
    CODE = f.read()

def create_ql_instance():
    ql = qiling.Qiling(code=CODE, archtype='x8664', ostype='linux')

for i in range(1000):
    create_ql_instance()
    print("Allocating")
    time.sleep(0.1)
``` 

This snippet will eventually saturate the RAM and the SWAP because the `Qiling` objects are not properly garbage collected. 
The problem here is that when the `Qiling` object gets out of scope the Python root log manager still holds a reference to it. This is caused by the fact that the logger formatter needs to have a reference to it so it can retrieve the current thread information while formatting the log message.
Substituting the reference with a `weak reference` solves the problem since now when the object goes out of scope only weak references are pointing to it and therefore the garbage collector is allowed to free the space.

