### PR TITLE
fix 20 typos

### DIFF
--- a/qiling/arch/arch.py
+++ b/qiling/arch/arch.py
@@ -131,7 +131,7 @@ class QlArch(ABC):
     @property
     @abstractmethod
     def endian(self) -> QL_ENDIAN:
-        """Get processor endianess.
+        """Get processor endianness.
         """
 
         pass

--- a/qiling/arch/arm.py
+++ b/qiling/arch/arm.py
@@ -83,7 +83,7 @@ class QlArchARM(QlArch):
 
     @property
     def disassembler(self) -> Cs:
-        # note: since endianess and thumb mode might change during execution, we cannot
+        # note: since endianness and thumb mode might change during execution, we cannot
         # cache the disassembler instance directly; rather we pick the appropriate cached
         # instance
 
@@ -103,7 +103,7 @@ class QlArchARM(QlArch):
 
     @property
     def assembler(self) -> Ks:
-        # note: since endianess and thumb mode might change during execution, we cannot
+        # note: since endianness and thumb mode might change during execution, we cannot
         # cache the assembler instance directly; rather we pick the appropriate cached
         # instance
 

--- a/qiling/arch/utils.py
+++ b/qiling/arch/utils.py
@@ -100,12 +100,12 @@ class QlArchUtils:
 
 # used by qltool prior to ql instantiation. to get an assembler object
 # after ql instantiation, use the appropriate ql.arch method
-def assembler(arch: QL_ARCH, endianess: QL_ENDIAN, is_thumb: bool) -> Ks:
+def assembler(arch: QL_ARCH, endianness: QL_ENDIAN, is_thumb: bool) -> Ks:
     """Instantiate an assembler object for a specified architecture.
 
     Args:
         arch: architecture type
-        endianess: architecture endianess
+        endianness: architecture endianness
         is_thumb: thumb mode for ARM (ignored otherwise)
 
     Returns: an assembler object
@@ -114,7 +114,7 @@ def assembler(arch: QL_ARCH, endianess: QL_ENDIAN, is_thumb: bool) -> Ks:
     endian = {
         QL_ENDIAN.EL: KS_MODE_LITTLE_ENDIAN,
         QL_ENDIAN.EB: KS_MODE_BIG_ENDIAN
-    }[endianess]
+    }[endianness]
 
     thumb = KS_MODE_THUMB if is_thumb else 0
 

--- a/qiling/core.py
+++ b/qiling/core.py
@@ -146,8 +146,8 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         if ostype is None:
             raise QlErrorOsType(f'Unknown or unsupported operating system')
 
-        # if endianess is still undetermined, set it to little-endian.
-        # this setting is ignored for architectures with predefined endianess
+        # if endianness is still undetermined, set it to little-endian.
+        # this setting is ignored for architectures with predefined endianness
         if endian is None:
             endian = QL_ENDIAN.EL
 
@@ -749,7 +749,7 @@ class Qiling(QlCoreHooks, QlCoreStructs):
         # was initialized with.
         #
         # either unicorn is patched to reflect thumb mode in cpsr upon initialization, or we pursue the same logic
-        # by determining the endianess by address lsb. either way this condition should not be here
+        # by determining the endianness by address lsb. either way this condition should not be here
         if getattr(self.arch, '_init_thumb', False):
             begin |= 0b1
 

--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -159,11 +159,11 @@ class QlGdb(QlDebugger):
                 val = int(hexval, 16)
 
                 if self.ql.arch.endian == QL_ENDIAN.EL:
-                    val = __swap_endianess(val)
+                    val = __swap_endianness(val)
 
                 self.ql.arch.regs.write(reg, val)
 
-        def __swap_endianess(value: int) -> int:
+        def __swap_endianness(value: int) -> int:
             length = (value.bit_length() + 7) // 8
             raw = value.to_bytes(length, 'little')
 

--- a/qiling/os/struct.py
+++ b/qiling/os/struct.py
@@ -247,7 +247,7 @@ def get_aligned_union(archbits: int):
     """Provide an aligned union class based on the emulated architecture
     properties. This class does not inherit the special BaseStruct methods.
 
-    FIXME: ctypes.Union endianess cannot be set arbitrarily, rather it depends
+    FIXME: ctypes.Union endianness cannot be set arbitrarily, rather it depends
     on the hosting system. ctypes.LittleEndianUnion and ctypes.BigEndianUnion
     are available only starting from Python 3.11
 

--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -131,7 +131,7 @@ def __emu_env_from_elf(path: str) -> Tuple[Optional[QL_ARCH], Optional[QL_OS], O
     EM_RISCV   = 243
     EM_PPC     = 20
 
-    endianess = {
+    endianness = {
         ELFDATA2LSB: (QL_ENDIAN.EL, 'little'),
         ELFDATA2MSB: (QL_ENDIAN.EB, 'big')
     }
@@ -181,14 +181,14 @@ def __emu_env_from_elf(path: str) -> Tuple[Optional[QL_ARCH], Optional[QL_OS], O
 
     if e_ident[:4] == b'\x7fELF':
         ei_class = e_ident[4]   # arch bits
-        ei_data  = e_ident[5]   # arch endianess
+        ei_data  = e_ident[5]   # arch endianness
         ei_osabi = e_ident[7]
 
         if ei_class in classes:
             machines = classes[ei_class]
 
-            if ei_data in endianess:
-                archendian, endian = endianess[ei_data]
+            if ei_data in endianness:
+                archendian, endian = endianness[ei_data]
 
                 machine = int.from_bytes(e_machine, endian)
 
@@ -375,12 +375,12 @@ def select_debugger(options: Union[str, bool]) -> Optional[QlClassInit['QlDebugg
 def select_arch(archtype: QL_ARCH, cputype: Optional[QL_CPU], endian: QL_ENDIAN, thumb: bool) -> QlClassInit['QlArch']:
     kwargs = {'cputype': cputype}
 
-    # set endianess and thumb mode for arm-based archs
+    # set endianness and thumb mode for arm-based archs
     if archtype is QL_ARCH.ARM:
         kwargs['endian'] = endian
         kwargs['thumb'] = thumb
 
-    # set endianess for mips arch
+    # set endianness for mips arch
     elif archtype is QL_ARCH.MIPS:
         kwargs['endian'] = endian
 

--- a/qltool
+++ b/qltool
@@ -205,7 +205,7 @@ def run():
     code_parser.add_argument('-i', '--input', metavar="INPUT", dest="input", help='input hex value')
     code_parser.add_argument('--arch', required=True, choices=arch_map, action=__arg_archtype)
     code_parser.add_argument('--thumb', action='store_true', default=False, help='specify thumb mode for ARM')
-    code_parser.add_argument('--endian', choices=endian_map, default=QL_ENDIAN.EL, action=__arg_endian, help='specify endianess for bi-endian archs')
+    code_parser.add_argument('--endian', choices=endian_map, default=QL_ENDIAN.EL, action=__arg_endian, help='specify endianness for bi-endian archs')
     code_parser.add_argument('--os', required=True, choices=os_map, action=__arg_ostype)
     code_parser.add_argument('--rootfs', default='.', help='emulated root filesystem, that is where all libraries reside')
     code_parser.add_argument('--format', choices=('asm', 'hex', 'bin'), default='bin', help='input file format')


### PR DESCRIPTION
Fix typo: `endianess` to `endianness`.