### PR TITLE
Added qltui in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     keywords='qiling binary emulator framework malware analysis UEFI IoT',
 
     packages=find_packages(),
-    scripts=['qltool'],
+    scripts=['qltool', 'qltui.py'],
     package_data={
         'qiling': ['profiles/*.ql'],
         'qiling.debugger.gdb': ['xml/*/*'],


### PR DESCRIPTION
When using `pip install qiling`, the `qltui.py` is not copied to the site-packages folder.

Running `qltool qltui` would get a `No module found` error.

```
(test) ➜  qiling git:(master) qltool qltui
Traceback (most recent call last):
  File "/Users/river/.virtualenvs/test/bin/qltool", line 232, in <module>
    import qltui
ModuleNotFoundError: No module named 'qltui'
```

Added `qltui.py` in setup.py.

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [ ] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
