### PR TITLE
fix null byte truncation in __place_input_wrapper

### DIFF
--- a/qiling/extensions/afl/afl.py
+++ b/qiling/extensions/afl/afl.py
@@ -94,7 +94,7 @@ def ql_afl_fuzz_custom(ql: Qiling,
                        persistent_iters: int = 1):
 
     def __place_input_wrapper(uc: Uc, input_bytes: Array[c_char], iters: int, context: Any) -> bool:
-        return place_input_callback(ql, input_bytes.value, iters)
+        return place_input_callback(ql, bytes(input_bytes), iters)
 
     def __validate_crash_wrapper(uc: Uc, result: int, input_bytes: bytes, iters: int, context: Any) -> bool:
         return validate_crash_callback(ql, result, input_bytes, iters)

--- a/qiling/extensions/afl/afl.py
+++ b/qiling/extensions/afl/afl.py
@@ -94,7 +94,7 @@ def ql_afl_fuzz_custom(ql: Qiling,
                        persistent_iters: int = 1):
 
     def __place_input_wrapper(uc: Uc, input_bytes: Array[c_char], iters: int, context: Any) -> bool:
-        return place_input_callback(ql, bytes(input_bytes), iters)
+        return place_input_callback(ql, input_bytes.raw, iters)
 
     def __validate_crash_wrapper(uc: Uc, result: int, input_bytes: bytes, iters: int, context: Any) -> bool:
         return validate_crash_callback(ql, result, input_bytes, iters)


### PR DESCRIPTION
when using input_bytes.value, the input buffer will be truncated to the first null bytes encountered.

a initial seed such as : b"\x04\x08\x00\x66" will be b"\x04\x08"

<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [X ] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X ] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [X ] Tests will be added after some discussion and review.

### Changelog?

- [ ?] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [ X] The target branch is dev branch.

### One last thing

- [ X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
