### PR TITLE
Fix improper signaling of emulation termination in gdb single step

### DIFF
--- a/qiling/const.py
+++ b/qiling/const.py
@@ -66,6 +66,12 @@ class QL_STOP(Flag):
     EXIT_TRAP = (1 << 1)
 
 
+class QL_STATE(Enum):
+    NOT_SET = 0
+    STARTED = 1
+    STOPPED = 2
+
+
 QL_ARCH_INTERPRETER: Final = (QL_ARCH.EVM,)
 
 QL_OS_POSIX: Final = (QL_OS.LINUX, QL_OS.FREEBSD, QL_OS.MACOS, QL_OS.QNX)

--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -30,7 +30,7 @@ from unicorn.unicorn_const import (
 )
 
 from qiling import Qiling
-from qiling.const import QL_ARCH, QL_ENDIAN, QL_OS
+from qiling.const import QL_ARCH, QL_ENDIAN, QL_OS, QL_STATE
 from qiling.debugger import QlDebugger
 from qiling.debugger.gdb.xmlregs import QlGdbFeatures
 from qiling.debugger.gdb.utils import QlGdbUtils
@@ -673,6 +673,11 @@ class QlGdb(QlDebugger):
 
             self.gdb.resume_emu(steps=1)
 
+            # if emulation has been stopped, signal program termination
+            if self.ql.emu_state is QL_STATE.STOPPED:
+                return f'S{SIGTERM:02x}'
+
+            # otherwise, this is just single stepping
             return f'S{SIGTRAP:02x}'
 
         def handle_X(subcmd: str) -> Reply:

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -11,7 +11,7 @@ from unicorn.x86_const import UC_X86_REG_CR4, UC_X86_REG_CR8
 
 from qiling import Qiling
 from qiling.arch.x86_const import FS_SEGMENT_ADDR, GS_SEGMENT_ADDR
-from qiling.const import QL_ARCH
+from qiling.const import QL_ARCH, QL_STATE
 from qiling.exception import QlErrorArch
 from qiling.os.const import POINTER
 from qiling.os.windows.api import HINSTANCE, DWORD, LPVOID
@@ -247,13 +247,8 @@ class Process:
             #
             # in case of a dll loaded from a hooked API call, failures would not be
             # recoverable and we have to give up its DllMain.
-            if not self.ql.os.PE_RUN:
-
-                # temporarily set PE_RUN to allow proper fcall unwinding during
-                # execution of DllMain
-                self.ql.os.PE_RUN = True
+            if self.ql.emu_state is not QL_STATE.STARTED:
                 self.call_dll_entrypoint(dll, dll_base, dll_len, dll_name)
-                self.ql.os.PE_RUN = False
 
         self.ql.log.info(f'Done loading {dll_name}')
 

--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -19,6 +19,7 @@ from .stats import QlOsStats
 from .utils import QlOsUtils
 from .path import QlOsPath
 
+
 class QlOs:
     type: QL_OS
 
@@ -226,7 +227,7 @@ class QlOs:
 
     def stop(self):
         if self.ql.multithread:
-            self.thread_management.stop() 
+            self.thread_management.stop()
         else:
             self.ql.emu_stop()
 

--- a/qiling/os/uefi/uefi.py
+++ b/qiling/os/uefi/uefi.py
@@ -27,7 +27,6 @@ class QlOsUefi(QlOs):
         self.entry_point = 0
         self.running_module: str
         self.smm: SmmEnv
-        self.PE_RUN: bool
         self.heap: QlMemoryHeap    # Will be initialized by the loader.
 
         self.on_module_enter: MutableSequence[Callable[[str], bool]] = []
@@ -217,8 +216,6 @@ class QlOsUefi(QlOs):
             self.exit_point = self.ql.exit_point
 
         try:
-            self.PE_RUN = True
-
             self.ql.emu_start(self.ql.loader.entry_point, self.exit_point, self.ql.timeout, self.ql.count)
         except KeyboardInterrupt:
             self.ql.log.critical(f'Execution interrupted by user')
@@ -229,4 +226,3 @@ class QlOsUefi(QlOs):
 
     def stop(self) -> None:
         self.ql.emu_stop()
-        self.PE_RUN = False

--- a/qiling/os/uefi/uefi.py
+++ b/qiling/os/uefi/uefi.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
@@ -17,6 +17,7 @@ from qiling.os.fcall import QlFunctionCall, TypedArg
 
 from qiling.os.uefi import guids_db
 from qiling.os.uefi.smm import SmmEnv
+
 
 class QlOsUefi(QlOs):
     type = QL_OS.UEFI
@@ -44,11 +45,9 @@ class QlOsUefi(QlOs):
         saved_state['entry_point'] = self.entry_point
         return saved_state
 
-
     def restore(self, saved_state):
         super(QlOsUefi, self).restore(saved_state)
         self.entry_point = saved_state['entry_point']
