### PR TITLE
Fix  bug: qdb  load address error

### DIFF
--- a/qiling/debugger/qdb/qdb.py
+++ b/qiling/debugger/qdb/qdb.py
@@ -81,7 +81,10 @@ class QlQdb(cmd.Cmd, QlDebugger):
         elif init_hook and self.ql.loader.entry_point != init_hook:
             self.do_breakpoint(init_hook)
 
-        self.cur_addr = self.ql.loader.entry_point
+        if self.ql.entry_point:
+            self.cur_addr = self.ql.entry_point
+        else:
+            self.cur_addr = self.ql.loader.entry_point
 
         self.init_state = self.ql.save()
 


### PR DESCRIPTION
Fix  bug:  Using ql.run(begin=myaddr) but qdb executes from the entry point of the binary.
## Example
When use
```
ql.debugger = "qdb:0x140086efa"
ql.run(begin=0x140086efa)
```
![image](https://github.com/qilingframework/qiling/assets/86669384/da322b26-7124-4fe0-949d-026ff32075e2)

But it should be
![image](https://github.com/qilingframework/qiling/assets/86669384/1d83edf6-3ca1-4081-b8b5-3335a1ea5f7b)

## Reason
The "begin" parameter is stored in ql.entry_point, but qdb loads only ql.loader.entry_point, and ql.loader.entry_point points to the entry point of the binary

## Checklist
### Which kind of PR do you create?
- [x] This PR only contains minor fixes.

### Coding convention?
- [x] The new code conforms to Qiling Framework naming convention.

### Extra tests?
- [x] No extra tests are needed for this PR.
### Target branch?
- [x] The target branch is dev branch.
-----
