### PR TITLE
Fix gdb attach on ARM thumb mode

### DIFF
--- a/qiling/arch/arm.py
+++ b/qiling/arch/arm.py
@@ -68,7 +68,7 @@ class QlArchARM(QlArch):
         """
 
         # append 1 to pc if in thumb mode, or 0 otherwise
-        return self.regs.pc + int(self.is_thumb)
+        return self.regs.pc | int(self.is_thumb)
 
     @property
     def disassembler(self) -> Cs:

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -737,8 +737,14 @@ class Qiling(QlCoreHooks, QlCoreStructs):
             count   : max emulation steps (instructions count); unlimited by default
         """
 
-        if self._arch.type in (QL_ARCH.ARM, QL_ARCH.CORTEX_M) and self._arch._init_thumb:
-            begin |= 1
+        # FIXME: we cannot use arch.is_thumb to determine this because unicorn sets the coresponding bit in cpsr
+        # only when pc is set. unicorn sets or clears the thumb mode bit based on pc lsb, ignoring the mode it
+        # was initialized with.
+        #
+        # either unicorn is patched to reflect thumb mode in cpsr upon initialization, or we pursue the same logic
+        # by determining the endianess by address lsb. either way this condition should not be here
+        if getattr(self.arch, '_init_thumb', False):
+            begin |= 0b1
 
         # reset exception status before emulation starts
         self._internal_exception = None

--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -95,6 +95,11 @@ class QlGdb(QlDebugger):
         else:
             entry_point = ql.os.entry_point
 
+        # though linkers set the entry point LSB to indicate arm thumb mode, the
+        # effective entry point address is aligned. make sure we have it aligned
+        if hasattr(ql.arch, 'is_thumb'):
+            entry_point &= ~0b1
+
         # Only part of the binary file will be debugged.
         if ql.entry_point is not None:
             entry_point = ql.entry_point

--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -239,7 +239,7 @@ class QlGdb(QlDebugger):
                 reply = f'S{SIGINT:02x}'
 
             else:
-                if self.ql.arch.regs.arch_pc == self.gdb.last_bp:
+                if getattr(self.ql.arch, 'effective_pc', self.ql.arch.regs.arch_pc) == self.gdb.last_bp:
                     # emulation stopped because it hit a breakpoint
                     reply = f'S{SIGTRAP:02x}'
                 else:

--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -671,12 +671,6 @@ class QlGdb(QlDebugger):
             """Perform a single step.
             """
 
-            # BUG: a known unicorn caching issue causes it to emulate more
-            # steps than requestes. until that issue is fixed, single stepping
-            # is essentially broken.
-            #
-            # @see: https://github.com/unicorn-engine/unicorn/issues/1606
-
             self.gdb.resume_emu(steps=1)
 
             return f'S{SIGTRAP:02x}'

--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -714,8 +714,9 @@ class QlGdb(QlDebugger):
             #   4 = access watchpoint
 
             if type == 0:
-                self.gdb.bp_insert(addr)
-                return REPLY_OK
+                success = self.gdb.bp_insert(addr, kind)
+
+                return REPLY_OK if success else 'E22'
 
             return REPLY_EMPTY
 
@@ -726,12 +727,9 @@ class QlGdb(QlDebugger):
             type, addr, kind = (int(p, 16) for p in subcmd.split(','))
 
             if type == 0:
-                try:
-                    self.gdb.bp_remove(addr)
-                except ValueError:
-                    return 'E22'
-                else:
-                    return REPLY_OK
+                success = self.gdb.bp_remove(addr, kind)
+
+                return REPLY_OK if success else 'E22'
 
             return REPLY_EMPTY
 

--- a/qiling/debugger/gdb/utils.py
+++ b/qiling/debugger/gdb/utils.py
@@ -47,11 +47,6 @@ class QlGdbUtils:
             ql.log.info(f'{PROMPT} breakpoint hit, stopped at {address:#x}')
             ql.stop()
 
-        # # TODO: not sure what this is about
-        # if address + size == self.exit_point:
-        #     ql.log.debug(f'{PROMPT} emulation entrypoint at {self.entry_point:#x}')
-        #     ql.log.debug(f'{PROMPT} emulation exitpoint at {self.exit_point:#x}')
-
     def bp_insert(self, addr: int, size: int):
         targets = set(addr + i for i in range(size or 1))
 
@@ -83,7 +78,7 @@ class QlGdbUtils:
             address = self.ql.arch.regs.arch_pc
 
         if getattr(self.ql.arch, 'is_thumb', False):
-            address |= 1
+            address |= 0b1
 
         op = f'stepping {steps} instructions' if steps else 'resuming'
         self.ql.log.info(f'{PROMPT} {op} from {address:#x}')


### PR DESCRIPTION
Linkers set the entry point LSB to indicate ARM thumb mode, however the effective entry point address is aligned. Since gdb hooks the entry point, it needs to take the aligned address into consideration and not the reported one.

Fixes #1282 