### PR TITLE
Periodic maintenance PR

### DIFF
--- a/examples/shellcode_run.py
+++ b/examples/shellcode_run.py
@@ -94,10 +94,14 @@ if __name__ == "__main__":
     ql = Qiling(code=X8664_WIN, archtype=QL_ARCH.X8664, ostype=QL_OS.WINDOWS, rootfs=r'rootfs/x8664_windows')
     ql.run()
 
-    print("\nFreeBSD x86-64 Shellcode")
-    ql = Qiling(code=X8664_FBSD, archtype=QL_ARCH.X8664, ostype=QL_OS.FREEBSD, verbose=QL_VERBOSE.DEBUG)
-    ql.run()
+    # FIXME: freebsd sockets are currently broken.
+    #
+    # print("\nFreeBSD x86-64 Shellcode")
+    # ql = Qiling(code=X8664_FBSD, archtype=QL_ARCH.X8664, ostype=QL_OS.FREEBSD, verbose=QL_VERBOSE.DEBUG)
+    # ql.run()
 
-    print("\nMacOS x86-64 Shellcode")
-    ql = Qiling(code=X8664_MACOS, archtype=QL_ARCH.X8664, ostype=QL_OS.MACOS, verbose=QL_VERBOSE.DEBUG)
-    ql.run()
+    # FIXME: macos shellcode loader is currently broken
+    #
+    # print("\nMacOS x86-64 Shellcode")
+    # ql = Qiling(code=X8664_MACOS, archtype=QL_ARCH.X8664, ostype=QL_OS.MACOS, verbose=QL_VERBOSE.DEBUG)
+    # ql.run()

--- a/examples/shellcode_run.py
+++ b/examples/shellcode_run.py
@@ -1,58 +1,103 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-from binascii import unhexlify
 import sys
 
 sys.path.append("..")
 from qiling import Qiling
-from qiling.const import QL_VERBOSE
+from qiling.const import QL_ARCH, QL_OS, QL_VERBOSE
 
-X86_LIN      = unhexlify('31c050682f2f7368682f62696e89e3505389e1b00bcd80')
-X8664_LIN    = unhexlify('31c048bbd19d9691d08c97ff48f7db53545f995257545eb03b0f05')
-MIPS32EL_LIN = unhexlify('ffff0628ffffd004ffff05280110e4270ff08424ab0f02240c0101012f62696e2f7368')
-X86_WIN      = unhexlify('fce8820000006089e531c0648b50308b520c8b52148b72280fb74a2631ffac3c617c022c20c1cf0d01c7e2f252578b52108b4a3c8b4c1178e34801d1518b592001d38b4918e33a498b348b01d631ffacc1cf0d01c738e075f6037df83b7d2475e4588b582401d3668b0c4b8b581c01d38b048b01d0894424245b5b61595a51ffe05f5f5a8b12eb8d5d6a01eb2668318b6f87ffd5bbf0b5a25668a695bd9dffd53c067c0a80fbe07505bb4713726f6a0053ffd5e8d5ffffff63616c6300')
-X8664_WIN    = unhexlify('fc4881e4f0ffffffe8d0000000415141505251564831d265488b52603e488b52183e488b52203e488b72503e480fb74a4a4d31c94831c0ac3c617c022c2041c1c90d4101c1e2ed5241513e488b52203e8b423c4801d03e8b80880000004885c0746f4801d0503e8b48183e448b40204901d0e35c48ffc93e418b34884801d64d31c94831c0ac41c1c90d4101c138e075f13e4c034c24084539d175d6583e448b40244901d0663e418b0c483e448b401c4901d03e418b04884801d0415841585e595a41584159415a4883ec204152ffe05841595a3e488b12e949ffffff5d49c7c1000000003e488d95fe0000003e4c8d850f0100004831c941ba45835607ffd54831c941baf0b5a256ffd548656c6c6f2c2066726f6d204d534621004d657373616765426f7800') 
-ARM_LIN      = unhexlify('01108fe211ff2fe102200121921a0f02193701df061c08a11022023701df3f270221301c01df0139fbd505a0921a05b469460b2701dfc046020012340a0002022f73797374656d2f62696e2f736800')
-ARM64_LIN    = unhexlify('420002ca210080d2400080d2c81880d2010000d4e60300aa01020010020280d2681980d2010000d4410080d2420002cae00306aa080380d2010000d4210400f165ffff54e0000010420002ca210001caa81b80d2010000d4020004d27f0000012f62696e2f736800')
-X8664_FBSD   = unhexlify('6a61586a025f6a015e990f054897baff02aaaa80f2ff524889e699046680c2100f05046a0f05041e4831f6990f0548976a035852488d7424f080c2100f0548b8523243427730637257488d3e48af74084831c048ffc00f055f4889d04889fe48ffceb05a0f0575f799043b48bb2f62696e2f2f73685253545f5257545e0f05')
-X8664_MACOS  = unhexlify('4831f65648bf2f2f62696e2f7368574889e74831d24831c0b00248c1c828b03b0f05')
+X86_LIN = bytes.fromhex('31c050682f2f7368682f62696e89e3505389e1b00bcd80')
+X8664_LIN = bytes.fromhex('31c048bbd19d9691d08c97ff48f7db53545f995257545eb03b0f05')
+
+MIPS32EL_LIN = bytes.fromhex('''
+    ffff0628ffffd004ffff05280110e4270ff08424ab0f02240c0101012f62696e
+    2f7368
+''')
+
+X86_WIN = bytes.fromhex('''
+    fce8820000006089e531c0648b50308b520c8b52148b72280fb74a2631ffac3c
+    617c022c20c1cf0d01c7e2f252578b52108b4a3c8b4c1178e34801d1518b5920
+    01d38b4918e33a498b348b01d631ffacc1cf0d01c738e075f6037df83b7d2475
+    e4588b582401d3668b0c4b8b581c01d38b048b01d0894424245b5b61595a51ff
+    e05f5f5a8b12eb8d5d6a01eb2668318b6f87ffd5bbf0b5a25668a695bd9dffd5
+    3c067c0a80fbe07505bb4713726f6a0053ffd5e8d5ffffff63616c6300
+''')
+
+X8664_WIN = bytes.fromhex('''
+    fc4881e4f0ffffffe8d0000000415141505251564831d265488b52603e488b52
+    183e488b52203e488b72503e480fb74a4a4d31c94831c0ac3c617c022c2041c1
+    c90d4101c1e2ed5241513e488b52203e8b423c4801d03e8b80880000004885c0
+    746f4801d0503e8b48183e448b40204901d0e35c48ffc93e418b34884801d64d
+    31c94831c0ac41c1c90d4101c138e075f13e4c034c24084539d175d6583e448b
+    40244901d0663e418b0c483e448b401c4901d03e418b04884801d0415841585e
+    595a41584159415a4883ec204152ffe05841595a3e488b12e949ffffff5d49c7
+    c1000000003e488d95fe0000003e4c8d850f0100004831c941ba45835607ffd5
+    4831c941baf0b5a256ffd548656c6c6f2c2066726f6d204d534621004d657373
+    616765426f7800
+''')
+
+ARM_LIN = bytes.fromhex('''
+    01108fe211ff2fe102200121921a0f02193701df061c08a11022023701df3f27
+    0221301c01df0139fbd505a0921a05b469460b2701dfc046020012340a000202
+    2f73797374656d2f62696e2f736800
+''')
+
+ARM64_LIN = bytes.fromhex('''
+    420002ca210080d2400080d2c81880d2010000d4e60300aa01020010020280d2
+    681980d2010000d4410080d2420002cae00306aa080380d2010000d4210400f1
+    65ffff54e0000010420002ca210001caa81b80d2010000d4020004d27f000001
+    2f62696e2f736800
+''')
+
+X8664_FBSD = bytes.fromhex('''
+    6a61586a025f6a015e990f054897baff02aaaa80f2ff524889e699046680c210
+    0f05046a0f05041e4831f6990f0548976a035852488d7424f080c2100f0548b8
+    523243427730637257488d3e48af74084831c048ffc00f055f4889d04889fe48
+    ffceb05a0f0575f799043b48bb2f62696e2f2f73685253545f5257545e0f05
+''')
+
+X8664_MACOS = bytes.fromhex('''
+    4831f65648bf2f2f62696e2f7368574889e74831d24831c0b00248c1c828b03b
+    0f05
+''')
+
 
 if __name__ == "__main__":
     print("\nLinux ARM 64bit Shellcode")
