### PR TITLE
fix errno bug

### DIFF
--- a/qiling/os/posix/syscall/fcntl.py
+++ b/qiling/os/posix/syscall/fcntl.py
@@ -33,8 +33,8 @@ def __do_open(ql: Qiling, absvpath: str, flags: int, mode: int) -> int:
 
     try:
         ql.os.fd[idx] = ql.os.fs_mapper.open_ql_file(absvpath, flags, mode)
-    except QlSyscallError:
-        return -1
+    except QlSyscallError as err:
+        return -err.errno
 
     return idx
 


### PR DESCRIPTION
this is actually related to #1341, after dig more deeper, I found that the musl loader will try to locate and map library according to the path described in the file `/etc/ld-musl-$ARCH-.path`, the behavior of the binary is not correct due to the `__do_open` always return -1 on syscall error, and it will fail the process mapping library during runtime.

1.  use proper errno instead of always return -1 in __do_open 