### PR TITLE
Periodic maintenance PR

### DIFF
--- a/qiling/core.py
+++ b/qiling/core.py
@@ -687,11 +687,11 @@ class Qiling(QlCoreHooks, QlCoreStructs):
 
     # Map "ql_path" to any objects which implements QlFsMappedObject.
     def add_fs_mapper(self, ql_path: Union["PathLike", str], real_dest):
-        self.os.fs_mapper.add_fs_mapping(ql_path, real_dest)
+        self.os.fs_mapper.add_mapping(ql_path, real_dest)
 
     # Remove "ql_path" mapping.
     def remove_fs_mapper(self, ql_path: Union["PathLike", str]):
-        self.os.fs_mapper.remove_fs_mapping(ql_path)
+        self.os.fs_mapper.remove_mapping(ql_path)
 
     # push to stack bottom, and update stack register
     def stack_push(self, data):

--- a/qiling/core_hooks.py
+++ b/qiling/core_hooks.py
@@ -8,7 +8,7 @@
 # handling hooks                             #
 ##############################################
 
-import functools
+from functools import wraps
 from typing import Any, Callable, MutableMapping, MutableSequence, Protocol
 from typing import TYPE_CHECKING
 
@@ -87,8 +87,7 @@ class InterruptHookCallback(Protocol):
 
 
 def hookcallback(ql: 'Qiling', callback: Callable):
-
-    functools.wraps(callback)
+    @wraps(callback)
     def wrapper(*args, **kwargs):
         try:
             return callback(*args, **kwargs)

--- a/qiling/core_hooks.py
+++ b/qiling/core_hooks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from unicorn import Uc
     from qiling import Qiling
 
+
 class MemHookCallback(Protocol):
     def __call__(self, __ql: Qiling, __access: int, __address: int, __size: int, __value: int, *__context: Any) -> Any:
         """Memory access hook callback.
@@ -70,6 +71,7 @@ class MemHookCallback(Protocol):
         """
         pass
 
+
 class TraceHookCalback(Protocol):
     def __call__(self, __ql: Qiling, __address: int, __size: int, *__context: Any) -> Any:
         """Execution hook callback.
@@ -86,6 +88,7 @@ class TraceHookCalback(Protocol):
         """
         pass
 
+
 class AddressHookCallback(Protocol):
     def __call__(self, __ql: Qiling, *__context: Any) -> Any:
         """Address hook callback.
@@ -99,6 +102,7 @@ class AddressHookCallback(Protocol):
             (if any) or `None`
         """
         pass
+
 
 class InterruptHookCallback(Protocol):
     def __call__(self, __ql: Qiling, intno: int, *__context: Any) -> Any:
@@ -142,10 +146,10 @@ class QlCoreHooks:
         self._addr_hook: MutableMapping[int, MutableSequence[HookAddr]] = {}
         self._addr_hook_fuc: MutableMapping[int, int] = {}
 
-
     ########################
     # Callback definitions #
     ########################
+
     def _hook_intr_cb(self, uc: Uc, intno: int, pack_data) -> None:
         """Interrupt hooks dispatcher.
         """
@@ -171,7 +175,6 @@ class QlCoreHooks:
         if not handled:
             raise QlErrorCoreHook("_hook_intr_cb : not handled")
 
-
     def _hook_insn_cb(self, uc: Uc, *args):
         """Instruction hooks dispatcher.
         """
@@ -195,7 +198,6 @@ class QlCoreHooks:
         # use the last return value received
         return retval
 
-
     def _hook_trace_cb(self, uc: Uc, addr: int, size: int, pack_data) -> None:
         """Code and block hooks dispatcher.
         """
@@ -211,7 +213,6 @@ class QlCoreHooks:
 
                     if type(ret) is int and ret & QL_HOOK_BLOCK:
                         break
-
 
     def _hook_mem_cb(self, uc: Uc, access: int, addr: int, size: int, value: int, pack_data):
         """Memory access hooks dispatcher.
@@ -236,7 +237,6 @@ class QlCoreHooks:
 
         return True
 
-
     def _hook_insn_invalid_cb(self, uc: Uc, pack_data) -> None:
         """Invalid instruction hooks dispatcher.
         """
@@ -257,7 +257,6 @@ class QlCoreHooks:
         if not handled:
             raise QlErrorCoreHook("_hook_insn_invalid_cb : not handled")
 
-
     def _hook_addr_cb(self, uc: Uc, addr: int, size: int, pack_data):
         """Address hooks dispatcher.
         """
@@ -276,17 +275,16 @@ class QlCoreHooks:
     ###############
     # Class Hooks #
     ###############
+
     def _ql_hook_internal(self, hook_type: int, callback: Callable, context: Any, *args) -> int:
         _callback = hookcallback(self, callback)
 
         return self._h_uc.hook_add(hook_type, _callback, (self, context), 1, 0, *args)
 
-
     def _ql_hook_addr_internal(self, callback: Callable, address: int) -> int:
         _callback = hookcallback(self, callback)
 
         return self._h_uc.hook_add(UC_HOOK_CODE, _callback, self, address, address)
-
 
     def _ql_hook(self, hook_type: int, h: Hook, *args) -> None:
 
@@ -359,7 +357,6 @@ class QlCoreHooks:
             if hook_type & t:
                 handler(t)
 
-
     def ql_hook(self, hook_type: int, callback: Callable, user_data: Any = None, begin: int = 1, end: int = 0, *args) -> HookRet:
         """Intercept certain emulation events within a specified range.
 