-    ql = Qiling(code=ARM64_LIN, archtype="arm64", ostype="linux", verbose=QL_VERBOSE.DEBUG)
+    ql = Qiling(code=ARM64_LIN, archtype=QL_ARCH.ARM64, ostype=QL_OS.LINUX, verbose=QL_VERBOSE.DEBUG)
     ql.run()
 
     print("\nLinux ARM 32bit Shellcode")
-    ql = Qiling(code=ARM_LIN, archtype="arm", ostype="linux", verbose=QL_VERBOSE.DEBUG)
+    ql = Qiling(code=ARM_LIN, archtype=QL_ARCH.ARM, ostype=QL_OS.LINUX, verbose=QL_VERBOSE.DEBUG)
     ql.run()
 
-    print("\nLinux X86 32bit Shellcode")
-    ql = Qiling(code=X86_LIN, archtype="x86", ostype="linux", verbose=QL_VERBOSE.DEBUG)
+    print("\nLinux x86 32bit Shellcode")
+    ql = Qiling(code=X86_LIN, archtype=QL_ARCH.X86, ostype=QL_OS.LINUX, verbose=QL_VERBOSE.DEBUG)
     ql.run()
 
     print("\nLinux MIPS 32bit EL Shellcode")
-    ql = Qiling(code=MIPS32EL_LIN, archtype="mips", ostype="linux", verbose=QL_VERBOSE.DEBUG)
+    ql = Qiling(code=MIPS32EL_LIN, archtype=QL_ARCH.MIPS, ostype=QL_OS.LINUX, verbose=QL_VERBOSE.DEBUG)
     ql.run()
 
-    print("\nLinux X86 64bit Shellcode")
-    ql = Qiling(code=X8664_LIN, archtype="x8664", ostype="linux", verbose=QL_VERBOSE.DEBUG)
+    print("\nLinux x86-64 Shellcode")
+    ql = Qiling(code=X8664_LIN, archtype=QL_ARCH.X8664, ostype=QL_OS.LINUX, verbose=QL_VERBOSE.DEBUG)
     ql.run()
 
-    print("\nWindows X86 32bit Shellcode")
-    ql = Qiling(code=X86_WIN, archtype="x86", ostype="windows", rootfs="rootfs/x86_windows")
+    print("\nWindows x86 Shellcode")
+    ql = Qiling(code=X86_WIN, archtype=QL_ARCH.X86, ostype=QL_OS.WINDOWS, rootfs=r'rootfs/x86_windows')
     ql.run()
 
-    print("\nWindows X8664 64bit Shellcode")
-    ql = Qiling(code=X8664_WIN, archtype="x8664", ostype="windows", rootfs="rootfs/x8664_windows")
+    print("\nWindows x86-64 Shellcode")
+    ql = Qiling(code=X8664_WIN, archtype=QL_ARCH.X8664, ostype=QL_OS.WINDOWS, rootfs=r'rootfs/x8664_windows')
     ql.run()
 
-    print("\nFreeBSD X86 64bit Shellcode")
-    ql = Qiling(code=X8664_FBSD, archtype="x8664", ostype="freebsd", verbose=QL_VERBOSE.DEBUG)
+    print("\nFreeBSD x86-64 Shellcode")
+    ql = Qiling(code=X8664_FBSD, archtype=QL_ARCH.X8664, ostype=QL_OS.FREEBSD, verbose=QL_VERBOSE.DEBUG)
     ql.run()
 
