### PR TITLE
Add overlooked base class for #1574

### DIFF
--- a/qiling/debugger/qdb/branch_predictor/branch_predictor_arm.py
+++ b/qiling/debugger/qdb/branch_predictor/branch_predictor_arm.py
@@ -17,7 +17,7 @@ from capstone.arm_const import (
 from unicorn.arm_const import UC_ARM_REG_PC
 
 from .branch_predictor import BranchPredictor, Prophecy
-from ..arch import ArchARM
+from ..arch import ArchARM, ArchCORTEX_M
 from ..misc import InvalidInsn
 
 
@@ -261,6 +261,6 @@ class BranchPredictorARM(BranchPredictor, ArchARM):
         return Prophecy(going, where)
 
 
-class BranchPredictorCORTEX_M(BranchPredictorARM):
+class BranchPredictorCORTEX_M(BranchPredictorARM, ArchCORTEX_M):
     """Branch Predictor for ARM Cortex-M.
     """


### PR DESCRIPTION
Added missing Cortex-M base class per @antcpl [observation](https://github.com/qilingframework/qiling/issues/1573#issuecomment-2995177892)