@@ -384,7 +381,6 @@ class QlCoreHooks:
 
         return HookRet(self, hook_type, hook)
 
-
     def hook_code(self, callback: TraceHookCalback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept assembly instructions before they get executed.
 
@@ -403,11 +399,9 @@ class QlCoreHooks:
 
         return self.ql_hook(UC_HOOK_CODE, callback, user_data, begin, end)
 
-
     # TODO: remove; this is a special case of hook_intno(-1)
     def hook_intr(self, callback, user_data=None, begin=1, end=0):
         return self.ql_hook(UC_HOOK_INTR, callback, user_data, begin, end)
-
 
     def hook_block(self, callback: TraceHookCalback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept landings in new basic blocks in a specified range.
@@ -427,7 +421,6 @@ class QlCoreHooks:
 
         return self.ql_hook(UC_HOOK_BLOCK, callback, user_data, begin, end)
 
-
     def hook_mem_unmapped(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept illegal accesses to unmapped memory in a specified range.
 
@@ -445,7 +438,6 @@ class QlCoreHooks:
         """
 
         return self.ql_hook(UC_HOOK_MEM_UNMAPPED, callback, user_data, begin, end)
-
 
     def hook_mem_read_invalid(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept illegal reading attempts from a specified range.
@@ -465,7 +457,6 @@ class QlCoreHooks:
 
         return self.ql_hook(UC_HOOK_MEM_READ_INVALID, callback, user_data, begin, end)
 
-
     def hook_mem_write_invalid(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept illegal writing attempts to a specified range.
 
@@ -484,7 +475,6 @@ class QlCoreHooks:
 
         return self.ql_hook(UC_HOOK_MEM_WRITE_INVALID, callback, user_data, begin, end)
 
-
     def hook_mem_fetch_invalid(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept illegal code fetching attempts from a specified range.
 
@@ -502,7 +492,6 @@ class QlCoreHooks:
         """
 
         return self.ql_hook(UC_HOOK_MEM_FETCH_INVALID, callback, user_data, begin, end)
-
 
     def hook_mem_valid(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept benign memory accesses within a specified range.
@@ -523,7 +512,6 @@ class QlCoreHooks:
 
         return self.ql_hook(UC_HOOK_MEM_VALID, callback, user_data, begin, end)
 
-
     def hook_mem_invalid(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept invalid memory accesses within a specified range.
         This is equivalent to hooking invalid memory reads, writes and fetches.
@@ -542,7 +530,6 @@ class QlCoreHooks:
         """
 
         return self.ql_hook(UC_HOOK_MEM_INVALID, callback, user_data, begin, end)
-
 
     def hook_address(self, callback: AddressHookCallback, address: int, user_data: Any = None) -> HookRet:
         """Intercept execution from a certain memory address.
@@ -569,7 +556,6 @@ class QlCoreHooks:
         # note: assuming 0 is not a valid hook type
         return HookRet(self, 0, hook)
 
-
     def hook_intno(self, callback: InterruptHookCallback, intno: int, user_data: Any = None) -> HookRet:
         """Intercept interrupts.
 
@@ -586,7 +572,6 @@ class QlCoreHooks:
         self._ql_hook(UC_HOOK_INTR, hook)
 
         return HookRet(self, UC_HOOK_INTR, hook)
-
 
     def hook_mem_read(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept benign memory reads from a specified range.
@@ -606,7 +591,6 @@ class QlCoreHooks:
 
         return self.ql_hook(UC_HOOK_MEM_READ, callback, user_data, begin, end)
 
-
     def hook_mem_write(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept benign memory writes to a specified range.
 
@@ -625,7 +609,6 @@ class QlCoreHooks:
 
         return self.ql_hook(UC_HOOK_MEM_WRITE, callback, user_data, begin, end)
 
-
     def hook_mem_fetch(self, callback: MemHookCallback, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept benign code fetches from a specified range.
 
@@ -643,7 +626,6 @@ class QlCoreHooks:
         """
 
         return self.ql_hook(UC_HOOK_MEM_FETCH, callback, user_data, begin, end)
-
 
     def hook_insn(self, callback, insn_type: int, user_data: Any = None, begin: int = 1, end: int = 0) -> HookRet:
         """Intercept execution of a certain instruction type within a specified range.
@@ -665,7 +647,6 @@ class QlCoreHooks:
         """
 
         return self.ql_hook(UC_HOOK_INSN, callback, user_data, begin, end, insn_type)
-
 
     def hook_del(self, hret: HookRet) -> None:
         """Unregister an existing hook and release its resources.
@@ -721,7 +702,6 @@ class QlCoreHooks:
             if hook_type & t:
                 handler(t)
 
-
     def clear_hooks(self):
         for ptr in self._hook_fuc.values():
             self._h_uc.hook_del(ptr)
@@ -733,7 +713,6 @@ class QlCoreHooks:
             self._h_uc.hook_del(ptr)
 
         self.clear_ql_hooks()
-
 
     def clear_ql_hooks(self):
         self._hook = {}

--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -293,11 +293,11 @@ class QlGdb(QlDebugger):
             addr, size = (int(p, 16) for p in subcmd.split(','))
 
             try:
-                data = self.ql.mem.read(addr, size).hex()
-            except UcError:
-                return 'E14'
+                data = self.ql.mem.read(addr, size)
+            except UcError as ex:
+                return f'E{ex.errno:02d}'
             else:
-                return data
+                return data.hex()
 
         def handle_M(subcmd: str) -> Reply:
             """Write target memory.
@@ -313,8 +313,8 @@ class QlGdb(QlDebugger):
 
             try:
                 self.ql.mem.write(addr, data)
-            except UcError:
-                return 'E01'
+            except UcError as ex:
+                return f'E{ex.errno:02d}'
             else:
                 return REPLY_OK
 
@@ -688,8 +688,8 @@ class QlGdb(QlDebugger):
             try:
                 if data:
                     self.ql.mem.write(addr, data.encode(ENCODING))
-            except UcError:
-                return 'E01'
+            except UcError as ex:
+                return f'E{ex.errno:02d}'
             else:
                 return REPLY_OK
 

--- a/qiling/extensions/idaplugin/qilingida.py
+++ b/qiling/extensions/idaplugin/qilingida.py
@@ -898,7 +898,7 @@ class QlEmuQiling:
             elffile = ELFFile(f)
             elf_header = elffile.header
             if elf_header['e_type'] == 'ET_EXEC':
-                self.baseaddr = self.ql.os.elf_mem_start
+                self.baseaddr = self.ql.loader.images[0].base
             elif elf_header['e_type'] == 'ET_DYN':
                 if self.ql.arch.bits == 32:
                     self.baseaddr = int(self.ql.os.profile.get("OS32", "load_address"), 16)

--- a/qiling/loader/dos.py
+++ b/qiling/loader/dos.py
@@ -84,7 +84,7 @@ class QlLoaderDOS(QlLoader):
 
             # https://en.wikipedia.org/wiki/Master_boot_record#BIOS_to_MBR_interface
             if not self.ql.os.fs_mapper.has_mapping(0x80):
-                self.ql.os.fs_mapper.add_fs_mapping(0x80, QlDisk(path, 0x80))
+                self.ql.os.fs_mapper.add_mapping(0x80, QlDisk(path, 0x80))
 
             # 0x80 -> first drive
             self.ql.arch.regs.dx = 0x80

--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -353,7 +353,6 @@ class QlLoaderELF(QlLoader):
         self.init_sp = self.ql.arch.regs.arch_sp
 
         self.ql.os.entry_point = self.entry_point = entry_point
-        self.ql.os.elf_mem_start = mem_start
         self.ql.os.elf_entry = self.elf_entry
         self.ql.os.function_hook = FunctionHook(self.ql, elf_phdr, elf_phnum, elf_phent, load_address, mem_end)
 

--- a/qiling/os/filestruct.py
+++ b/qiling/os/filestruct.py
@@ -18,6 +18,8 @@ class ql_file:
     def __init__(self, path: AnyStr, fd: int):
         self.__path = path
         self.__fd = fd
+        self.__closed = False
+
         # information for syscall mmap
         self._is_map_shared = False
         self._mapped_offset = -1
@@ -51,6 +53,8 @@ class ql_file:
 
     def close(self) -> None:
         os.close(self.__fd)
+
+        self.__closed = True
 
     def fstat(self):
         return Fstat(self.__fd)
@@ -87,4 +91,6 @@ class ql_file:
     def name(self):
         return self.__path
 
-
+    @property
+    def closed(self) -> bool:
+        return self.__closed

--- a/qiling/os/filestruct.py
+++ b/qiling/os/filestruct.py
@@ -21,7 +21,7 @@ class ql_file:
         # information for syscall mmap
         self._is_map_shared = False
         self._mapped_offset = -1
-        self._close_on_exec = False
+        self.close_on_exec = False
 
     @classmethod
     def open(cls, open_path: AnyStr, open_flags: int, open_mode: int, dir_fd: int = None):
@@ -87,10 +87,4 @@ class ql_file:
     def name(self):
         return self.__path
 
-    @property
-    def close_on_exec(self) -> bool:
-        return self._close_on_exec
 
-    @close_on_exec.setter
-    def close_on_exec(self, value: bool) -> None:
-        self._close_on_exec = value

--- a/qiling/os/filestruct.py
+++ b/qiling/os/filestruct.py
@@ -21,7 +21,7 @@ class ql_file:
         # information for syscall mmap
         self._is_map_shared = False
         self._mapped_offset = -1
-        self._close_on_exec = 0
+        self._close_on_exec = False
 
     @classmethod
     def open(cls, open_path: AnyStr, open_flags: int, open_mode: int, dir_fd: int = None):
@@ -88,9 +88,9 @@ class ql_file:
         return self.__path
 
     @property
-    def close_on_exec(self) -> int:
+    def close_on_exec(self) -> bool:
         return self._close_on_exec
 
     @close_on_exec.setter
-    def close_on_exec(self, value: int) -> None:
+    def close_on_exec(self, value: bool) -> None:
         self._close_on_exec = value

--- a/qiling/os/freebsd/freebsd.py
+++ b/qiling/os/freebsd/freebsd.py
@@ -16,7 +16,6 @@ class QlOsFreebsd(QlOsPosix):
     def __init__(self, ql):
         super(QlOsFreebsd, self).__init__(ql)
 
-        self.elf_mem_start = 0x0
         self.load()
 
 

--- a/qiling/os/freebsd/freebsd.py
+++ b/qiling/os/freebsd/freebsd.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
@@ -10,6 +10,7 @@ from qiling.arch.x86_utils import GDTManager, SegmentManager86
 from qiling.const import QL_OS
 from qiling.os.posix.posix import QlOsPosix
 
+
 class QlOsFreebsd(QlOsPosix):
     type = QL_OS.FREEBSD
 
@@ -17,7 +18,6 @@ class QlOsFreebsd(QlOsPosix):
         super(QlOsFreebsd, self).__init__(ql)
 
         self.load()
-
 
     def load(self):
         gdtm = GDTManager(self.ql)
@@ -28,16 +28,14 @@ class QlOsFreebsd(QlOsPosix):
 
         self.ql.hook_insn(self.hook_syscall, UC_X86_INS_SYSCALL)
 
-
     def hook_syscall(self, ql):
         return self.load_syscall()
-
 
     def run(self):
         if self.ql.exit_point is not None:
             self.exit_point = self.ql.exit_point
 
-        if  self.ql.entry_point is not None:
+        if self.ql.entry_point is not None:
             self.ql.loader.elf_entry = self.ql.entry_point
 
         try:

--- a/qiling/os/linux/linux.py
+++ b/qiling/os/linux/linux.py
@@ -121,11 +121,11 @@ class QlOsLinux(QlOsPosix):
                 self.fd[i] = None
 
     def setup_procfs(self):
-        self.fs_mapper.add_fs_mapping(r'/proc/self/auxv',    partial(QlProcFS.self_auxv, self))
-        self.fs_mapper.add_fs_mapping(r'/proc/self/cmdline', partial(QlProcFS.self_cmdline, self))
-        self.fs_mapper.add_fs_mapping(r'/proc/self/environ', partial(QlProcFS.self_environ, self))
-        self.fs_mapper.add_fs_mapping(r'/proc/self/exe',     partial(QlProcFS.self_exe, self))
-        self.fs_mapper.add_fs_mapping(r'/proc/self/maps',    partial(QlProcFS.self_map, self.ql.mem))
+        self.fs_mapper.add_mapping(r'/proc/self/auxv',    partial(QlProcFS.self_auxv, self),       force=True)
+        self.fs_mapper.add_mapping(r'/proc/self/cmdline', partial(QlProcFS.self_cmdline, self),    force=True)
+        self.fs_mapper.add_mapping(r'/proc/self/environ', partial(QlProcFS.self_environ, self),    force=True)
+        self.fs_mapper.add_mapping(r'/proc/self/exe',     partial(QlProcFS.self_exe, self),        force=True)
+        self.fs_mapper.add_mapping(r'/proc/self/maps',    partial(QlProcFS.self_map, self.ql.mem), force=True)
 
     def hook_syscall(self, ql, intno = None):
         return self.load_syscall()

--- a/qiling/os/linux/linux.py
+++ b/qiling/os/linux/linux.py
@@ -48,7 +48,6 @@ class QlOsLinux(QlOsPosix):
         self.futexm = None
         self.fh = None
         self.function_after_load_list = []
-        self.elf_mem_start = 0x0
         self.load()
 
     def load(self):

--- a/qiling/os/linux/linux.py
+++ b/qiling/os/linux/linux.py
@@ -117,7 +117,7 @@ class QlOsLinux(QlOsPosix):
 
         # on fork or execve, do not inherit opened files tagged as 'close on exec'
         for i in range(len(self.fd)):
-            if getattr(self.fd[i], 'close_on_exec', 0):
+            if getattr(self.fd[i], 'close_on_exec', False):
                 self.fd[i] = None
 
     def setup_procfs(self):

--- a/qiling/os/linux/procfs.py
+++ b/qiling/os/linux/procfs.py
@@ -16,6 +16,10 @@ class FsMappedStream(io.BytesIO):
     def __init__(self, fname: str, *args) -> None:
         super().__init__(*args)
 
+        # note that the name property should reflect the actual file name
+        # on the host file system, and here we get a virtual file name
+        # instead. we should be fine, however, since there is no file
+        # backing this object anyway
         self.name = fname
 
 

--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -19,6 +19,7 @@ from .stats import QlOsStats
 from .utils import QlOsUtils
 from .path import QlOsPath
 
+
 class QlOs:
     type: QL_OS
 
@@ -47,9 +48,9 @@ class QlOs:
             self.fs_mapper = QlFsMapper(self.path)
 
         self.user_defined_api = {
-            QL_INTERCEPT.CALL : {},
+            QL_INTERCEPT.CALL:  {},
             QL_INTERCEPT.ENTER: {},
-            QL_INTERCEPT.EXIT : {}
+            QL_INTERCEPT.EXIT:  {}
         }
 
         # IDAPython has some hack on standard io streams and thus they don't have corresponding fds.
@@ -224,7 +225,7 @@ class QlOs:
 
     def stop(self):
         if self.ql.multithread:
-            self.thread_management.stop() 
+            self.thread_management.stop()
         else:
             self.ql.emu_stop()
 

--- a/qiling/os/path.py
+++ b/qiling/os/path.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
@@ -9,6 +9,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from qiling.const import QL_OS, QL_OS_POSIX
 
 AnyPurePath = Union[PurePosixPath, PureWindowsPath]
+
 
 class QlOsPath:
     """Virtual to host path manipulations helper.
@@ -59,6 +60,10 @@ class QlOsPath:
                 path = path.relative_to(pardir)
 
         return path
+
+    @property
+    def root(self) -> str:
+        return str(self._cwd_anchor)
 
     @property
     def cwd(self) -> str:
@@ -274,6 +279,18 @@ class QlOsPath:
 
         return str(virtpath)
 
+    def is_virtual_abspath(self, virtpath: str) -> bool:
+        """Determine whether a given virtual path is absolute.
+
+        Args:
+            virtpath : virtual path to query
+
+        Returns: `True` if `virtpath` is an absolute path, `False` if relative
+        """
+
+        vpath = self.PureVirtualPath(virtpath)
+
+        return vpath.is_absolute()
 
     def virtual_abspath(self, virtpath: str) -> str:
         """Convert a relative virtual path to an absolute virtual path based
@@ -346,4 +363,3 @@ class QlOsPath:
             return QlOsPath.__host_casefold_path(hostpath)
 
         return hostpath
-

--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -1024,3 +1024,17 @@ SHMMNI = 4096   # max num of segs system wide
 # see: https://elixir.bootlin.com/linux/v5.19.17/source/include/uapi/asm-generic/hugetlb_encode.h
 HUGETLB_FLAG_ENCODE_SHIFT = 26
 HUGETLB_FLAG_ENCODE_MASK  = 0x3f
+
+# ipc syscall
+SEMOP       = 1
+SEMGET      = 2
+SEMCTL      = 3
+SEMTIMEDOP  = 4
+MSGSND      = 11
+MSGRCV      = 12
+MSGGET      = 13
+MSGCTL      = 14
+SHMAT       = 21
+SHMDT       = 22
+SHMGET      = 23
+SHMCTL      = 24

--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -1003,11 +1003,24 @@ errors = {
 }
 
 # shm syscall
-IPC_CREAT = 8**3
-IPC_EXCL = 2*(8**3)
-IPC_NOWAIT = 4*(8**3)
+IPC_PRIVATE = 0
 
-SHM_RDONLY = 8**4
-SHM_RND = 2*(8**4)
-SHM_REMAP= 4*(8**4)
-SHM_EXEC = 1*(8**5)
+# see: https://elixir.bootlin.com/linux/v5.19.17/source/include/uapi/linux/ipc.h
+IPC_CREAT  = 0o0001000  # create if key is nonexistent
+IPC_EXCL   = 0o0002000  # fail if key exists
+IPC_NOWAIT = 0o0004000  # return error on wait
+
+# see: https://elixir.bootlin.com/linux/v5.19.17/source/include/uapi/linux/shm.h
+SHM_W       = 0o000200
+SHM_R       = 0o000400
+SHM_HUGETLB = 0o004000  # segment will use huge TLB pages
+SHM_RDONLY	= 0o010000  # read-only access
+SHM_RND		= 0o020000	# round attach address to SHMLBA boundary
+SHM_REMAP	= 0o040000	# take-over region on attach
+SHM_EXEC	= 0o100000	# execution access
+
+SHMMNI = 4096   # max num of segs system wide
+
+# see: https://elixir.bootlin.com/linux/v5.19.17/source/include/uapi/asm-generic/hugetlb_encode.h
+HUGETLB_FLAG_ENCODE_SHIFT = 26
+HUGETLB_FLAG_ENCODE_MASK  = 0x3f

--- a/qiling/os/posix/const_mapping.py
+++ b/qiling/os/posix/const_mapping.py
@@ -156,12 +156,13 @@ def socket_domain_mapping(p: int, archtype: QL_ARCH, ostype: QL_OS) -> str:
 
 def socket_tcp_option_mapping(t: int, archtype: QL_ARCH) -> str:
     socket_option_map = {
-        QL_ARCH.X86: linux_socket_tcp_options,
+        QL_ARCH.X86:   linux_socket_tcp_options,
         QL_ARCH.X8664: linux_socket_tcp_options,
-        QL_ARCH.ARM: linux_socket_tcp_options,
+        QL_ARCH.ARM:   linux_socket_tcp_options,
         QL_ARCH.ARM64: linux_socket_tcp_options,
-        QL_ARCH.MIPS: linux_socket_tcp_options,
+        QL_ARCH.MIPS:  linux_socket_tcp_options,
     }[archtype]
+
     return _constant_mapping(t, socket_option_map)
 
 

--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -72,7 +72,7 @@ class QlFileDes:
     def __len__(self):
         return len(self.__fds)
 
-    def __getitem__(self, idx: Union[slice, int]):
+    def __getitem__(self, idx: int):
         return self.__fds[idx]
 
     def __setitem__(self, idx: int, val: Optional[IO]):

--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -4,7 +4,7 @@
 #
 
 from inspect import signature, Parameter
-from typing import TextIO, Union, Callable, IO, List, Optional
+from typing import Dict, NamedTuple, TextIO, Union, Callable, IO, List, Optional
 
 from unicorn.arm64_const import UC_ARM64_REG_X8, UC_ARM64_REG_X16
 from unicorn.arm_const import (
@@ -91,6 +91,16 @@ class QlFileDes:
         self.__fds = fds
 
 
+# vaguely reflects a shmid_ds structure
+class QlShmId(NamedTuple):
+    segsz: int
+    uid: int
+    gid: int
+    # cuid: int
+    # cgid: int
+    mode: int
+
+
 class QlOsPosix(QlOs):
 
     def __init__(self, ql: Qiling):
@@ -157,7 +167,7 @@ class QlOsPosix(QlOs):
         self.stdout = self._stdout
         self.stderr = self._stderr
 
-        self._shms = {}
+        self._shm: Dict[int, QlShmId] = {}
 
     def __get_syscall_mapper(self, archtype: QL_ARCH):
         qlos_path = f'.os.{self.type.name.lower()}.map_syscall'
@@ -349,3 +359,7 @@ class QlOsPosix(QlOs):
     @property
     def fd(self):
         return self._fd
+
+    @property
+    def shm(self):
+        return self._shm

--- a/qiling/os/posix/posix.py
+++ b/qiling/os/posix/posix.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
@@ -110,9 +110,9 @@ class QlOsPosix(QlOs):
         self.ifrname_ovr = conf.get('ifrname_override')
 
         self.posix_syscall_hooks = {
-            QL_INTERCEPT.CALL : {},
+            QL_INTERCEPT.CALL:  {},
             QL_INTERCEPT.ENTER: {},
-            QL_INTERCEPT.EXIT : {}
+            QL_INTERCEPT.EXIT:  {}
         }
 
         self.__syscall_id_reg = {
@@ -191,7 +191,7 @@ class QlOsPosix(QlOs):
         self.euid = 0 if enabled else self.uid
         self.egid = 0 if enabled else self.gid
 
-    def set_syscall(self, target: Union[int, str], handler: Callable, intercept: QL_INTERCEPT=QL_INTERCEPT.CALL):
+    def set_syscall(self, target: Union[int, str], handler: Callable, intercept: QL_INTERCEPT = QL_INTERCEPT.CALL):
         """Either hook or replace a system call with a custom one.
 
         Args:
@@ -298,7 +298,7 @@ class QlOsPosix(QlOs):
                 raise e
 
             # print out log entry
-            syscall_basename = syscall_name[len(SYSCALL_PREF) if syscall_name.startswith(SYSCALL_PREF) else 0:] 
+            syscall_basename = syscall_name[len(SYSCALL_PREF) if syscall_name.startswith(SYSCALL_PREF) else 0:]
 
             args = []
 

--- a/qiling/os/posix/syscall/__init__.py
+++ b/qiling/os/posix/syscall/__init__.py
@@ -16,6 +16,7 @@ from .resource import *
 from .sched import *
 from .select import *
 from .sendfile import *
+from .shm import *
 from .signal import *
 from .socket import *
 from .stat import *

--- a/qiling/os/posix/syscall/__init__.py
+++ b/qiling/os/posix/syscall/__init__.py
@@ -21,6 +21,7 @@ from .signal import *
 from .socket import *
 from .stat import *
 from .sysctl import *
+from .syscall import *
 from .sysinfo import *
 from .time import *
 from .types import *

--- a/qiling/os/posix/syscall/fcntl.py
+++ b/qiling/os/posix/syscall/fcntl.py
@@ -147,10 +147,10 @@ def ql_syscall_fcntl(ql: Qiling, fd: int, cmd: int, arg: int):
             regreturn = -EMFILE
 
     elif cmd == F_GETFD:
-        regreturn = getattr(f, "close_on_exec", 0)
+        regreturn = getattr(f, "close_on_exec", False)
 
     elif cmd == F_SETFD:
-        f.close_on_exec = 1 if arg & FD_CLOEXEC else 0
+        f.close_on_exec = bool(arg & FD_CLOEXEC)
         regreturn = 0
 
     elif cmd == F_GETFL:

--- a/qiling/os/posix/syscall/mman.py
+++ b/qiling/os/posix/syscall/mman.py
@@ -225,33 +225,3 @@ def ql_syscall_mmap2(ql: Qiling, addr: int, length: int, prot: int, flags: int, 
         pgoffset *= ql.mem.pagesize
 
     return syscall_mmap_impl(ql, addr, length, prot, flags, fd, pgoffset, 2)
-
-
-def ql_syscall_shmget(ql: Qiling, key: int, size: int, shmflg: int):
-    if shmflg & IPC_CREAT:
-        if shmflg & IPC_EXCL:
-            if key in ql.os._shms:
-                return EEXIST
-        else:
-            #addr = ql.mem.map_anywhere(size)
-            ql.os._shms[key] = (key, size)
-            return key
-    else:
-        if key not in ql.os._shms:
-            return ENOENT
-
-
-def ql_syscall_shmat(ql: Qiling, shmid: int, shmaddr: int, shmflg: int):
-    # shmid == key
-    # dummy implementation
-    if shmid not in ql.os._shms:
-        return EINVAL
-
-    key, size = ql.os._shms[shmid]
-
-    if shmaddr == 0:
-        addr = ql.mem.map_anywhere(size)
-    else:
-        addr = ql.mem.map(shmaddr, size, info="[shm]")
-
-    return addr

--- a/qiling/os/posix/syscall/shm.py
+++ b/qiling/os/posix/syscall/shm.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# Cross Platform and Multi Architecture Advanced Binary Emulation Framework
+#
+
+from unicorn.unicorn_const import UC_PROT_WRITE, UC_PROT_READ
+
+from qiling import Qiling
+from qiling.exception import QlOutOfMemory
+from qiling.os.posix.const import *
+from qiling.os.posix.posix import QlShmId
+
+
+def ql_syscall_shmget(ql: Qiling, key: int, size: int, shmflg: int):
+
+    def __create_shm(size: int, flags: int) -> int:
+        perms = flags & ((1 << 9) - 1)
+
+        posix_to_uc = (
+            (SHM_W, UC_PROT_WRITE),
+            (SHM_R, UC_PROT_READ)
+        )
+
+        # convert posix permissions to unicorn memory access bits
+        uc_perms = sum(u_perm for p_perm, u_perm in posix_to_uc if perms & p_perm)
+
+        # determine size alignment: either normal or huge page
+        if flags & SHM_HUGETLB:
+            shiftsize = (flags >> HUGETLB_FLAG_ENCODE_SHIFT) & HUGETLB_FLAG_ENCODE_MASK
+            pagesize = (1 << shiftsize)
+        else:
+            pagesize = ql.mem.pagesize
+
+        size = ql.mem.align_up(size, pagesize)
+
+        if len(ql.os.shm) < SHMMNI:
+            try:
+                key = ql.mem.map_anywhere(size, perms=uc_perms, info='[shm]')
+            except QlOutOfMemory:
+                return -1   # ENOMEM
+
+            ql.os.shm[key] = QlShmId(size, ql.os.uid, ql.os.gid, perms)
+
+        else:
+            return -1   # ENOSPC
+
+        return key
+
+    # create new shared memory segment
+    if key == IPC_PRIVATE:
+        key = __create_shm(size, shmflg)
+
+    # a shm with the specified key exists
+    elif key in ql.os.shm:
+        # ... but the user requested to create a new one
+        if shmflg & (IPC_CREAT | IPC_EXCL):
+            return -1   # EEXIST
+
+        shmid = ql.os.shm[key]
+
+        # check whether the user has permissions to access this shm
+        # FIXME: should probably use ql.os.cuid instead, but we don't support it yet
+        if (ql.os.uid == shmid.uid) and (shmid.mode & (SHM_W | SHM_R)):
+            return key
+
+        else:
+            return -1   # EACCES
+
+    # a shm with the specified key does not exist
+    else:
+        if shmflg & IPC_CREAT:
+            key = __create_shm(size, shmflg)
+
+        else:
+            return -1   # ENOENT
+
+    return key
+
+
+def ql_syscall_shmat(ql: Qiling, shmid: int, shmaddr: int, shmflg: int):
+    if shmid not in ql.os.shm:
+        return -1   # EINVAL
+
+    if shmaddr == 0:
+        # system may choose any suitable page-aligned address, so just use the key
+        addr = shmid
+
+    elif shmflg & SHM_RND:
+        # note: should align to SHMLBA, but usually its value is just a page
+        addr = ql.mem.align(shmaddr)
+
+    else:
+        if shmaddr & (ql.mem.pagesize - 1):
+            return -1   # EINVAL
+
+        addr = shmaddr
+
+    return addr
+
+
+__all__ = [
+    'ql_syscall_shmget',
+    'ql_syscall_shmat'
+]

--- a/qiling/os/posix/syscall/syscall.py
+++ b/qiling/os/posix/syscall/syscall.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+#
+# Cross Platform and Multi Architecture Advanced Binary Emulation Framework
+#
+
+from qiling import Qiling
+from qiling.os.posix.const import *
+
+from .shm import *
+
+
+def ql_syscall_ipc(ql: Qiling, call: int, first: int, second: int, third: int, ptr: int, fifth: int):
+    version = call >> 16  # hi word
+    call &= 0xffff        # lo word
+
+    # FIXME: this is an incomplete implementation.
+    # see: https://elixir.bootlin.com/linux/v5.19.17/source/ipc/syscall.c
+
+    def __call_shmat(*args: int) -> int:
+        if version == 1:
+            return -1   # EINVAL
+
+        return ql_syscall_shmget(ql, args[0], args[3], args[1])
+
+    def __call_shmget(*args: int) -> int:
+        return ql_syscall_shmget(ql, args[0], args[1], args[2])
+
+    ipc_call = {
+        SHMAT:  __call_shmat,
+        SHMGET: __call_shmget
+    }
+
+    if call not in ipc_call:
+        return -1   # ENOSYS
+
+    return ipc_call[call](first, second, third, ptr, fifth)
+
+
+__all__ = [
+    'ql_syscall_ipc'
+]

--- a/qiling/os/qnx/qnx.py
+++ b/qiling/os/qnx/qnx.py
@@ -45,7 +45,6 @@ class QlOsQnx(QlOsPosix):
         self.futexm = None
         self.fh = None
         self.function_after_load_list = []
-        self.elf_mem_start = 0x0
         self.load()
         
         # use counters to get free Ids

--- a/qiling/os/qnx/qnx.py
+++ b/qiling/os/qnx/qnx.py
@@ -3,8 +3,6 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
-import os
-
 from unicorn import UcError
 
 from qiling import Qiling
@@ -93,15 +91,17 @@ class QlOsQnx(QlOsPosix):
         if self.ql.entry_point is not None:
             self.ql.loader.elf_entry = self.ql.entry_point
 
-        self.cpupage_addr        = int(self.ql.os.profile.get("OS32", "cpupage_address"), 16)
-        self.cpupage_tls_addr    = int(self.ql.os.profile.get("OS32", "cpupage_tls_address"), 16)
-        self.tls_data_addr       = int(self.ql.os.profile.get("OS32", "tls_data_address"), 16)
-        self.syspage_addr        = int(self.ql.os.profile.get("OS32", "syspage_address"), 16)
-        syspage_path             = os.path.join(self.ql.rootfs, "syspage.bin")
+        profile = self.ql.os.profile['OS32']
+
+        self.cpupage_addr     = profile.getint('cpupage_address')
+        self.cpupage_tls_addr = profile.getint('cpupage_tls_address')
+        self.tls_data_addr    = profile.getint('tls_data_address')
+        self.syspage_addr     = profile.getint('syspage_address')
 
         self.ql.mem.map(self.syspage_addr, 0x4000, info="[syspage_mem]")
-        
-        with open(syspage_path, "rb") as sp:
+        syspage_hpath = self.ql.os.path.virtual_to_host_path("/syspage.bin")
+
+        with open(syspage_hpath, "rb") as sp:
             self.ql.mem.write(self.syspage_addr, sp.read())
 
         # Address of struct _thread_local_storage for our thread

--- a/qiling/os/qnx/qnx.py
+++ b/qiling/os/qnx/qnx.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
@@ -19,6 +19,7 @@ from qiling.const import QL_ARCH, QL_OS
 from qiling.os.fcall import QlFunctionCall
 from qiling.os.const import *
 from qiling.os.posix.posix import QlOsPosix
+
 
 class QlOsQnx(QlOsPosix):
     type = QL_OS.QNX
@@ -46,7 +47,7 @@ class QlOsQnx(QlOsPosix):
         self.fh = None
         self.function_after_load_list = []
         self.load()
-        
+
         # use counters to get free Ids
         self.channel_id = 1
         # TODO: replace 0x400 with NR_OPEN from Qiling 1.25
@@ -74,26 +75,22 @@ class QlOsQnx(QlOsPosix):
                 'get_tls': 0xffff0fe0
             })
 
-
     def hook_syscall(self, ql, intno):
         return self.load_syscall()
-
 
     def register_function_after_load(self, function):
         if function not in self.function_after_load_list:
             self.function_after_load_list.append(function)
 
-
     def run_function_after_load(self):
         for f in self.function_after_load_list:
             f()
-
 
     def run(self):
         if self.ql.exit_point is not None:
             self.exit_point = self.ql.exit_point
 
-        if  self.ql.entry_point is not None:
+        if self.ql.entry_point is not None:
             self.ql.loader.elf_entry = self.ql.entry_point
 
         self.cpupage_addr        = int(self.ql.os.profile.get("OS32", "cpupage_address"), 16)

--- a/qiling/os/windows/dlls/kernel32/fileapi.py
+++ b/qiling/os/windows/dlls/kernel32/fileapi.py
@@ -52,21 +52,13 @@ def hook_FindFirstFileA(ql: Qiling, address: int, params):
     if len(filename) >= MAX_PATH:
         return ERROR_INVALID_PARAMETER
 
-    host_path = ql.os.path.virtual_to_host_path(filename)
-
-    # Verify the directory is in ql.rootfs to ensure no path traversal has taken place
-    if not ql.os.path.is_safe_host_path(host_path):
-        ql.os.last_error = ERROR_FILE_NOT_FOUND
-
-        return INVALID_HANDLE_VALUE
-
     # Check if path exists
     filesize = 0
 
     try:
-        f = ql.os.fs_mapper.open(host_path, "r")
+        f = ql.os.fs_mapper.open(filename, "r")
 
-        filesize = os.path.getsize(host_path)
+        filesize = os.path.getsize(f.name)
     except FileNotFoundError:
         ql.os.last_error = ERROR_FILE_NOT_FOUND
 


### PR DESCRIPTION
Yet another maintenance PR including bug fixes and various improvements around security and robustness.

Highlights:
 - Revamped the `fs_mapper` module (_might break a few old DOS examples_)
 - Eliminated potential path traversal risks where emulated program could access arbitrary resources on the host file system
   - Patched POSIX `fcntl`
   - Patched POSIX `unistd`
   - Partially patched POSIX `stat`
 - Re-implemented POSIX `shm` syscalls
 - Added an initial implementation for POSIX `ipc` syscall
 - As always, opportunistic PEP8-friendly tweaks to keep it clean an tidy