### PR TITLE
Improve afl_fuzz wrapper

### DIFF
--- a/examples/fuzzing/stm32f429/fuzz.py
+++ b/examples/fuzzing/stm32f429/fuzz.py
@@ -42,10 +42,7 @@ def main(input_file: str):
         
         return UC_ERR_OK
 
-    ql.uc.ctl_exits_enabled(True)
-    ql.uc.ctl_set_exits([0x80006d9])
-
-    ql_afl_fuzz_custom(ql, input_file, place_input_callback, fuzzing_callback=fuzzing_callback)
+    ql_afl_fuzz_custom(ql, input_file, place_input_callback, fuzzing_callback=fuzzing_callback, exits=[0x80006d9])
 
     os.exit(0)
 

--- a/qiling/extensions/afl/afl.py
+++ b/qiling/extensions/afl/afl.py
@@ -28,9 +28,6 @@ def ql_afl_fuzz(ql: Qiling,
             :raises UcAflError: If something wrong happens with the fuzzer.
         """
 
-        ql.uc.ctl_exits_enabled(True)
-        ql.uc.ctl_set_exits(exits)
-
         def _dummy_fuzz_callback(_ql: "Qiling"):
             if isinstance(_ql.arch, QlArchARM):
                 pc = _ql.arch.effective_pc
@@ -43,16 +40,20 @@ def ql_afl_fuzz(ql: Qiling,
             
             return UC_ERR_OK
         
-        return ql_afl_fuzz_custom(ql, input_file, place_input_callback, _dummy_fuzz_callback, 
+        return ql_afl_fuzz_custom(ql, input_file, place_input_callback, _dummy_fuzz_callback, exits,
                                   validate_crash_callback, always_validate, persistent_iters)
 
 def ql_afl_fuzz_custom(ql: Qiling,
                        input_file: str,
                        place_input_callback: Callable[["Qiling", bytes, int], bool],
                        fuzzing_callback: Callable[["Qiling"], int],
+                       exits: List[int] = [],
                        validate_crash_callback: Callable[["Qiling", bytes, int], bool] = None,
                        always_validate: bool = False,
                        persistent_iters: int = 1):
+
+        ql.uc.ctl_exits_enabled(True)
+        ql.uc.ctl_set_exits(exits)
 
         def _ql_afl_place_input_wrapper(uc, input_bytes, iters, data):
             (ql, cb, _, _) = data


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

The current `ql_afl_fuzz` wrapper in Qiling supports setting exit addresses using the `exits` parameter. It sets the exit addresses at the start and calls the `ql_afl_fuzz_custom` wrapper with a dummy fuzz callback.

Although both `ql_afl_fuzz` and `ql_afl_fuzz_custom` wrappers have almost the same API, it is impossible to set exit addresses if `ql_afl_fuzz_custom` is called directly. 

To address this issue, I passed the exits parameter seamlessly to `ql_afl_fuzz_custom` for both wrappers to support setting exit addresses.

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
