### PR TITLE
Add QlOs init for QlOsMcu.

### DIFF
--- a/qiling/os/mcu/mcu.py
+++ b/qiling/os/mcu/mcu.py
@@ -38,6 +38,7 @@ class QlOsMcu(QlOs):
     type = QL_OS.MCU
 
     def __init__(self, ql: 'Qiling'):
+        super(QlOsMcu, self).__init__(ql)
         self.ql = ql
         self.runable = True
         self.fast_mode = False


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

When I need to hijack some api in mcu by `ql.os.set_api`, I found that can't be done because class `QlOsMcu`  hasn't initialize its super class `QlOs` in `__init__`. That's the reason why I made this change. 