### PR TITLE
Fixed DOS Disk Mapping

### DIFF
--- a/examples/doogie_8086_crack.py
+++ b/examples/doogie_8086_crack.py
@@ -137,7 +137,7 @@ def show_once(ql: Qiling, key):
 def third_stage(keys):
     # To setup terminal again, we have to restart the whole program.
     ql = Qiling(["rootfs/8086/doogie/doogie.DOS_MBR"], "rootfs/8086", console=False)
-    ql.add_fs_mapper(0x80, QlDisk("rootfs/8086/doogie/doogie.DOS_MBR", 0x80))
+    ql.add_fs_mapper("C:", QlDisk("rootfs/8086/doogie/doogie.DOS_MBR", "C:"))
     ql.os.set_api((0x1a, 4), set_required_datetime, QL_INTERCEPT.EXIT)
     hk = ql.hook_code(stop, begin=0x8018, end=0x8018)
     ql.run()
@@ -191,7 +191,7 @@ def stop(ql, addr, data):
 # In this stage, we get the encrypted data which xored with the specific date.
 def first_stage():
     ql = Qiling(["rootfs/8086/doogie/doogie.DOS_MBR"], "rootfs/8086", console=False)
-    ql.add_fs_mapper(0x80, QlDisk("rootfs/8086/doogie/doogie.DOS_MBR", 0x80))
+    ql.add_fs_mapper("C:", QlDisk("rootfs/8086/doogie/doogie.DOS_MBR", "C:"))
     # Doogie suggests that the datetime should be 1990-02-06.
     ql.os.set_api((0x1a, 4), set_required_datetime, QL_INTERCEPT.EXIT)
     # A workaround to stop the program.

--- a/examples/petya_8086_crack.py
+++ b/examples/petya_8086_crack.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
@@ -39,18 +39,18 @@ def third_stage(key):
     def pass_red(ql, addr, data):
         curses.ungetch(ord("\n"))
         curses.ungetch(ord("\r"))
-    
+
     def input_key(ql, addr, data):
         for i in key[::-1]:
             curses.ungetch(i)
         curses.ungetch(ord("\n"))
         curses.ungetch(ord("\r"))
 
-    ql = Qiling(["rootfs/8086/petya/petya.DOS_MBR"], 
+    ql = Qiling(["rootfs/8086/petya/petya.DOS_MBR"],
                  "rootfs/8086",
-                 console=False, 
+                 console=False,
                  verbose=QL_VERBOSE.DEBUG)
-    ql.add_fs_mapper(0x80, QlDisk("rootfs/8086/petya/out_1M.raw", 0x80))
+    ql.add_fs_mapper("C:", QlDisk("rootfs/8086/petya/out_1M.raw", "C:"))
     ql.hook_code(pass_red, begin=0x886d, end=0x886d)
     ql.hook_code(input_key, begin=0x85f0, end=0x85f0)
     ql.hook_code(stop, begin=0x6806, end=0x6806)
@@ -58,7 +58,7 @@ def third_stage(key):
 
 # In this stage, we will crack for the password.
 def second_stage(ql: Qiling):
-    disk = QlDisk("rootfs/8086/petya/out_1M.raw", 0x80)
+    disk = QlDisk("rootfs/8086/petya/out_1M.raw", "C:")
     #nonce = get_nonce(disk)
     verfication_data = disk.read_sectors(0x37, 1)
     nonce_data = disk.read_sectors(0x36, 1)
@@ -89,18 +89,18 @@ def second_stage(ql: Qiling):
 
 # In this stage, we have to wait for petya being load to the right place.
 def first_stage():
-    ql = Qiling(["rootfs/8086/petya/petya.DOS_MBR"], 
+    ql = Qiling(["rootfs/8086/petya/petya.DOS_MBR"],
                  "rootfs/8086",
-                 console=False, 
+                 console=False,
                  verbose=QL_VERBOSE.DEBUG)
-    ql.add_fs_mapper(0x80, QlDisk("rootfs/8086/petya/out_1M.raw", 0x80))
+    ql.add_fs_mapper("C:", QlDisk("rootfs/8086/petya/out_1M.raw", "C:"))
     # Workaround for `until` in uc_emu_start not working with dynamic loaded code.
     ql.hook_code(stop, begin=petya_2nd_stage_start, end=petya_2nd_stage_start)
     ql.run()
     return ql
 
 if __name__ == "__main__":
-    
+
     ql = first_stage()
     key = second_stage(ql)
     third_stage(key)

--- a/qiling/loader/dos.py
+++ b/qiling/loader/dos.py
@@ -90,8 +90,8 @@ class QlLoaderDOS(QlLoader):
             base_address = (cs << 4) + ip
 
             # https://en.wikipedia.org/wiki/Master_boot_record#BIOS_to_MBR_interface
-            if not self.ql.os.fs_mapper.has_mapping(0x80):
-                self.ql.os.fs_mapper.add_mapping(0x80, QlDisk(path, 0x80))
+            if not self.ql.os.fs_mapper.has_mapping("C:"):
+                self.ql.os.fs_mapper.add_mapping("C:", QlDisk(path, 0x80))
 
             # 0x80 -> first drive
             self.ql.arch.regs.dx = 0x80


### PR DESCRIPTION
This fixes the DOS Mappings and makes 8086 examples work again.

This is probably not the best way to fix them, but at least it works fine with current FS Mapper. Basically what it does is map 0x80 to C and beyond and 0x00 to A and beyond.

There is few limitations though: INT 13H actually allows up to 126 disks, this only supports disks from C to Z. INT13 also supports floppies in CDEF... letters, this PR only supports A and B as floppy letters.

Although this is not ideal, I don't think I ever saw something actually uses more than two floppies and few disks. At least this make qiling able to simulate DOS.

## Checklist

### Which kind of PR do you create?

- [X] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [X] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [X] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
