### PR TITLE
Fix wchar array encoding in structs

### DIFF
--- a/qiling/os/struct.py
+++ b/qiling/os/struct.py
@@ -123,7 +123,14 @@ class BaseStruct(ctypes.Structure):
 
                     # transform value into field bytes and write them to memory
                     fvalue = ftype(*value) if hasattr(ftype, '_length_') else ftype(value)
-                    data = bytes(fvalue)
+                    
+                    # Decode wchar strings seperately to prevent double encoding
+                    if (hasattr(ftype, '_type_') and ftype._type_ == ctypes.c_wchar):
+                        data = b''
+                        for i in ftype(*value) if hasattr(ftype, '_length_') else ftype(value):
+                            data += bytes(i, 'utf-16')
+                    else:
+                        data = bytes(fvalue)
 
                     mem.write(address + field.offset, data)
 


### PR DESCRIPTION
## Checklist

### Which kind of PR do you create?

- [ x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [ x] The new code conforms to Qiling Framework naming convention.
- [ x] The imports are arranged properly.
- [ x] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ?] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ?] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [ x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x ] The target branch is dev branch.

### One last thing

- [x ] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
Structs that use the ctypes.c_wchar_array type were being double encoded, causing the bytes to be padded with '\x00\x00\x00' instead of just '\x00'. I added a few lines to struct.py that fix this.
Example code that shows the problem by reading KUSER_SHARED_DATA->NtSystemRoot:
```
from qiling import *

ql = Qiling(["x86_windows/bin/x86_hello.exe"], "x86_windows")
ql.log.info(f"NtSystemRoot bytes: {ql.mem.read(0x7ffe0030, 0x20).hex()}")
ql.log.info(f"NtSystemRoot wstring: {ql.os.utils.read_wstring(0x7ffe0030)}")
```