### PR TITLE
add reloc type R_ARM_ABS32,R_ARM_CALL,R_ARM_JUMP24

### DIFF
--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -554,6 +554,15 @@ class QlLoaderELF(QlLoader):
 
                         ql.mem.write_ptr(prev_mips_hi16_loc + 2, (val >> 16), 2)
                         ql.mem.write_ptr(loc + 2, (val & 0xFFFF), 2)
+                    
+                    elif desc in ('R_ARM_CALL', "R_ARM_JUMP24"):
+                        val = (rev_reloc_symbols[symbol_name] - loc - 8) >> 2
+                        val = (val & 0xffffff) | (ql.mem.read_ptr(loc, 4) & 0xff000000)
+                        ql.mem.write_ptr(loc, (val & 0xFFFFFFFF), 4)
+                    
+                    elif desc == "R_ARM_ABS32":
+                        val = rev_reloc_symbols[symbol_name] + ql.mem.read_ptr(loc, 4)
+                        ql.mem.write_ptr(loc, (val & 0xFFFFFFFF), 4)
 
                     else:
                         raise NotImplementedError(f'Relocation type {desc} not implemented')


### PR DESCRIPTION
When I simulated an ARM firmware kernel, some reloc types could not be handled.
![image](https://github.com/qilingframework/qiling/assets/54018598/16ae6903-0d94-44cd-87a0-21a6591308f9)
Therefore I fixed the problem according to the manual, including R_ARM_ABS32,R_ARM_CALL, and R_ARM_JUMP24.