-
 
     def process_fcall_params(self, targs: Iterable[TypedArg]) -> Sequence[Tuple[str, str]]:
         '''[override] Post-process function call arguments values to
@@ -64,7 +63,7 @@ class QlOsUefi(QlOs):
             '''Use original processing method for other types.
             '''
 
-            # the original method accepts a list and returns a list, so here we 
+            # the original method accepts a list and returns a list, so here we
             # craft a list containing one 3-tuple, and extracting the single element
             # the result list contains. that element is a 2-tuple, from which we
             # only need the value
@@ -101,7 +100,6 @@ class QlOsUefi(QlOs):
 
         return bool(sum(callback(module) for callback in self.on_module_enter))
 
-
     def emit_context(self):
         rgroups = (
             ((8, 'rax'), (8, 'r8'),  (4, 'cs')),
@@ -130,7 +128,6 @@ class QlOsUefi(QlOs):
 
         self.ql.log.error(f'')
 
-
     def emit_hexdump(self, address: int, data: bytearray, num_cols: int = 16):
         self.ql.log.error('Hexdump:')
 
@@ -146,7 +143,6 @@ class QlOsUefi(QlOs):
 
         self.ql.log.error(f'')
 
-
     def emit_disasm(self, address: int, data: bytearray, num_insns: int = 8):
         md = self.ql.arch.disassembler
 
@@ -156,7 +152,6 @@ class QlOsUefi(QlOs):
             self.ql.log.error(f'{insn.address:08x} : {insn.bytes.hex():28s}  {insn.mnemonic:10s} {insn.op_str:s}')
 
         self.ql.log.error(f'')
-
 
     def emit_stack(self, nitems: int = 4):
         self.ql.log.error('Stack:')
@@ -198,7 +193,6 @@ class QlOsUefi(QlOs):
         self.ql.log.error(f'Memory map:')
         for info_line in self.ql.mem.get_formatted_mapinfo():
             self.ql.log.error(info_line)
-
 
     def set_api(self, target: str, handler: Callable, intercept: QL_INTERCEPT = QL_INTERCEPT.CALL):
         super().set_api(f'hook_{target}', handler, intercept)

--- a/qiling/os/windows/dlls/kernel32/processthreadsapi.py
+++ b/qiling/os/windows/dlls/kernel32/processthreadsapi.py
@@ -20,7 +20,6 @@ from qiling.os.windows.structs import Token, make_startup_info
 })
 def hook_ExitProcess(ql: Qiling, address: int, params):
     ql.emu_stop()
-    ql.os.PE_RUN = False
 
 def _GetStartupInfo(ql: Qiling, address: int, params, *, wide: bool):
     lpStartupInfo = params['lpStartupInfo']
@@ -238,7 +237,6 @@ def hook_TerminateProcess(ql: Qiling, address: int, params):
 
     if process == ql.os.profile.getint("KERNEL", "pid"):  # or process == ql.os.image_address:
         ql.emu_stop()
-        ql.os.PE_RUN = False
 
     return 1
 

--- a/qiling/os/windows/dlls/kernel32/winbase.py
+++ b/qiling/os/windows/dlls/kernel32/winbase.py
@@ -158,7 +158,6 @@ def hook__lwrite(ql: Qiling, address: int, params):
 })
 def hook_FatalExit(ql: Qiling, address: int, params):
     ql.emu_stop()
-    ql.os.PE_RUN = False
 
 # PVOID EncodePointer(
 #  _In_ PVOID Ptr

--- a/qiling/os/windows/dlls/mscoree.py
+++ b/qiling/os/windows/dlls/mscoree.py
@@ -15,4 +15,3 @@ from qiling.os.windows.fncc import *
 })
 def hook_CorExitProcess(ql: Qiling, address: int, params):
     ql.emu_stop()
-    ql.os.PE_RUN = False

--- a/qiling/os/windows/dlls/msvcrt.py
+++ b/qiling/os/windows/dlls/msvcrt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 

--- a/qiling/os/windows/dlls/msvcrt.py
+++ b/qiling/os/windows/dlls/msvcrt.py
@@ -193,7 +193,6 @@ def hook__initterm(ql: Qiling, address: int, params):
 })
 def hook_exit(ql: Qiling, address: int, params):
     ql.emu_stop()
-    ql.os.PE_RUN = False
 
 # int __cdecl _initterm_e(
 #    PVFV *,

--- a/qiling/os/windows/windows.py
+++ b/qiling/os/windows/windows.py
@@ -80,7 +80,6 @@ class QlOsWindows(QlOs):
         self.userprofile = ntpath.join(sysdrv, 'Users', username)
         self.username = username
 
-        self.PE_RUN = False
         self.last_error = 0
 
         self.argv = self.ql.argv
@@ -212,8 +211,6 @@ class QlOsWindows(QlOs):
 
         entry_point = self.ql.loader.entry_point
         exit_point = (self.ql.loader.entry_point + len(self.ql.code)) if self.ql.code else self.exit_point
-
-        self.PE_RUN = True
 
         try:
             self.ql.emu_start(entry_point, exit_point, self.ql.timeout, self.ql.count)


### PR DESCRIPTION
Changes
 - Introduced `emu_state` core property to allow querying emulation state
 - Removed the `PE_RUN` property
 - Fixed #1310