### PR TITLE
Qdb improvements

### DIFF
--- a/qiling/debugger/qdb/qdb.py
+++ b/qiling/debugger/qdb/qdb.py
@@ -9,7 +9,7 @@ from typing import Optional, Tuple, Union, List
 from contextlib import contextmanager
 
 from qiling import Qiling
-from qiling.const import QL_OS, QL_ARCH, QL_ENDIAN, QL_STATE
+from qiling.const import QL_OS, QL_ARCH, QL_ENDIAN, QL_STATE, QL_VERBOSE
 from qiling.debugger import QlDebugger
 
 from .utils import setup_context_render, setup_branch_predictor, setup_address_marker, SnapshotManager, run_qdb_script
@@ -76,19 +76,45 @@ class QlQdb(cmd.Cmd, QlDebugger):
 
         self.ql.hook_code(bp_handler, self.bp_list)
 
-        if self.ql.os.type == QL_OS.BLOB:
-            self.ql.loader.entry_point = self.ql.loader.load_address
-
-        elif init_hook:
-            for each_hook in init_hook:
-                self.do_breakpoint(each_hook)
-
         if self.ql.entry_point:
             self.cur_addr = self.ql.entry_point
         else:
             self.cur_addr = self.ql.loader.entry_point
 
         self.init_state = self.ql.save()
+
+        # stop emulator once interp. have been done emulating
+        if addr_elf_entry := getattr(self.ql.loader, 'elf_entry'):
+            handler = self.ql.hook_address(lambda ql: ql.stop(), addr_elf_entry)
+        else:
+            handler = self.ql.hook_address(lambda ql: ql.stop(), self.ql.loader.entry_point)
+
+        # suppress logging temporary
+        _verbose = self.ql.verbose
+        self.ql.verbose = QL_VERBOSE.DISABLED
+
+        # init os for integrity of hooks and patches,
+        self.ql.os.run()
+
+        handler.remove()
+
+        # ignore the memory unmap error for now, due to the MIPS memory layout issue
+        try:
+            self.ql.mem.unmap_all()
+        except:
+            pass
+
+        self.ql.restore(self.init_state)
+
+        # resotre logging verbose
+        self.ql.verbose = _verbose
+
+        if self.ql.os.type is QL_OS.BLOB:
+            self.ql.loader.entry_point = self.ql.loader.load_address
+
+        elif init_hook:
+            for each_hook in init_hook:
+                self.do_breakpoint(each_hook)
 
         if self._script:
             run_qdb_script(self, self._script)
@@ -123,14 +149,7 @@ class QlQdb(cmd.Cmd, QlDebugger):
         if getattr(self.ql.arch, 'is_thumb', False):
             address |= 0b1
 
-        # assume we're running PE if on Windows
-        if self.ql.os.type == QL_OS.WINDOWS:
-            self.ql.count = count
-            self.ql.entry_point = address
-            self.ql.os.run()
-
-        else:
-            self.ql.emu_start(begin=address, end=end, count=count)
+        self.ql.emu_start(begin=address, end=end, count=count)
 
     @contextmanager
     def _save(self, reg=True, mem=True, hw=False, fd=False, cpu_context=False, os=False, loader=False):
