### PR TITLE
feat(r2): human-friendly disassembler

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -80,7 +80,7 @@ jobs:
         cd ../qiling
         cd ../examples/rootfs/x86_linux/kernel && unzip -P infected m0hamed_rootkit.ko.zip
         cd ../../../../
-        pip3 install -e .[evm]
+        pip3 install -e .[evm,RE]
 
         if [ ${{ matrix.os }} == 'ubuntu-18.04' ] and [ ${{ matrix.python-version }} == '3.9' ]; then
           docker run -it --rm -v ${GITHUB_WORKSPACE}:/qiling qilingframework/qiling:dev bash -c "cd tests && ./test_onlinux.sh"

--- a/examples/extensions/r2/hello_r2.py
+++ b/examples/extensions/r2/hello_r2.py
@@ -16,7 +16,7 @@ def func(ql: Qiling, *args, **kwargs):
     return
 
 def my_sandbox(path, rootfs):
-    ql = Qiling(path, rootfs, verbose=QL_VERBOSE.DEBUG)
+    ql = Qiling(path, rootfs, verbose=QL_VERBOSE.DEFAULT)
     r2 = R2(ql)
 
     # search bytes sequence using ql.mem.search
@@ -33,7 +33,8 @@ def my_sandbox(path, rootfs):
     # get function address and hook it
     ql.hook_address(func, r2.functions['main'].offset)
     # enable trace powered by r2 symsmap
-    r2.enable_trace()
+    # r2.enable_trace()
+    r2.enable_disasm()
     ql.run()
 
 if __name__ == "__main__":

--- a/examples/extensions/r2/hello_r2.py
+++ b/examples/extensions/r2/hello_r2.py
@@ -34,8 +34,7 @@ def my_sandbox(path, rootfs):
     ql.hook_address(func, r2.functions['main'].offset)
     # enable trace powered by r2 symsmap
     # r2.enable_trace()
-    # selectively disasm by regex searching flag name
-    r2.enable_disasm('main')
+    r2.enable_disasm()  # monky-patched disasm powered by r2
     ql.run()
 
 if __name__ == "__main__":

--- a/examples/extensions/r2/hello_r2.py
+++ b/examples/extensions/r2/hello_r2.py
@@ -16,7 +16,8 @@ def func(ql: Qiling, *args, **kwargs):
     return
 
 def my_sandbox(path, rootfs):
-    ql = Qiling(path, rootfs, verbose=QL_VERBOSE.DEFAULT)
+    ql = Qiling(path, rootfs, verbose=QL_VERBOSE.DISASM)
+    # QL_VERBOSE.DISASM will be monkey-patched when r2 is available
     r2 = R2(ql)
 
     # search bytes sequence using ql.mem.search
@@ -34,7 +35,6 @@ def my_sandbox(path, rootfs):
     ql.hook_address(func, r2.functions['main'].offset)
     # enable trace powered by r2 symsmap
     # r2.enable_trace()
-    r2.enable_disasm()  # monky-patched disasm powered by r2
     ql.run()
 
 if __name__ == "__main__":

--- a/examples/extensions/r2/hello_r2.py
+++ b/examples/extensions/r2/hello_r2.py
@@ -34,7 +34,8 @@ def my_sandbox(path, rootfs):
     ql.hook_address(func, r2.functions['main'].offset)
     # enable trace powered by r2 symsmap
     # r2.enable_trace()
-    r2.enable_disasm()
+    # selectively disasm by regex searching flag name
+    r2.enable_disasm('main')
     ql.run()
 
 if __name__ == "__main__":

--- a/qiling/arch/utils.py
+++ b/qiling/arch/utils.py
@@ -73,7 +73,12 @@ class QlArchUtils:
             self._block_hook = None
 
         if verbosity >= QL_VERBOSE.DISASM:
-            self._disasm_hook = self.ql.hook_code(self.disassembler)
+            try:  # monkey patch disassembler
+                from qiling.extensions.r2 import R2
+                r2 = R2(self.ql)
+                self._disasm_hook = self.ql.hook_code(r2.disassembler)
+            except (ImportError, ModuleNotFoundError):
+                self._disasm_hook = self.ql.hook_code(self.disassembler)
 
             if verbosity >= QL_VERBOSE.DUMP:
                 self._block_hook = self.ql.hook_block(ql_hook_block_disasm)

