### PR TITLE
修复ida插件在ida pro 7.7上异常报错

### DIFF
--- a/qiling/extensions/idaplugin/qilingida.py
+++ b/qiling/extensions/idaplugin/qilingida.py
@@ -878,7 +878,7 @@ class QlEmuQiling:
     def __init__(self):
         self.path = None
         self.rootfs = None
-        self.ql: Qiling
+        self.ql: Qiling = None
         self.status = None
         self.exit_addr = None
         self.baseaddr = None


### PR DESCRIPTION
self.ql 不赋值就不存在，如果在这期间没有使用qiling插件时，self.ql就不会初始化，
导致在销毁插件时访问self.ql就会报异常，在ida pro 7.7版本上可以复现。

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
