### PR TITLE
Fix struct packing logic associated with calls to `getdents64`

### DIFF
--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -766,7 +766,7 @@ def __getdents_common(ql: Qiling, fd: int, dirp: int, count: int, *, is_64: bool
         return bytes([t])
 
     if ql.os.fd[fd].tell() == 0:
-        n = ql.arch.pointersize
+        n = 8 if is_64 else ql.arch.pointersize
         total_size = 0
         results = os.scandir(ql.os.fd[fd].name)
         _ent_count = 0
@@ -787,8 +787,8 @@ def __getdents_common(ql: Qiling, fd: int, dirp: int, count: int, *, is_64: bool
 
             if is_64:
                 fields = (
-                    (ql.pack(d_ino), n),
-                    (ql.pack(d_off), n),
+                    (ql.pack64(d_ino), n),
+                    (ql.pack64(d_off), n),
                     (ql.pack16(d_reclen), 2),
                     (d_type, 1),
                     (d_name, len(d_name))


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly. (N/A)
- [ ] Essential comments are added. (N/A)
- [ ] The reference of the new code is pointed out. (N/A)

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

Fixes the issue outlined in #1328.
