### PR TITLE
feat(os): add posix message queue syscalls

### DIFF
--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -1025,6 +1025,15 @@ SHMMNI = 4096   # max num of segs system wide
 HUGETLB_FLAG_ENCODE_SHIFT = 26
 HUGETLB_FLAG_ENCODE_MASK  = 0x3f
 
+# see: https://elixir.bootlin.com/linux/v5.19.17/source/include/uapi/linux/msg.h
+MSG_NOERROR = 0o10000  # no error if message is too big
+MSG_EXCEPT = 0o20000  # recv any msg except of specified type
+MSG_COPY = 0o40000  # copy (not remove) all queue messages
+
+MSGMNI = 32000 # <= IPCMNI, max # of msg queue identifiers
+MSGMAX = 8192 # <= INT_MAX, max size of message (bytes)
+MSGMNB = 16384 # <= INT_MAX, default max size of a message queue
+
 # ipc syscall
 SEMOP       = 1
 SEMGET      = 2

--- a/qiling/os/posix/syscall/__init__.py
+++ b/qiling/os/posix/syscall/__init__.py
@@ -6,6 +6,7 @@ from .fcntl import *
 from .futex import *
 from .ioctl import *
 from .mman import *
+from .msg import *
 from .net import *
 from .personality import *
 from .poll import *

--- a/qiling/os/posix/syscall/msg.py
+++ b/qiling/os/posix/syscall/msg.py
@@ -24,7 +24,7 @@ def __find_msg(msq: QlMsqId, msgtyp: int, msgflg: int) -> Optional[QlMsgBuf]:
     elif msgtype < 0:
         predicate = lambda msg: msg.mtype <= -msgtyp
 
-     return next((msg for msg in msq.queue if predicate(msg)), None)
+    return next((msg for msg in msq.queue if predicate(msg)), None)
 
 
 def __perms(ql: Qiling, msq: QlMsqId, flag: int) -> int:

--- a/qiling/os/posix/syscall/msg.py
+++ b/qiling/os/posix/syscall/msg.py
@@ -1,0 +1,145 @@
+from typing import Optional
+from qiling import Qiling
+from qiling.os.posix.const import *
+from qiling.os.posix.posix import QlMsqId, QlMsgBuf
+
+
+def __find_msg(msq: QlMsqId, msgtyp: int, msgflg: int) -> Optional[QlMsgBuf]:
+    if msgtyp == 0:  # SEARCH_ANY: get first
+        return msq.queue[0]
+    cnt = 0
+    for msg in msq.queue:
+        # SEARCH_NUMBER, SEARCH_LESSEQUAL, SEARCH_EQUAL, SEARCH_NOTEQUAL
+        if (msgflg & MSG_COPY and cnt == msgtyp) or \
+            (msgtyp < 0 and msg.mtype <= -msgtyp) or \
+            (msgtyp > 0 and msg.mtype == msgtyp) or \
+            (msgflg & MSG_EXCEPT and msg.mtype != msgtyp):
+            return msg
+        cnt += 1
+
+
+def __perms(ql: Qiling, msq: QlMsqId, flag: int) -> int:
+    """
+    # see: https://elixir.bootlin.com/linux/v5.19.17/source/ipc/util.c#L553
+    # check whether the user has permissions to access this message queue
+    # FIXME: should probably also use cuid and (c)gid, but we don't support it yet
+    # TODO: other ipc mechanisms like shm can also reuse this
+    """
+    request_mode = (flag >> 6) | (flag >> 3) | flag
+    granted_mode = msq.mode
+    if ql.os.uid == msq.uid:
+        granted_mode >>= 6
+    # is there some bit set in requested_mode but not in granted_mode? 
+    if request_mode & ~granted_mode & 0o007:
+        return -1  # EACCES
+    return 0
+
+def ql_syscall_msgget(ql: Qiling, key: int, msgflg: int):
+    def __create_msq(key: int, flags: int) -> int:
+        """Create a new message queue for the specified key.
+
+        Returns: msqid of the newly created message queue, -1 if an error has occurred
+        """
+
+        if len(ql.os.msq) >= MSGMNI:
+            return -1  # ENOSPC
+
+        mode = flags & ((1 << 9) - 1)
+
+        msqid = ql.os.msq.add(QlMsqId(key, ql.os.uid, ql.os.gid, mode))
+
+        ql.log.debug(f'created a new msg queue: key = {key:#x}, mode = 0{mode:o}. assigned id: {msqid:#x}')
+
+        return msqid
+
+    # create new message queue
+    if key == IPC_PRIVATE:
+        msqid = __create_msq(key, msgflg)
+
+    else:
+        msqid, msq = ql.os.msq.get_by_key(key)
+
+        # a message queue with the specified key does not exist
+        if msq is None:
+            # the user asked to create a new one?
+            if msgflg & IPC_CREAT:
+                msqid = __create_msq(key, msgflg)
+
+            else:
+                return -1  # ENOENT
+
+        # a message queue with the specified key exists
+        else:
+            # the user asked to create a new one?
+            if msgflg & (IPC_CREAT | IPC_EXCL):
+                return -1  # EEXIST
+
+            if err := __perms(ql, msq, msgflg):
+                return err  # EACCES
+
+    return msqid
+
+def ql_syscall_msgsnd(ql: Qiling, msqid: int, msgp: int, msgsz: int, msgflg: int):
+    msq = ql.os.msq.get_by_id(msqid)
+
+    if msq is None:
+        return -1  # EINVAL
+
+    # Check if the user has write permissions for the message queue
+    if err := __perms(ql, msq, 0o222):  # S_IWUGO
+        return err  # EACCES
+
+    msg_type = ql.mem.read_ptr(msgp)
+    msg_text = ql.mem.read(msgp + ql.arch.pointersize, msgsz)
+
+    while True:
+        if len(msq.queue) < msq.queue.maxlen:
+            break
+        if msgflg & IPC_NOWAIT:
+            return -1  # EAGAIN
+
+    msq.queue.append(QlMsgBuf(msg_type, bytes(msg_text)))
+
+    return 0  # Success
+
+
+def ql_syscall_msgrcv(ql: Qiling, msqid: int, msgp: int, msgsz: int, msgtyp: int, msgflg: int):
+    msq = ql.os.msq.get_by_id(msqid)
+
+    if msq is None:
+        return -1  # EINVAL
+    
+    if msgflg & MSG_COPY:
+        if msgflg & MSG_EXCEPT or not (msgflg & IPC_NOWAIT):
+            return -1  # EINVAL
+
+    # Check if the user has read permissions for the message queue
+    if err := __perms(ql, msq, 0o444):  # S_IRUGO
+        return err  # EACCES
+
+    while True:
+        msg = __find_msg(msq, msgtyp, msgflg)
+        if msg is not None:
+            break
+        if msgflg & IPC_NOWAIT:
+            return -1  # ENOMSG
+    if not (msgflg & MSG_COPY):
+        msq.queue.remove(msg)
+
+    if msgsz < len(msg.mtext):
+        if not (msgflg & MSG_NOERROR):
+            return -1  # E2BIG
+        else:
+            sz = msgsz
+    else:
+        sz = len(msg.mtext)
+    ql.mem.write_ptr(msgp, msg.mtype)
+    ql.mem.write(msgp + ql.arch.pointersize, msg.mtext[:sz])
+
+    return sz  # Success
+
+__all__ = [
+    'ql_syscall_msgget',
+    'ql_syscall_msgsnd',
+    'ql_syscall_msgrcv'
+]

