### PR TITLE
Delete legacy object before reloading custom_script

### DIFF
--- a/qiling/extensions/idaplugin/qilingida.py
+++ b/qiling/extensions/idaplugin/qilingida.py
@@ -2026,6 +2026,7 @@ class QlEmuPlugin(plugin_t, UI_Hooks):
                 module = importlib.import_module(scriptname)
 
                 if is_reload:
+                    del self.userobj
                     importlib.reload(module)
                 cls = getattr(module, classname)
                 return cls()


### PR DESCRIPTION
Legacy objects are automatically destructed after the creation of new objects. 
It caused `__init__` of new version script called before calling `__del__` of old one. 
This means that you cannot unregister old things before new module loading. 
So we delete legacy object explicitly at there to ensure the correct call order.

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [ ] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [x] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
