### PR TITLE
Clear memory before restore.

### DIFF
--- a/qiling/os/memory.py
+++ b/qiling/os/memory.py
@@ -286,6 +286,9 @@ class QlMemoryManager:
         """Restore saved memory content.
         """
 
+        # Unmap everything so we start with a clean memory state.
+        self.unmap_all()
+
         for lbound, ubound, perms, label, data in mem_dict['ram']:
             self.ql.log.debug(f'restoring memory range: {lbound:#08x} {ubound:#08x} {label}')
 


### PR DESCRIPTION
This fixes #1136 by unmapping everything before applying the restore operation. This will make sure that after a restore, the memory state will be exactly the same as it was when the memory's `save` method was called.

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