--- a/qiling/os/posix/syscall/syscall.py
+++ b/qiling/os/posix/syscall/syscall.py
@@ -7,6 +7,7 @@ from qiling import Qiling
 from qiling.os.posix.const import *
 
 from .shm import *
+from .msg import *
 
 
 def ql_syscall_ipc(ql: Qiling, call: int, first: int, second: int, third: int, ptr: int, fifth: int):
@@ -27,11 +28,29 @@ def ql_syscall_ipc(ql: Qiling, call: int, first: int, second: int, third: int, p
 
     def __call_shmget(*args: int) -> int:
         return ql_syscall_shmget(ql, args[0], args[1], args[2])
+    
+    def __call_msgget(*args: int) -> int:
+        return ql_syscall_msgget(ql, args[0], args[1])
+
+    def __call_msgsnd(*args: int) -> int:
+        return ql_syscall_msgsnd(ql, args[0], args[3], args[1], args[2])
+    
+    def __call_msgrcv(*args: int) -> int:
+        if version == 0:
+            if args[3] == 0:
+                return -1   # EINVAL
+            msgp = ql.mem.read_ptr(args[3])
+            msgtyp = ql.mem.read_ptr(args[3] + ql.arch.pointersize)
+            return ql_syscall_msgrcv(ql, args[0], msgp, args[1], msgtyp, args[2])
+        return ql_syscall_msgrcv(ql, args[0], args[3], args[1], args[4], args[2])
 
     ipc_call = {
         SHMAT:  __call_shmat,
         SHMDT:  __call_shmdt,
-        SHMGET: __call_shmget
+        SHMGET: __call_shmget,
+        MSGGET: __call_msgget,
+        MSGSND: __call_msgsnd,
+        MSGRCV: __call_msgrcv
     }
 
     if call not in ipc_call:

--- a/qiling/os/posix/syscall/syscall.py
+++ b/qiling/os/posix/syscall/syscall.py
@@ -39,10 +39,15 @@ def ql_syscall_ipc(ql: Qiling, call: int, first: int, second: int, third: int, p
         if version == 0:
             if args[3] == 0:
                 return -1   # EINVAL
+
             msgp = ql.mem.read_ptr(args[3])
             msgtyp = ql.mem.read_ptr(args[3] + ql.arch.pointersize)
-            return ql_syscall_msgrcv(ql, args[0], msgp, args[1], msgtyp, args[2])
-        return ql_syscall_msgrcv(ql, args[0], args[3], args[1], args[4], args[2])
+
+        else:
+            msgp = args[3]
+            msgtyp = args[4]
+
+        return ql_syscall_msgrcv(ql, args[0], msgp, args[1], msgtyp, args[2])
 
     ipc_call = {
         SHMAT:  __call_shmat,


### PR DESCRIPTION
To solve #1346, I implement `msgget`, `msgsnd`, `msgrcv` syscalls to fulfill the IPC syscall. To support message queue for `QlOsPosix`, I add `QlMsq`, a component similar to existing `QlShm`.

If we want to support **semaphore** in the future, the code can be refactored to share code for different IPC objects, just as https://elixir.bootlin.com/linux/v5.19.17/source/ipc/util.c did.

Re-implementing syscalls is error-prone, and it is impossible to be exactly same as the original implementation. Simple examples or unit tests can be added to ensure the basic functionality.

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [ ] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [x] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [x] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