--- a/qiling/extensions/r2/r2.py
+++ b/qiling/extensions/r2/r2.py
@@ -10,7 +10,7 @@ import re
 import libr
 from dataclasses import dataclass, field, fields
 from functools import cached_property, wraps
-from typing import TYPE_CHECKING, Dict, List, Literal, Pattern, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Pattern, Tuple, Union
 from qiling.const import QL_ARCH
 from qiling.extensions import trace
 from unicorn import UC_PROT_NONE, UC_PROT_READ, UC_PROT_WRITE, UC_PROT_EXEC, UC_PROT_ALL
@@ -243,6 +243,18 @@ class R2:
         # minus 1 to find the corresponding flag
         flag = self.flags[idx - 1]
         return flag, addr - flag.offset
+
+    def where(self, name: str, offset: int=0) -> Optional[int]:
+        '''Given a name (+ offset), return its address or None'''
+        if '+' in name:  # func_name + offset
+            name, offset = name.split('+')
+            name = name.strip()
+            try:
+               offset = int(offset.strip(), 0)
+            except ValueError:
+                pass
+        func = self.functions.get(name)
+        return func.offset + offset if func else None
 
     def refrom(self, addr: int) -> List[Xref]:
         return [x for x in self.xrefs if x.fromaddr == addr]

--- a/qiling/extensions/r2/r2.py
+++ b/qiling/extensions/r2/r2.py
@@ -180,7 +180,9 @@ class R2:
             self._r2c, ctypes.create_string_buffer(cmd.encode("utf-8")))
         return ctypes.string_at(r).decode('utf-8')
 
-    @staticmethod
+    def _cmdj(self, cmd: str) -> Union[Dict, List[Dict]]:
+        return json.loads(self._cmd(cmd))
+
     def aaa(fun):
         @wraps(fun)
         def wrapper(self):
@@ -190,9 +192,6 @@ class R2:
             return fun(self)
         return wrapper
 
-    def _cmdj(self, cmd: str) -> Union[Dict, List[Dict]]:
-        return json.loads(self._cmd(cmd))
-    
     @cached_property
     def binfo(self) -> Dict[str, str]:
         return self._cmdj("iIj")

--- a/qiling/extensions/r2/r2.py
+++ b/qiling/extensions/r2/r2.py
@@ -277,7 +277,7 @@ class R2:
             if filt.search(flag.name):
                 ql.log.info(f'{inst.offset:0{anibbles}x} [{flag.name:20s} + {offset:#08x}] {inst.bytes.hex(" "):20s} {inst.disasm}')
 
-    def enable_disasm(self, filt_str: str):
+    def enable_disasm(self, filt_str: str=''):
         filt = re.compile(filt_str)
         self.ql.hook_code(self.disassembler, filt)
 

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -13,10 +13,17 @@ EVM_CODE = bytes.fromhex("6060604052341561000f57600080fd5b60405160208061031c8339
 
 class R2Test(unittest.TestCase):
     def test_shellcode_disasm(self):
-        ql = Qiling(code=EVM_CODE, archtype="evm", verbose=QL_VERBOSE.DEBUG)
+        ql = Qiling(code=EVM_CODE, archtype="evm", verbose=QL_VERBOSE.DISABLED)
         r2 = R2(ql)
         pd = r2._cmd("pd 32")
-        self.assertTrue('invalid' not in pd)
+        self.assertTrue('callvalue' in pd)
+
+    def test_addr_flag(self):
+        ql = Qiling(["../examples/rootfs/x86_windows/bin/x86_hello.exe"], "../examples/rootfs/x86_windows",
+                    verbose=QL_VERBOSE.DISABLED)  # x8864_hello does not have 'main'
+        r2 = R2(ql)
+        print(r2.where('main'))
+        self.assertEqual(r2.at(r2.where('main')), 'main')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [ ] This PR only contains minor fixes.
- [x] This PR contains major feature update.
- [x] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [x] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

This is part of the further work discussed in #1172 
`r2` has `pD` to disassemble N bytes and `pd` to disassemble N instructions directly. Though the latter may be used more often, counting bytes is more compatible with the callback type `ql.hook_code()` expects, like `QlArchUtils.disassembler`.

Now there is no change in qiling core, so the code looks a bit ugly. If we can integrate r2 into qiling, the feature can be implemented with only a few lines and no attention of users.