### PR TITLE
Fixed the issue where x86_64 architecture Windows systems could not emulate running Linux programs (dev branch).

### DIFF
--- a/qiling/utils.py
+++ b/qiling/utils.py
@@ -51,6 +51,7 @@ def os_convert(os: str) -> Optional[QL_OS]:
 
 def arch_convert(arch: str) -> Optional[QL_ARCH]:
     alias_map = {
+        'amd64': 'x8664',
         'x86_64':  'x8664',
         'riscv32': 'riscv'
     }


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->
### The main issue was that the alias for amd64 (x86_64) was missing in ql.host.arch, resulting in ql.host.arch being None. This caused an early return at ql_open_flag_mapping (const_mapping.py) without executing ret |= host_flags['O_BINARY'].value, leading to a binary truncation issue. This problem only occurs on the dev branch; the code structure in the master branch is different and does not have this issue.

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [x] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
