### PR TITLE
support FILE_GENERIC_* access modes

### DIFF
--- a/qiling/os/windows/const.py
+++ b/qiling/os/windows/const.py
@@ -473,6 +473,24 @@ CRYPT_STRING_BINARY = 2
 CRYPT_STRING_BASE64REQUESTHEADER = 3
 # ...
 
+# File Access Rights Constants
+# https://learn.microsoft.com/en-us/windows/win32/fileio/file-access-rights-constants
+FILE_ADD_FILE = 0x0002
+FILE_ADD_SUBDIRECTORY = 0x0004
+FILE_APPEND_DATA = 0x0004
+FILE_CREATE_PIPE_INSTANCE = 0x0004
+FILE_DELETE_CHILD = 0x0040
+FILE_EXECUTE = 0x0020
+FILE_LIST_DIRECTORY = 0x0001
+FILE_READ_ATTRIBUTES = 0x0080
+FILE_READ_DATA = 0x0001
+FILE_READ_EA = 0x0008
+FILE_TRAVERSE = 0x0020
+FILE_WRITE_ATTRIBUTES = 0x0100
+FILE_WRITE_DATA = 0x0002
+FILE_WRITE_EA = 0x0010
+# ...
+
 # File Attribtues Constantsc
 # https://docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
 FILE_ATTRIBUTE_ARCHIVE = 0x0020

--- a/qiling/os/windows/dlls/kernel32/fileapi.py
+++ b/qiling/os/windows/dlls/kernel32/fileapi.py
@@ -226,11 +226,11 @@ def _CreateFile(ql: Qiling, address: int, params):
     # hTemplateFile = params["hTemplateFile"]
 
     # access mask DesiredAccess
-    perm_write = dwDesiredAccess & GENERIC_WRITE
-    perm_read  = dwDesiredAccess & GENERIC_READ
+    perm_write = dwDesiredAccess & (GENERIC_WRITE | FILE_WRITE_DATA)
+    perm_read  = dwDesiredAccess & (GENERIC_READ | FILE_READ_DATA)
     
     # TODO: unused
-    perm_exec = dwDesiredAccess & GENERIC_EXECUTE
+    perm_exec = dwDesiredAccess & (GENERIC_EXECUTE | FILE_EXECUTE)
 
     # only open file if it exists. error otherwise
     open_existing = (


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

`CreateFile` `dwDesiredAccess` is weird. Qiling supports `GENERIC_READ` and `GENERIC_WRITE`, but `CreateFile` natively uses `FILE_READ_DATA` and `FILE_WRITE_DATA` ([Generic Access Rights](https://learn.microsoft.com/en-us/windows/win32/secauthz/generic-access-rights)). This PR doesn't translate the `GENERIC_*` values to specific file [access rights](https://learn.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights) (Qiling doesn't have all of the involved constants), but it does allow Qiling to recognize the `FILE_*` rights.

Do you know about winmd files? It should be possible to dump constants and generate hook method stubs from the definitions in the winmd files. https://github.com/microsoft/win32metadata

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