@@ -374,7 +393,6 @@ class QlQdb(cmd.Cmd, QlDebugger):
         """
 
         if self.ql.arch != QL_ARCH.CORTEX_M:
-
             self.ql.restore(self.init_state)
             self.do_context()
 
@@ -534,6 +552,11 @@ class QlQdb(cmd.Cmd, QlDebugger):
         """
         show some runtime information
         """
+
+        qdb_print(QDB_MSG.INFO, f"Entry point: {self.ql.loader.entry_point:#x}")
+
+        if addr_elf_entry := getattr(self.ql.loader, 'elf_entry'):
+            qdb_print(QDB_MSG.INFO, f"ELF entry: {addr_elf_entry:#x}")
 
         for info_line in self.ql.mem.get_formatted_mapinfo():
             qdb_print(QDB_MSG.INFO, info_line)

--- a/qiling/debugger/qdb/qdb.py
+++ b/qiling/debugger/qdb/qdb.py
@@ -130,13 +130,7 @@ class QlQdb(cmd.Cmd, QlDebugger):
             self.ql.os.run()
 
         else:
-
-            # use os.run instead if QL_STATE is NOT_SET, for keeping integrity of hooks and patches in Qdb
-            if self.ql._state is QL_STATE.NOT_SET:
-                self.ql.os.run()
-
-            else:
-                self.ql.emu_start(begin=address, end=end, count=count)
+            self.ql.emu_start(begin=address, end=end, count=count)
 
     @contextmanager
     def _save(self, reg=True, mem=True, hw=False, fd=False, cpu_context=False, os=False, loader=False):

--- a/qiling/debugger/qdb/qdb.py
+++ b/qiling/debugger/qdb/qdb.py
@@ -548,11 +548,12 @@ class QlQdb(cmd.Cmd, QlDebugger):
         args = reg_args + stk_args
         qdb_print(QDB_MSG.INFO, f'args: {args}')
 
-    def do_show(self, *args) -> None:
+    def do_show(self, keyword: Optional[str] = None, *args) -> None:
         """
         show some runtime information
         """
 
+<<<<<<< Updated upstream
         qdb_print(QDB_MSG.INFO, f"Entry point: {self.ql.loader.entry_point:#x}")
 
         if addr_elf_entry := getattr(self.ql.loader, 'elf_entry'):
@@ -560,6 +561,21 @@ class QlQdb(cmd.Cmd, QlDebugger):
 
         for info_line in self.ql.mem.get_formatted_mapinfo():
             qdb_print(QDB_MSG.INFO, info_line)
+=======
+        info_lines = iter(self.ql.mem.get_formatted_mapinfo())
+
+        # print filed name first
+        qdb_print(QDB_MSG.INFO, next(info_lines))
+
+        # keyword filtering
+        if keyword:
+            lines = filter(lambda line: keyword in line, info_lines)
+        else:
+            lines = info_lines
+
+        for line in lines:
+            qdb_print(QDB_MSG.INFO, line)
+>>>>>>> Stashed changes
 
         qdb_print(QDB_MSG.INFO, f"Breakpoints: {[hex(addr) for addr in self.bp_list.keys()]}")
         qdb_print(QDB_MSG.INFO, f"Marked symbol: {[{key:hex(val)} for key,val in self.marker.mark_list]}")

--- a/qiling/debugger/qdb/qdb.py
+++ b/qiling/debugger/qdb/qdb.py
@@ -553,15 +553,11 @@ class QlQdb(cmd.Cmd, QlDebugger):
         show some runtime information
         """
 
-<<<<<<< Updated upstream
         qdb_print(QDB_MSG.INFO, f"Entry point: {self.ql.loader.entry_point:#x}")
 
         if addr_elf_entry := getattr(self.ql.loader, 'elf_entry'):
             qdb_print(QDB_MSG.INFO, f"ELF entry: {addr_elf_entry:#x}")
 
-        for info_line in self.ql.mem.get_formatted_mapinfo():
-            qdb_print(QDB_MSG.INFO, info_line)
-=======
         info_lines = iter(self.ql.mem.get_formatted_mapinfo())
 
         # print filed name first
@@ -575,7 +571,6 @@ class QlQdb(cmd.Cmd, QlDebugger):
 
         for line in lines:
             qdb_print(QDB_MSG.INFO, line)
->>>>>>> Stashed changes
 
         qdb_print(QDB_MSG.INFO, f"Breakpoints: {[hex(addr) for addr in self.bp_list.keys()]}")
         qdb_print(QDB_MSG.INFO, f"Marked symbol: {[{key:hex(val)} for key,val in self.marker.mark_list]}")

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -350,15 +350,18 @@ def select_debugger(options: Union[str, bool]) -> Optional[QlClassInit['QlDebugg
                     return None
 
             # qdb init args are independent and may include any combination of: rr enable, init hook and script
-            for a in args:
-                if a == 'rr':
+            arg_init_hook = []
+            for arg in args:
+                if arg == 'rr':
                     kwargs['rr'] = True
 
-                elif __int_nothrow(a) is not None:
-                    kwargs['init_hook'] = a
+                elif __int_nothrow(arg) is not None:
+                     arg_init_hook.append(arg)
 
                 else:
-                    kwargs['script'] = a
+                    kwargs['script'] = arg
+            else:
+                kwargs['init_hook'] = arg_init_hook
 
         else:
             raise QlErrorOutput('Debugger not supported')


### PR DESCRIPTION
1. allow multi-breakpoints
we can now use some thing like `ql.debugger = "qdb:0xAAAA:0xBBBB:0xCCCC"` for setting up multiple breakpoints 

2. integrity of hooks and patches
with this commit, all hooks from ql.os should be able to triggered as expected

3. add simple filter for output of command show , also show both entry points of elf and ld if possible

![image](https://github.com/qilingframework/qiling/assets/10076774/7568775f-d49f-4455-96b0-3c84c7e16e1f)
