### PR TITLE
Improvements around POSIX sockets

### DIFF
--- a/qiling/os/posix/filestruct.py
+++ b/qiling/os/posix/filestruct.py
@@ -59,10 +59,8 @@ class ql_socket:
             pass
 
     def ioctl(self, cmd, arg):
-        try:
-            return fcntl.ioctl(self.__fd, cmd, arg)
-        except Exception:
-            pass
+        # might throw an OSError
+        return fcntl.ioctl(self.__fd, cmd, arg)
 
     def dup(self) -> 'ql_socket':
         new_s = self.__socket.dup()

--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -99,12 +99,15 @@ class QlOsPosix(QlOs):
         self.ql = ql
         self.sigaction_act = [0] * 256
 
-        self.uid = self.euid = self.profile.getint("KERNEL","uid")
-        self.gid = self.egid = self.profile.getint("KERNEL","gid")
+        conf = self.profile['KERNEL']
+        self.uid = self.euid = conf.getint('uid')
+        self.gid = self.egid = conf.getint('gid')
+        self.pid = conf.getint('pid')
 
-        self.pid = self.profile.getint("KERNEL", "pid")
-        self.ipv6 = self.profile.getboolean("NETWORK", "ipv6")
-        self.bindtolocalhost = self.profile.getboolean("NETWORK", "bindtolocalhost")
+        conf = self.profile['NETWORK']
+        self.ipv6 = conf.getboolean('ipv6')
+        self.bindtolocalhost = conf.getboolean('bindtolocalhost')
+        self.ifrname_ovr = conf.get('ifrname_override')
 
         self.posix_syscall_hooks = {
             QL_INTERCEPT.CALL : {},

--- a/qiling/os/posix/syscall/ioctl.py
+++ b/qiling/os/posix/syscall/ioctl.py
@@ -81,6 +81,15 @@ def ql_syscall_ioctl(ql: Qiling, fd: int, cmd: int, arg: int):
     if isinstance(ql.os.fd[fd], ql_socket) and cmd in (SIOCGIFADDR, SIOCGIFNETMASK):
         data = ql.mem.read(arg, 64)
 
+        ifr_name_override = ql.os.ifrname_ovr
+
+        if ifr_name_override is not None:
+            # make sure the interface name does not exceed 16 characters.
+            # pad it with null bytes if shorter
+            ifr_name_override = ifr_name_override[:16].ljust(16, '\x00')
+
+            data[0:16] = ifr_name_override.encode()
+
         try:
             data = ql.os.fd[fd].ioctl(cmd, bytes(data))
         except OSError as ex:

--- a/qiling/os/posix/syscall/ioctl.py
+++ b/qiling/os/posix/syscall/ioctl.py
@@ -79,12 +79,15 @@ def ql_syscall_ioctl(ql: Qiling, fd: int, cmd: int, arg: int):
             return None
 
     if isinstance(ql.os.fd[fd], ql_socket) and cmd in (SIOCGIFADDR, SIOCGIFNETMASK):
+        data = ql.mem.read(arg, 64)
+
         try:
-            data = ql.os.fd[fd].ioctl(cmd, bytes(ql.mem.read(arg, 64)))
-            ql.mem.write(arg, data)
-        except:
+            data = ql.os.fd[fd].ioctl(cmd, bytes(data))
+        except OSError as ex:
+            ql.log.debug(f'the underlying ioctl raised an exception: {ex.strerror}')
             regreturn = -1
         else:
+            ql.mem.write(arg, data)
             regreturn = 0
 
     else:

--- a/qiling/profiles/linux.ql
+++ b/qiling/profiles/linux.ql
@@ -32,6 +32,11 @@ current_path = /
 
 
 [NETWORK]
+# override the ifr_name field in ifreq structures to match the hosts network interface name.
+# that fixes certain socket ioctl errors where the requested interface name does not match the
+# one on the host. comment out to avoid override
+ifrname_override = eth0
+
 # To use IPv6 or not, to avoid binary double bind. ipv6 and ipv4 bind the same port at the same time
 bindtolocalhost = True
 # Bind to localhost


### PR DESCRIPTION
Improved flexibility around POSIX sockets, after troubleshooting #1214.

### Problem
POSIX socket ioctl receives an [ifreq](https://www.man7.org/linux/man-pages/man7/netdevice.7.html) structure as an input, where the `ifr_name` field specifies the name of the network interface. Since Qiling uses native OS sockets under the hood, the interface name passed in the `ifr_name` field is expected to match the local network interface name.

The Tenda AC15xx firmware specifies `br0` as the interface name, and if the local network interface name is different (e.g. `eth0`), the underlying ioctl operation fails with an `OSError` saying `No such device`.

### Solution
This PR adds a new option to the NETWORK profile section: `ifrname_override`. When enabled, Qiling will patch the `ifr_name` field before passing the data bytes to the udnerlying ioctl. The user may choose to avoid that override by commenting out the option in the profile.

### Other
- Simplified one or two function along the way
- Improve logging around the flows in subject