### PR TITLE
Enable more flexible logging redirection

### DIFF
--- a/qiling/core.py
+++ b/qiling/core.py
@@ -4,9 +4,11 @@
 #
 
 import os
+import sys
 import pickle
+
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, AnyStr, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, AnyStr, Collection, IO, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 # See https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports
 if TYPE_CHECKING:
@@ -43,7 +45,7 @@ class Qiling(QlCoreHooks, QlCoreStructs):
             verbose: QL_VERBOSE = QL_VERBOSE.DEFAULT,
             profile: Optional[Union[str, Mapping]] = None,
             console: bool = True,
-            log_file: Optional[str] = None,
+            log_devices: Optional[Collection[Union[IO, str]]] = None,
             log_override: Optional['Logger'] = None,
             log_plain: bool = False,
             multithread: bool = False,
@@ -161,7 +163,10 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         ##########
         # Logger #
         ##########
-        self._log_file_fd = setup_logger(self, log_file, console, log_override, log_plain)
+        if log_devices is None:
+            log_devices = [sys.stderr]
+
+        self._log_file_fd = setup_logger(self, log_devices, log_plain, log_override)
 
         self.filter = filter
         self.verbose = verbose

--- a/qltool
+++ b/qltool
@@ -267,7 +267,7 @@ def run():
         'profile':     options.profile,
         'console':     options.console,
         'filter':      options.filter,
-        'log_file':    options.log_file,
+        'log_devices': options.log_file or [options.log_file],
         'log_plain':   options.log_plain,
         'multithread': options.multithread,
         'libcache':    options.libcache

--- a/qltool
+++ b/qltool
@@ -267,7 +267,7 @@ def run():
         'profile':     options.profile,
         'console':     options.console,
         'filter':      options.filter,
-        'log_devices': options.log_file or [options.log_file],
+        'log_devices': options.log_file and [options.log_file],
         'log_plain':   options.log_plain,
         'multithread': options.multithread,
         'libcache':    options.libcache

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -218,7 +218,7 @@ class ELFTest(unittest.TestCase):
     def test_elf_linux_x86(self):
         filename = 'test.qlog'
 
-        ql = Qiling(["../examples/rootfs/x86_linux/bin/x86_hello"], "../examples/rootfs/x86_linux", verbose=QL_VERBOSE.DEBUG, log_file=filename)
+        ql = Qiling(["../examples/rootfs/x86_linux/bin/x86_hello"], "../examples/rootfs/x86_linux", verbose=QL_VERBOSE.DEBUG, log_devices=[filename])
         ql.run()
 
         os.remove(filename)


### PR DESCRIPTION
Modified logger setup to allow more flexible logging redirection and multiplexing.

## Interface changes
The current interface in which `log_file` is used to optionally specify a filename to log into:
```python
ql = Qiling(argv, rootfs, log_file=r'/tmp/myprog.log')
```
Was changed into an optional variable that accepts a `Collection` of either filenames or open streams:
```python
ql = Qiling(argv, rootfs, log_devices=[sys.stderr, r'/tmp/myprog.log'])
```

### Notes
 - While the current design creates a file logger **in addition** to the normal `sys.stderr` logger, the new implementation replaces it. That is, if a list of log devices is specified there would be be no `sys.stderr` logger by default anymore, unless it is specified (as seen in the example above)
 - The default behavior (i.e. not specifying any `log_file` / `log_devices`) is maintained: only `sys.stderr` will be created
 - Specifying an empty `Collection`, such as `log_devices=[]`, would result in no logger (same as setting `console=False`)
 - For that reason the `console` argument has no use anymore. However the `console` argument was not removed to maintain compatibility and maybe will be used in the future for other purposes

## Advantages
It is now way easier to open multiple loggers and redirect them to any file, stream or socket. This is very useful when trying to separate the emulated program output from logging output, or enable logging while fuzzing (which is currently hidden "behind" AFL box).

In the following example the logging output is redirected to another terminal pane to separate program output from logging output:
```python
ql = Qiling(argv, rootfs, log_devices=['/dev/pts/6'])
```

![image](https://github.com/qilingframework/qiling/assets/10291650/1ef637e5-fbc7-46fa-aaba-7cc88abc7004)
