### PR TITLE
Feature/improve api logging

### DIFF
--- a/qiling/os/posix/syscall/fcntl.py
+++ b/qiling/os/posix/syscall/fcntl.py
@@ -80,6 +80,18 @@ def ql_syscall_creat(ql: Qiling, filename: int, mode: int):
 
     return regreturn
 
+def ql_syscall_openat_parse(ql: Qiling, fd: int, path: int, flags: int, mode: int) -> dict:
+    ql.log.warn(f"flag value is {flags}")
+    flags &= 0xffffffff
+    mode &= 0xffffffff
+    ql.log.warn(f"{fd}")
+    return {
+        'fd': ql.unpacks(ql.pack(fd)),
+        'path': ql.os.utils.read_cstring(path),
+        'flags': ql_open_flag_mapping(ql, flags),
+        'mode': mode
+    }
+
 def ql_syscall_openat(ql: Qiling, fd: int, path: int, flags: int, mode: int):
     file_path = ql.os.utils.read_cstring(path)
     # real_path = ql.os.path.transform_to_real_path(path)


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [ ] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [x] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [x] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----



Hello!~

This is just a proof of concept, and if approved I would want to add in more syscall function parsers before merging to dev. The issue that this fixes is shown when running one of the tests

`import qiling
ql = qiling.Qiling(["../examples/rootfs/x8664_linux/bin/patch_test.bin"], "../examples/rootfs/x8664_linux", verbose=qiling.const.QL_VERBOSE.DEBUG)
ql.patch(0x0000000000000575, b'qiling\x00', target='libpatch_test.so')
ql.run()`

one of the lines of output produced is shown below

`
[+] 	openat(fd = 4294967196, path = /usr/lib/x86_64-linux-gnu/i686/x86_64/libpatch_test.so, mode = 0o0) = -2
[+] 	0x00007ffff7df1cdb: openat(fd = 0xffffff9c, path = 0x80000000d300, flags = 0x80000, mode = 0x0) = -0x2 (ENOENT)
`

the first openat logging message is produced only when ql.verbose == QL_VERBOSE.DEBUG and handled by `ql_syscall_openat`, and the second line is done with logging level info, and handled by `print_function` in os/utils.py. however we can see that the second logging statement is less readable, seeing as we are just given the addresses for things like the fd and path arguments. this issue with missing usefulness of logging shows up again in `ql.os.stats.syscalls['ql_syscall_openat']`, where the same values are logged in the same format:

`{'params': {'fd': 0xffffff9c,
   'path': 0x80000000d300,
   'flags': 0x80000,
   'mode': 0x0},
  'retval': -0x2,
  'address': 0x7ffff7df1cdb,
  'retaddr': None,
  'position': 0x33}`

this pr seeks to implement a handler for better interpretation of arguments passed to the syscall handlers. this is useful because 

- we can parse out the arguments for a syscall in its own function, so when people overwrite the syscall handler in `self.posix_syscall_hooks[QL_INTERCEPT.CALL]`, they can just call the parser function and get good looking arguments
- you can use the parsing when it comes time for logging

here's the results of the changes already implemented so far for the openat call, as seen by what gets put in `ql.os.stats.syscalls['ql_syscall_openat']`:

`{'params': {'fd': 4294967196,
  'path': '/etc/ld.so.cache',
  'flags': 524288,
  'mode': 0},
 'retval': -2,
 'address': 140737351982299,
 'retaddr': None,
 'position': 4}`