### PR TITLE
Improved handling of export table for invalid export address and removed GandCrab workaround in GetProcAddress

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -553,6 +553,9 @@ class Process:
 
         # Do a full load if IMAGE_DIRECTORY_ENTRY_EXPORT is present so we can load the exports
         pe.full_load()
+        
+        # check whether loading of export table succeeded
+        if not hasattr(pe, 'DIRECTORY_ENTRY_EXPORT'): return
 
         iat = {}
 

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -554,8 +554,9 @@ class Process:
         # Do a full load if IMAGE_DIRECTORY_ENTRY_EXPORT is present so we can load the exports
         pe.full_load()
         
-        # check whether loading of export table succeeded
-        if not hasattr(pe, 'DIRECTORY_ENTRY_EXPORT'): return
+        # address corner case for malformed export tables where IMAGE_DIRECTORY_ENTRY_EXPORT exists, but DIRECTORY_ENTRY_EXPORT does not
+        if not hasattr(pe, 'DIRECTORY_ENTRY_EXPORT'): 
+            return
 
         iat = {}
 

--- a/qiling/os/windows/dlls/kernel32/libloaderapi.py
+++ b/qiling/os/windows/dlls/kernel32/libloaderapi.py
@@ -144,10 +144,6 @@ def hook_GetProcAddress(ql: Qiling, address: int, params):
         # let log output reflect a human-readable procname
         params["lpProcName"] = procname
 
-        # WORKAROUND for gandcrab
-        if procname == "RtlComputeCrc32":
-            return 0
-
         procname = procname.encode('latin1')
 
     else:


### PR DESCRIPTION
Binaries with an invalid export address table cause Qiling to crash when attempting to load exports. This fix ensures that pefile has loaded the export table before attempting to parse the exports.

Additionally, the hook for GetProcAddress contains a workaround for GandCrab that returns 0 when looking for RtlComputeCrc32. This causes other emulated binaries using the RtlComputeCrc32 API to fail, which makes me think this workaround was included unintentionally.

## Checklist

### Which kind of PR do you create?

- [X] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [X] The imports are arranged properly.
- [X] Essential comments are added.
- [X] The reference of the new code is pointed out.

### Extra tests?

- [X] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [X] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
