### PR TITLE
Fix r2 disassembler invalid instruction and add test

### DIFF
--- a/qiling/extensions/r2/r2.py
+++ b/qiling/extensions/r2/r2.py
@@ -279,7 +279,7 @@ class R2:
         anibbles = ql.arch.bits // 4
         progress = 0
         for inst in self.dis_nbytes(addr, size):
-            if inst.type.lower() == 'invalid':
+            if inst.type.lower() in ('invalid', 'ill'):
                 break  # stop disasm
             name, offset = self.at(inst.offset, parse=True)
             if filt is None or filt.search(name):

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import unittest
+from io import StringIO
 
 import sys
 sys.path.append("..")
 
 from qiling import Qiling
-from qiling.const import QL_ARCH, QL_VERBOSE
+from qiling.const import QL_ARCH, QL_INTERCEPT, QL_OS, QL_VERBOSE
+from tests.test_shellcode import ARM64_LIN, graceful_execve
 
 try:
     from qiling.extensions.r2.r2 import R2
@@ -59,6 +61,20 @@ class R2Test(unittest.TestCase):
         print(r2.where('main'))
         self.assertEqual(r2.at(r2.where('main')), 'main')
 
+    def test_disasm_monkeypatch(self):
+        # QlArchUtils.setup_output(QL_VERBOSE.DISASM) implicitly uses r2.disassembler if available
+        # see https://github.com/qilingframework/qiling/issues/1396
+        ql = Qiling(code=ARM64_LIN, archtype=QL_ARCH.ARM64, ostype=QL_OS.LINUX, verbose=QL_VERBOSE.DISASM)
+        ql.os.set_syscall('execve', graceful_execve, QL_INTERCEPT.EXIT)
+
+        # store ql log output in a string
+        ql_log = StringIO()
+        ql.log.handlers[0].setStream(ql_log)
+        ql.run()
+
+        ql_log_str = ql_log.getvalue()
+        self.assertFalse('invalid' in ql_log_str)
+        self.assertTrue('adr                  x1, #0x11ff058' in ql_log_str)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [x] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

- cherry pick from https://github.com/chinggg/qiling/commit/4f81f62ccf0560b87f8deb4b3eadbc667d2f021e to fix #1396
- add unit test to ensure `QL_VERBOSE.DISASM` has correct output