### PR TITLE
fix command show_args crashed if argument is 5

### DIFF
--- a/qiling/debugger/qdb/qdb.py
+++ b/qiling/debugger/qdb/qdb.py
@@ -463,7 +463,7 @@ class QlQdb(cmd.Cmd, QlDebugger):
             reg_n, stk_n = 2, 0
         else:
             if argc > 4:
-                stk_n = argc - 4
+                reg_n, stk_n = 4, argc - 4
             elif argc <= 4:
                 reg_n, stk_n = argc, 0
 


### PR DESCRIPTION
bug fix:  command show_args crashed if argument is 5