-    print("\nmacos X86 64bit Shellcode")
-    ql = Qiling(code=X8664_MACOS, archtype="x8664", ostype="macos", verbose=QL_VERBOSE.DEBUG)
+    print("\nMacOS x86-64 Shellcode")
+    ql = Qiling(code=X8664_MACOS, archtype=QL_ARCH.X8664, ostype=QL_OS.MACOS, verbose=QL_VERBOSE.DEBUG)
     ql.run()

--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
@@ -25,6 +25,7 @@ from qiling.os.linux.function_hook import FunctionHook
 from qiling.os.linux.syscall_nums import SYSCALL_NR
 from qiling.os.linux.kernel_api.hook import *
 from qiling.os.linux.kernel_api.kernel_api import hook_sys_open, hook_sys_read, hook_sys_write
+
 
 # auxiliary vector types
 # see: https://man7.org/linux/man-pages/man3/getauxval.3.html
@@ -53,12 +54,14 @@ class AUXV(IntEnum):
     AT_HWCAP2   = 26
     AT_EXECFN   = 31
 
+
 # start area memory for API hooking
 # we will reserve 0x1000 bytes for this (which contains multiple slots of 4/8 bytes, each for one api)
 API_HOOK_MEM = 0x1000000
 
 # memory for syscall table
 SYSCALL_MEM = API_HOOK_MEM + 0x1000
+
 
 class QlLoaderELF(QlLoader):
     def __init__(self, ql: Qiling):
@@ -77,12 +80,7 @@ class QlLoaderELF(QlLoader):
 
             return
 
-        section = {
-            32 : 'OS32',
-            64 : 'OS64'
-        }[self.ql.arch.bits]
-
-        self.profile = self.ql.os.profile[section]
+        self.profile = self.ql.os.profile[f'OS{self.ql.arch.bits}']
 
         # setup program stack
         stack_address = self.profile.getint('stack_address')
@@ -658,7 +656,7 @@ class QlLoaderELF(QlLoader):
         # pick up loadable sections
         for sec in elffile.iter_sections():
             if sec['sh_flags'] & SH_FLAGS.SHF_ALLOC:
-                # pad aggregated elf data to the offset of the current section 
+                # pad aggregated elf data to the offset of the current section
                 elfdata_mapping.extend(b'\x00' * (sec['sh_offset'] - len(elfdata_mapping)))
 
                 # aggregate section data

--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -85,8 +85,8 @@ class QlLoaderELF(QlLoader):
         self.profile = self.ql.os.profile[section]
 
         # setup program stack
-        stack_address = int(self.profile.get('stack_address'), 0)
-        stack_size = int(self.profile.get('stack_size'), 0)
+        stack_address = self.profile.getint('stack_address')
+        stack_size = self.profile.getint('stack_size')
         self.ql.mem.map(stack_address, stack_size, info='[stack]')
 
         self.path = self.ql.path
@@ -110,7 +110,7 @@ class QlLoaderELF(QlLoader):
 
         # is it a shared object?
         elif elftype == 'ET_DYN':
-            load_address = int(self.profile.get('load_address'), 0)
+            load_address = self.profile.getint('load_address')
 
             self.load_with_ld(elffile, stack_address + stack_size, load_address, self.argv, self.env)
 
@@ -242,7 +242,7 @@ class QlLoaderELF(QlLoader):
                 # determine interpreter base address
                 # some old interpreters may not be PIE: p_vaddr of the first LOAD segment is not zero
                 # we should load interpreter at the address p_vaddr specified in such situation
-                interp_address = int(self.profile.get('interp_address'), 0) if min_vaddr == 0 else 0
+                interp_address = self.profile.getint('interp_address') if min_vaddr == 0 else 0
                 self.ql.log.debug(f'Interpreter addr: {interp_address:#x}')
 
                 # load interpreter segments data to memory
@@ -255,7 +255,7 @@ class QlLoaderELF(QlLoader):
                 entry_point = interp_address + interp['e_entry']
 
         # set mmap addr
-        mmap_address = int(self.profile.get('mmap_address'), 0)
+        mmap_address = self.profile.getint('mmap_address')
         self.ql.log.debug(f'mmap_address is : {mmap_address:#x}')
 
         # set info to be used by gdb

--- a/qiling/os/linux/thread.py
+++ b/qiling/os/linux/thread.py
@@ -239,7 +239,7 @@ class QlLinuxThread(QlThread):
             self.ql.log.debug(f"Scheduled from {hex(start_address)}.")
             try:
                 # Known issue for timeout: https://github.com/unicorn-engine/unicorn/issues/1355
-                self.ql.emu_start(start_address, self.exit_point, count=30000)
+                self.ql.emu_start(start_address, self.exit_point, count=31337)
             except UcError as e:
                 self.ql.os.emu_error()
                 self.ql.log.exception("")

--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
 import bisect
-import os, re
+import os
+import re
 from typing import Any, Callable, Iterator, List, Mapping, Optional, Pattern, Sequence, Tuple, Union
 
 from unicorn import UC_PROT_NONE, UC_PROT_READ, UC_PROT_WRITE, UC_PROT_EXEC, UC_PROT_ALL
@@ -18,6 +19,7 @@ MapInfoEntry = Tuple[int, int, int, str, bool]
 MmioReadCallback  = Callable[[Qiling, int, int], int]
 MmioWriteCallback = Callable[[Qiling, int, int, int], None]
 
