### PR TITLE
Fix: Define flags for hosting ARM64 MACOS

### DIFF
--- a/qiling/os/posix/const.py
+++ b/qiling/os/posix/const.py
@@ -476,6 +476,22 @@ class macos_x86_open_flags(QlPrettyFlag):
     O_BINARY    = None
     O_LARGEFILE = None
 
+class macos_arm_open_flags(QlPrettyFlag):
+    O_RDONLY    = 0x000000
+    O_WRONLY    = 0x000001
+    O_RDWR      = 0x000002
+    O_NONBLOCK  = 0x000004
+    O_APPEND    = 0x000008
+    O_ASYNC     = 0x000040
+    O_SYNC      = 0x000080
+    O_NOFOLLOW  = 0x000100
+    O_CREAT     = 0x000200
+    O_TRUNC     = 0x000400
+    O_EXCL      = 0x000800
+    O_NOCTTY    = 0x020000
+    O_DIRECTORY = 0x100000
+    O_BINARY    = None
+    O_LARGEFILE = None
 
 class linux_x86_open_flags(QlPrettyFlag):
     O_RDONLY    = 0x000000

--- a/qiling/os/posix/const_mapping.py
+++ b/qiling/os/posix/const_mapping.py
@@ -57,7 +57,9 @@ def get_open_flags_class(archtype: QL_ARCH, ostype: QL_OS) -> Union[Type[Flag], 
 
         QL_OS.MACOS: {
             QL_ARCH.X86:   macos_x86_open_flags,
-            QL_ARCH.X8664: macos_x86_open_flags
+            QL_ARCH.X8664: macos_x86_open_flags,
+            QL_ARCH.ARM: macos_arm_open_flags,
+            QL_ARCH.ARM64: macos_arm_open_flags
         },
 
         QL_OS.WINDOWS: {


### PR DESCRIPTION


## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

This PR resolves the `NotImplementedError` encountered when attempting to host ARM64 macOS architectures as described in issues #1491 and #1497. The proposed fix introduces the required definitions in `const.py` and maps them in `const_mapping.py` to ensure proper functionality, in a similar way to x86 macOS.