+
 class QlMemoryManager:
     """
     some ideas and code from:
@@ -30,9 +32,9 @@ class QlMemoryManager:
         self.mmio_cbs = {}
 
         bit_stuff = {
-            64 : (1 << 64) - 1,
-            32 : (1 << 32) - 1,
-            16 : (1 << 20) - 1   # 20bit address line
+            64: (1 << 64) - 1,
+            32: (1 << 32) - 1,
+            16: (1 << 20) - 1   # 20bit address line
         }
 
         if ql.arch.bits not in bit_stuff:
@@ -329,10 +331,10 @@ class QlMemoryManager:
             size = self.ql.arch.pointersize
 
         __unpack = {
-            1 : self.ql.unpack8,
-            2 : self.ql.unpack16,
-            4 : self.ql.unpack32,
-            8 : self.ql.unpack64
+            1: self.ql.unpack8,
+            2: self.ql.unpack16,
+            4: self.ql.unpack32,
+            8: self.ql.unpack64
         }.get(size)
 
         if __unpack is None:
@@ -364,10 +366,10 @@ class QlMemoryManager:
             size = self.ql.arch.pointersize
 
         __pack = {
-            1 : self.ql.pack8,
-            2 : self.ql.pack16,
-            4 : self.ql.pack32,
-            8 : self.ql.pack64
+            1: self.ql.pack8,
+            2: self.ql.pack16,
+            4: self.ql.pack32,
+            8: self.ql.pack64
         }.get(size)
 
         if __pack is None:

--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -513,13 +513,16 @@ class QlMemoryManager:
 
         assert minaddr < maxaddr
 
+        if (maxaddr - minaddr) < size:
+            raise ValueError('search domain is too small')
+
         # get gap ranges between mapped ones and memory bounds
         gaps_ubounds = tuple(lbound for lbound, _, _, _, _ in self.map_info) + (mem_ubound,)
         gaps_lbounds = (mem_lbound,) + tuple(ubound for _, ubound, _, _, _ in self.map_info)
-        gaps = zip(gaps_lbounds, gaps_ubounds)
+        gaps = ((lbound, ubound) for lbound, ubound in zip(gaps_lbounds, gaps_ubounds) if lbound < maxaddr and minaddr < ubound)
 
         for lbound, ubound in gaps:
-            addr = self.align_up(lbound, align)
+            addr = self.align_up(max(minaddr, lbound), align)
             end = addr + size
 
             # is aligned range within gap and satisfying min / max requirements?

--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -435,10 +435,13 @@ class QlMemoryManager:
 
         # map info is about to change during the unmapping loop, so we have to
         # determine the relevant ranges beforehand
-        mapped = [(lbound, ubound - lbound) for lbound, ubound, _, _, _ in self.map_info if (mem_s < ubound) and (mem_e > lbound)]
+        mapped = [(lbound, ubound) for lbound, ubound, _, _, _ in self.map_info if (mem_s < ubound) and (mem_e > lbound)]
 
-        for range in mapped:
-            self.unmap(*range)
+        for lbound, ubound in mapped:
+            lbound = max(mem_s, lbound)
+            ubound = min(mem_e, ubound)
+
+            self.unmap(lbound, ubound - lbound)
 
     def unmap_all(self) -> None:
         """Reclaim the entire memory space.

--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -425,6 +425,21 @@ class QlMemoryManager:
         if (addr, addr + size) in self.mmio_cbs:
             del self.mmio_cbs[(addr, addr+size)]
 
+    def unmap_between(self, mem_s: int, mem_e: int) -> None:
+        """Reclaim any allocated memory region within the specified range.
+
+        Args:
+            mem_s: range start
+            mem_s: range end (exclusive)
+        """
+
+        # map info is about to change during the unmapping loop, so we have to
+        # determine the relevant ranges beforehand
+        mapped = [(lbound, ubound - lbound) for lbound, ubound, _, _, _ in self.map_info if (mem_s < ubound) and (mem_e > lbound)]
+
+        for range in mapped:
+            self.unmap(*range)
+
     def unmap_all(self) -> None:
         """Reclaim the entire memory space.
         """

--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -298,8 +298,9 @@ class QlMemoryManager:
         for lbound, ubound, perms, label, read_cb, write_cb in mem_dict['mmio']:
             self.ql.log.debug(f"restoring mmio range: {lbound:#08x} {ubound:#08x} {label}")
 
+            size = ubound - lbound
             if not self.is_mapped(lbound, size):
-                self.map_mmio(lbound, ubound - lbound, read_cb, write_cb, info=label)
+                self.map_mmio(lbound, size, read_cb, write_cb, info=label)
 
     def read(self, addr: int, size: int) -> bytearray:
         """Read bytes from memory.

--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -647,6 +647,23 @@ class linux_mmap_flags(Flag):
     MAP_UNINITIALIZED   = 0x04000000
 
 
+# see: https://github.com/freebsd/freebsd-src/blob/master/sys/sys/mman.h
+class freebsd_mmap_flags(Flag):
+    MAP_FILE            = 0x00000000
+    MAP_SHARED          = 0x00000001
+    MAP_PRIVATE         = 0x00000002
+
+    MAP_FIXED           = 0x00000010
+    MAP_STACK           = 0x00000400
+    MAP_NOSYNC          = 0x00000800
+    MAP_ANONYMOUS       = 0x00001000
+    MAP_GUARD           = 0x00002000
+    MAP_EXCL            = 0x00004000
+    MAP_NOCORE          = 0x00020000
+
+    # define this alias for compatibility with other os flags
+    MAP_FIXED_NOREPLACE = MAP_EXCL
+
 # see: https://github.com/torvalds/linux/blob/master/arch/mips/include/uapi/asm/mman.h
 class mips_mmap_flags(Flag):
     MAP_FILE            = 0x00000000

--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -3,6 +3,8 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from enum import Flag
+
 # OS Threading Constants
 THREAD_EVENT_INIT_VAL         = 0
 THREAD_EVENT_EXIT_EVENT       = 1
@@ -621,6 +623,87 @@ qnx_arm64_open_flags = {
     'O_DIRECTORY' : None,
     'O_BINARY'    : None
 }
+
+
+# see: https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/mman-common.h
+class linux_mmap_flags(Flag):
+    MAP_FILE            = 0x00000000
+    MAP_SHARED          = 0x00000001
+    MAP_PRIVATE         = 0x00000002
+
+    MAP_FIXED           = 0x00000010
+    MAP_ANONYMOUS       = 0x00000020
+    MAP_GROWSDOWN       = 0x00000100
+    MAP_DENYWRITE       = 0x00000800
+    MAP_EXECUTABLE      = 0x00001000
+    MAP_LOCKED          = 0x00002000
+    MAP_NORESERVE       = 0x00004000
+    MAP_POPULATE        = 0x00008000
+    MAP_NONBLOCK        = 0x00010000
+    MAP_STACK           = 0x00020000
+    MAP_HUGETLB         = 0x00040000
+    MAP_SYNC            = 0x00080000
+    MAP_FIXED_NOREPLACE = 0x00100000
+    MAP_UNINITIALIZED   = 0x04000000
+
+
+# see: https://github.com/torvalds/linux/blob/master/arch/mips/include/uapi/asm/mman.h
+class mips_mmap_flags(Flag):
+    MAP_FILE            = 0x00000000
+    MAP_SHARED          = 0x00000001
+    MAP_PRIVATE         = 0x00000002
+
+    MAP_FIXED           = 0x00000010
+    MAP_NORESERVE       = 0x00000400
+    MAP_ANONYMOUS       = 0x00000800
+    MAP_GROWSDOWN       = 0x00001000
+    MAP_DENYWRITE       = 0x00002000
+    MAP_EXECUTABLE      = 0x00004000
+    MAP_LOCKED          = 0x00008000
+    MAP_POPULATE        = 0x00010000
+    MAP_NONBLOCK        = 0x00020000
+    MAP_STACK           = 0x00040000
+    MAP_HUGETLB         = 0x00080000
+    MAP_FIXED_NOREPLACE = 0x00100000
+
+
+# see: https://github.com/apple/darwin-xnu/blob/main/bsd/sys/mman.h
+class macos_mmap_flags(Flag):
+    MAP_FILE         = 0x00000000
+    MAP_SHARED       = 0x00000001
+    MAP_PRIVATE      = 0x00000002
+
+    MAP_FIXED        = 0x00000010
+    MAP_RENAME       = 0x00000020
+    MAP_NORESERVE    = 0x00000040
+    MAP_NOEXTEND     = 0x00000100
+    MAP_HASSEMAPHORE = 0x00000200
+    MAP_NOCACHE      = 0x00000400
+    MAP_JIT          = 0x00000800
+    MAP_ANONYMOUS    = 0x00001000
+
+
+# see: https://github.com/vocho/openqnx/blob/master/trunk/lib/c/public/sys/mman.h
+class qnx_mmap_flags(Flag):
+    MAP_FILE       = 0x00000000
+    MAP_SHARED     = 0x00000001
+    MAP_PRIVATE    = 0x00000002
+
+    MAP_FIXED      = 0x00000010
+    MAP_ELF        = 0x00000020
+    MAP_NOSYNCFILE = 0x00000040
+    MAP_LAZY       = 0x00000080
+    MAP_STACK      = 0x00001000
+    MAP_BELOW      = 0x00002000
+    MAP_NOINIT     = 0x00004000
+    MAP_PHYS       = 0x00010000
+    MAP_NOX64K     = 0x00020000
+    MAP_BELOW16M   = 0x00040000
+    MAP_ANONYMOUS  = 0x00080000
+    MAP_SYSRAM     = 0x01000000
+
+    # define this alias for compatibility with other os flags
+    MAP_UNINITIALIZED = MAP_NOINIT
 
 # fcntl flags
 F_DUPFD		= 0

--- a/qiling/os/posix/structs.py
+++ b/qiling/os/posix/structs.py
@@ -9,6 +9,22 @@ from qiling.const import QL_ENDIAN
 from qiling.os import struct
 
 
+# FIXME: freebsd socket structures differ from the unix ones by specifying the
+# sa_len and sa_family fields, one byte each, instead of using one short int
+# for sa_family.
+#
+# using the sturcutres as they defined here causes freebsd socket structures to
+# show high (hence unrecognized) values for sa_family. messing all sturctures
+# with "if ql.os.type == QL_OS.FREEBSD" is a cumbersome workaround and not
+# maintainable, let alone the code should also refer to sa_len and populate it
+# appropriately.
+#
+# unfortunately, until there is an elegant implemetation that takes freebsd
+# sockets into account freebsd sockets are broken.
+#
+# for more details: https://docs.freebsd.org/en/books/developers-handbook/sockets/
+
+
 def make_sockaddr(archbits: int, endian: QL_ENDIAN):
     Struct = struct.get_aligned_struct(archbits, endian)
 

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -80,7 +80,7 @@ def syscall_mmap_impl(ql: Qiling, addr: int, length: int, prot: int, flags: int,
 
         osflags = {
             QL_OS.LINUX:   mips_mmap_flags if archtype == QL_ARCH.MIPS else linux_mmap_flags,
-            QL_OS.FREEBSD: linux_mmap_flags,    # FIXME: need one for freebsd
+            QL_OS.FREEBSD: freebsd_mmap_flags,
             QL_OS.MACOS:   macos_mmap_flags,
             QL_OS.QNX:     qnx_mmap_flags       # FIXME: only for arm?
         }[ostype]

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -4,8 +4,11 @@
 #
 
 import os
+from enum import IntFlag
+from typing import Optional
 
 from qiling import Qiling
+from qiling.const import QL_ARCH, QL_OS
 from qiling.exception import QlMemoryMappedError
 from qiling.os.filestruct import ql_file
 from qiling.os.posix.const_mapping import *
@@ -53,97 +56,131 @@ def ql_syscall_mprotect(ql: Qiling, start: int, mlen: int, prot: int):
     return 0
 
 
-def syscall_mmap_impl(ql: Qiling, addr: int, mlen: int, prot: int, flags: int, fd: int, pgoffset: int, ver: int):
-    MAP_FAILED = -1
-    MAP_SHARED = 0x01
-    MAP_FIXED = 0x10
-    MAP_ANONYMOUS = 0x20
+def syscall_mmap_impl(ql: Qiling, addr: int, length: int, prot: int, flags: int, fd: int, pgoffset: int, ver: int):
+    def __select_mmap_flags(archtype: QL_ARCH, ostype: QL_OS):
+        """The mmap flags definitions differ between operating systems and architectures.
+        This method provides the apropriate flags set based on those properties.
+        """
+
+        osflags = {
+            QL_OS.LINUX:   mips_mmap_flags if archtype == QL_ARCH.MIPS else linux_mmap_flags,
+            QL_OS.FREEBSD: linux_mmap_flags,    # FIXME: need one for freebsd
+            QL_OS.MACOS:   macos_mmap_flags,
+            QL_OS.QNX:     qnx_mmap_flags       # FIXME: only for arm?
+        }[ostype]
+
+        class mmap_flags(IntFlag):
+            MAP_FILE      = osflags.MAP_FILE.value
+            MAP_SHARED    = osflags.MAP_SHARED.value
+            MAP_FIXED     = osflags.MAP_FIXED.value
+            MAP_ANONYMOUS = osflags.MAP_ANONYMOUS.value
+
+            # the following flags do not exist on all flags sets.
+            # if not exists, set it to 0 so it would fail all bitwise-and checks
+            MAP_FIXED_NOREPLACE = osflags.MAP_FIXED_NOREPLACE.value if hasattr(osflags, 'MAP_FIXED_NOREPLACE') else 0
+            MAP_UNINITIALIZED = osflags.MAP_UNINITIALIZED.value if hasattr(osflags, 'MAP_UNINITIALIZED') else 0
+
+        return mmap_flags
+
+    api_name = ('old_mmap', 'mmap', 'mmap2')[ver]
+    mmap_flags = __select_mmap_flags(ql.arch.type, ql.os.type)
 
     pagesize = ql.mem.pagesize
-    api_name = {
-        0 : 'old_mmap',
-        1 : 'mmap',
-        2 : 'mmap2'
-    }[ver]
+    mapping_size = ql.mem.align_up(length + (addr & (pagesize - 1)))
 
-    if ql.arch.bits == 64:
-        fd = ql.unpack64(ql.pack64(fd))
+    ################################
+    # determine mapping boundaries #
+    ################################
 
-    elif ql.arch.type == QL_ARCH.MIPS:
-        MAP_ANONYMOUS = 2048
-        if ver == 2:
-            pgoffset = pgoffset * pagesize
+    # as opposed to other systems, QNX allows specifying an unaligned base address
+    # for fixed mappings. to keep it consistent across all systems we allocate the
+    # enclosing pages of the requested area, while returning the requested fixed
+    # base address.
+    #
+    # to help track this, we use the following variables:
+    #   addr         : the address that becomes available, from program point of view
+    #   lbound       : lower bound of actual mapping range (aligned to page)
+    #   ubound       : upper bound of actual mapping range (aligned to page)
+    #   mapping_size : actual mapping range size
+    #
+    # note that on non-QNX systems addr and lbound are equal.
+    #
+    # for example, assume requested base address and length are 0x774ec8d8 and 0x1800
+    # respectively, then we allocate 3 pages as follows:
+    #   [align(0x7700c8d8), align_up(0x7700c8d8 + 0x1800)] -> [0x7700c000, 0x7700f000]
 
-    elif ql.arch.type == QL_ARCH.ARM and ql.os.type == QL_OS.QNX:
-        MAP_ANONYMOUS = 0x00080000
-        fd = ql.unpack32s(ql.pack32s(fd))
+    # if mapping is fixed, use the base address as-is
+    if flags & (mmap_flags.MAP_FIXED | mmap_flags.MAP_FIXED_NOREPLACE):
+        # on non-QNX systems, base must be aligned to page boundary
+        if addr & (pagesize - 1) and ql.os.type != QL_OS.QNX:
+            return -1   # errno: EINVAL
+
+    # if not, use the base address as a hint but always above or equal to
+    # the value specified in /proc/sys/vm/mmap_min_addr (here: mmap_address)
+    else:
+        addr = ql.mem.find_free_space(mapping_size, max(addr, ql.loader.mmap_address))
+
+    # on non-QNX systems addr is already aligned to page boundary
+    lbound = ql.mem.align(addr)
+    ubound = lbound + mapping_size
+
+    ##################################
+    # make sure memory can be mapped #
+    ##################################
+
+    if flags & mmap_flags.MAP_FIXED_NOREPLACE:
+        if not ql.mem.is_available(lbound, mapping_size):
+            return -1   # errno: EEXIST
+
+    elif flags & mmap_flags.MAP_FIXED:
+        for page in range(lbound, ubound, pagesize):
+            if ql.mem.is_mapped(page, pagesize):
+                ql.log.debug(f'{api_name}: unmapping page at {page:#x} to make room for fixed mapping')
+
+                ql.mem.unmap(page, pagesize)
+
+    #############################
+    # determine mapping content #
+    #############################
+
+    if flags & mmap_flags.MAP_ANONYMOUS:
+        data = b'' if flags & mmap_flags.MAP_UNINITIALIZED else b'\x00' * length
+        label = '[anonymous mapping]'
 
     else:
-        fd = ql.unpack32s(ql.pack32(fd))
-        if ver == 2:
-            pgoffset = pgoffset * pagesize
+        fd = ql.unpacks(ql.pack(fd))
 
-    need_mmap = True
-    mmap_base = addr
-    mmap_size = ql.mem.align_up(mlen - (addr & (pagesize - 1)))
+        if fd not in range(NR_OPEN):
+            return -1   # errno: EBADF
 
-    if ql.os.type != QL_OS.QNX:
-        mmap_base = ql.mem.align(mmap_base)
+        f: Optional[ql_file] = ql.os.fd[fd]
 
-        if (flags & MAP_FIXED) and mmap_base != addr:
-            return MAP_FAILED
+        if f is None:
+            return -1   # errno: EBADF
 
-    # initial ql.loader.mmap_address
-    if mmap_base != 0 and ql.mem.is_mapped(mmap_base, mmap_size):
-        if (flags & MAP_FIXED) > 0:
-            ql.log.debug("%s - MAP_FIXED, mapping not needed" % api_name)
-            try:
-                ql.mem.protect(mmap_base, mmap_size, prot)
-            except Exception as e:
-                ql.log.debug(e)
-                raise QlMemoryMappedError("Error: change protection at: 0x%x - 0x%x" % (mmap_base, mmap_base + mmap_size - 1))
-            need_mmap = False
-        else:
-            mmap_base = 0
+        # set mapping properties for future unmap
+        f._is_map_shared = bool(flags & mmap_flags.MAP_SHARED)
+        f._mapped_offset = pgoffset
 
-    # initialized mapping
-    if need_mmap:
-        if mmap_base == 0:
-            mmap_base = ql.loader.mmap_address
-            ql.loader.mmap_address = mmap_base + mmap_size
-        ql.log.debug("%s - mapping needed for 0x%x" % (api_name, mmap_base))
-        try:
-            ql.mem.map(mmap_base, mmap_size, prot, "[syscall_%s]" % api_name)
-        except Exception as e:
-            raise QlMemoryMappedError("Error: mapping needed but failed")
-        ql.log.debug("%s - addr range  0x%x - 0x%x: " % (api_name, mmap_base, mmap_base + mmap_size - 1))
+        fname = f.name
 
-    # FIXME: MIPS32 Big Endian
-    try:
-        ql.mem.write(mmap_base, b'\x00' * mmap_size)
-    except Exception as e:
-        raise QlMemoryMappedError("Error: trying to zero memory")
+        if isinstance(fname, bytes):
+            fname = fname.decode()
 
-    if ((flags & MAP_ANONYMOUS) == 0) and fd in range(NR_OPEN):
-        f = ql.os.fd[fd]
+        f.seek(pgoffset)
 
-        if f is not None:
-            f.seek(pgoffset)
-            data = f.read(mlen)
-            mem_info = str(f.name)
-            f._is_map_shared = flags & MAP_SHARED
-            f._mapped_offset = pgoffset
-            ql.log.debug("mem write : " + hex(len(data)))
-            ql.log.debug("mem mmap  : " + mem_info)
+        data = f.read(length)
+        label = os.path.basename(fname)
 
-            ql.mem.change_mapinfo(mmap_base, mmap_base + mmap_size, mem_info=f'[{api_name}] {os.path.basename(mem_info)}')
-            try:
-                ql.mem.write(mmap_base, data)
-            except Exception as e:
-                ql.log.debug(e)
-                raise QlMemoryMappedError("Error: trying to write memory: ")
+    # finally, we have everything we need to map the memory
+    ql.mem.map(lbound, mapping_size, info=label)
 
-    return mmap_base
+    if data:
+        ql.mem.write(addr, data)
+
+    ql.mem.protect(lbound, mapping_size, prot)
+
+    return addr
 
 
 def ql_syscall_old_mmap(ql: Qiling, struct_mmap_args: int):
@@ -164,6 +201,9 @@ def ql_syscall_mmap(ql: Qiling, addr: int, length: int, prot: int, flags: int, f
 
 
 def ql_syscall_mmap2(ql: Qiling, addr: int, length: int, prot: int, flags: int, fd: int, pgoffset: int):
+    if ql.os.type != QL_OS.QNX:
+        pgoffset *= ql.mem.pagesize
+
     return syscall_mmap_impl(ql, addr, length, prot, flags, fd, pgoffset, 2)
 
 

--- a/qiling/os/posix/syscall/net.py
+++ b/qiling/os/posix/syscall/net.py
@@ -44,6 +44,7 @@ def ql_syscall_socketcall(ql: Qiling, call: int, args: int):
         SOCKETCALL.SYS_ACCEPT:      ql_syscall_accept,
         SOCKETCALL.SYS_GETSOCKNAME: ql_syscall_getsockname,
         SOCKETCALL.SYS_GETPEERNAME: ql_syscall_getpeername,
+        SOCKETCALL.SYS_SOCKETPAIR:  ql_syscall_socketpair,
         SOCKETCALL.SYS_SEND:        ql_syscall_send,
         SOCKETCALL.SYS_RECV:        ql_syscall_recv,
         SOCKETCALL.SYS_SENDTO:      ql_syscall_sendto,

--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -782,7 +782,7 @@ def __getdents_common(ql: Qiling, fd: int, dirp: int, count: int, *, is_64: bool
             # For some reason MACOS return int value is 64bit
             try:
                 packed_d_ino = (ql.pack(d_ino), n)
-            except: 
+            except:
                 packed_d_ino = (ql.pack64(d_ino), n)
 
             if is_64:

--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -202,17 +202,16 @@ def ql_syscall__llseek(ql: Qiling, fd: int, offset_high: int, offset_low: int, r
 
 
 def ql_syscall_brk(ql: Qiling, inp: int):
-    # current brk_address will be modified if inp is not NULL(zero)
-    # otherwise, just return current brk_address
-
     if inp:
         cur_brk_addr = ql.loader.brk_address
         new_brk_addr = ql.mem.align_up(inp)
 
-        if inp > cur_brk_addr: # increase current brk_address if inp is greater
+        if new_brk_addr > cur_brk_addr:
+            ql.log.debug(f'brk: increasing program break from {cur_brk_addr:#x} to {new_brk_addr:#x}')
             ql.mem.map(cur_brk_addr, new_brk_addr - cur_brk_addr, info="[brk]")
 
-        elif inp < cur_brk_addr: # shrink current bkr_address to inp if its smaller
+        elif new_brk_addr < cur_brk_addr:
+            ql.log.debug(f'brk: decreasing program break from {cur_brk_addr:#x} to {new_brk_addr:#x}')
             ql.mem.unmap(new_brk_addr, cur_brk_addr - new_brk_addr)
 
         ql.loader.brk_address = new_brk_addr

--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -62,44 +62,75 @@ def ql_syscall_issetugid(ql: Qiling):
     return 0
 
 
-def ql_syscall_getuid(ql: Qiling):
+def __getuid(ql: Qiling):
     return ql.os.uid
 
 
-def ql_syscall_getuid32(ql: Qiling):
+def __setuid(ql: Qiling, uid: int):
+    # TODO: security checks
+    ql.os.uid = uid
+
     return 0
+
+
+def __getgid(ql: Qiling):
+    return ql.os.gid
+
+
+def __setgid(ql: Qiling, gid: int):
+    # TODO: security checks
+    ql.os.gid = gid
+
+    return 0
+
+
+def ql_syscall_getuid(ql: Qiling):
+    return __getuid(ql)
+
+
+def ql_syscall_setuid(ql: Qiling, uid: int):
+    return __setuid(ql, uid)
+
+
+def ql_syscall_getuid32(ql: Qiling):
+    return __getuid(ql)
+
+
+def ql_syscall_setuid32(ql: Qiling, uid: int):
+    return __setuid(ql, uid)
+
+
+def ql_syscall_getgid(ql: Qiling):
+    return __getgid(ql)
+
+
+def ql_syscall_setgid(ql: Qiling, gid: int):
+    return __setgid(ql, gid)
 
 
 def ql_syscall_getgid32(ql: Qiling):
-    return 0
+    return __getgid(ql)
+
+
+def ql_syscall_setgid32(ql: Qiling, gid: int):
+    return __setgid(ql, gid)
 
 
 def ql_syscall_geteuid(ql: Qiling):
     return ql.os.euid
 
 
+def ql_syscall_seteuid(ql: Qiling):
+    return 0
+
+
 def ql_syscall_getegid(ql: Qiling):
     return ql.os.egid
-
-
-def ql_syscall_getgid(ql: Qiling):
-    return ql.os.gid
 
 
 def ql_syscall_setgroups(ql: Qiling, gidsetsize: int, grouplist: int):
     return 0
 
-
-def ql_syscall_setgid(ql: Qiling):
-    return 0
-
-
-def ql_syscall_setgid32(ql: Qiling):
-    return 0
-
-
-def ql_syscall_setuid(ql: Qiling):
-    return 0
 
 def ql_syscall_setresuid(ql: Qiling):
     return 0

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -3,7 +3,7 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import os, platform, sys, unittest
+import platform, sys, unittest
 from collections import defaultdict
 
 sys.path.append("..")
@@ -13,47 +13,69 @@ from qiling.os.posix import syscall
 
 
 class Fake_maps(QlFsMappedObject):
-    def __init__(self, ql):
+    def __init__(self, ql: Qiling):
         self.ql = ql
+
     def read(self, size):
-        stack = next(filter(lambda x : x[3]=='[stack]', self.ql.mem.map_info))
-        return ('%x-%x %s\n' % (stack[0], stack[1], stack[3])).encode()
+        return ''.join(f'{lbound:x}-{ubound:x} {perms}p {label}\n' for lbound, ubound, perms, label, _ in self.ql.mem.get_mapinfo()).encode()
+
     def fstat(self):
         return defaultdict(int)
+
     def close(self):
         return 0
 
-def my_syscall_close(ql, fd):
-    if fd in [0, 1, 2]:
+
+def my_syscall_close(ql: Qiling, fd: int) -> int:
+    if fd in (0, 1, 2):
         return 0
+
     return syscall.ql_syscall_close(ql, fd)
+
+
+# addresses specified on non-fixed mmap calls are used as hints, where the allocated
+# address can never be less than the value set for mmap_address. nevertheless, android
+# uses a non-fixed mmap call to map "/system/framework/arm64/boot.art" at 0x70000000
+# and fails if mmap allocates it elsewhere.
+#
+# this override sets a lower value for mmap_address to allow android map the file using
+# a non-fixed mmap call to exactly where it wants it to be.
+OVERRIDES = {'mmap_address': 0x68000000}
 
 
 class TestAndroid(unittest.TestCase):
     @unittest.skipUnless(platform.system() == 'Linux', 'run only on Linux')
     def test_android_arm64(self):
-
         test_binary = "../examples/rootfs/arm64_android6.0/bin/arm64_android_jniart"
         rootfs = "../examples/rootfs/arm64_android6.0"
-        env = {"ANDROID_DATA":"/data", "ANDROID_ROOT":"/system"}
+        env = {
+            'ANDROID_DATA': r'/data',
+            'ANDROID_ROOT': r'/system'
+        }
 
-        ql = Qiling([test_binary], rootfs, env, multithread=True)
+        ql = Qiling([test_binary], rootfs, env, profile={'OS64': OVERRIDES}, multithread=True)
+
         ql.os.set_syscall("close", my_syscall_close)
         ql.add_fs_mapper("/proc/self/task/2000/maps", Fake_maps(ql))
         ql.run()
-        del ql
 
+        del ql
 
     @unittest.skipUnless(platform.system() == 'Linux', 'run only on Linux')
     def test_android_arm(self):
         test_binary = "../examples/rootfs/arm64_android6.0/bin/arm_android_jniart"
         rootfs = "../examples/rootfs/arm64_android6.0"
-        env = {"ANDROID_DATA":"/data", "ANDROID_ROOT":"/system"}
+        env = {
+            'ANDROID_DATA': r'/data',
+            'ANDROID_ROOT': r'/system'
+        }
 
-        ql = Qiling([test_binary], rootfs, env, multithread=True)
+        ql = Qiling([test_binary], rootfs, env, profile={'OS32': OVERRIDES}, multithread=True)
+
         ql.os.set_syscall("close", my_syscall_close)
         ql.add_fs_mapper("/proc/self/task/2000/maps", Fake_maps(ql))
         ql.run()
+
         del ql
 
 


### PR DESCRIPTION
Yet another maintenance PR including bug fixes and various improvements around robustness.

Highlights:
 - Fixes and improvements to the memory module
   - Fix mishandled corner cases in `find_free_space`
   - Fix a bug in the `resotre` method
   - Manage map info with `bisect` to improve performance
   - Introduce a new method: `unmap_between` for bulk unampping
 - Fixes and improvements to POSIX syscalls
   - Reimplemented `mmap` and `munmap` to make them more readable and maintinable, and better follow the POSIX spec
   - Minor improvements to `brk`
   - Rearranged uid and gid accessors, and implemented a few missing ones
   - De-duplicated some socket syscalls code
 - As always, opportunistic PEP8-friendly tweaks to keep it clean an tidy