### PR TITLE
QDB and BLOB fixes

### DIFF
--- a/examples/hello_arm_uboot.py
+++ b/examples/hello_arm_uboot.py
@@ -8,68 +8,82 @@ sys.path.append("..")
 
 from qiling.core import Qiling
 from qiling.const import QL_ARCH, QL_OS, QL_VERBOSE
-from qiling.os.const import STRING
+from qiling.os.const import STRING, SIZE_T, POINTER
 
 
-def get_kaimendaji_password():
-    def my_getenv(ql: Qiling):
-        env = {
-            "ID"      : b"000000000000000",
-            "ethaddr" : b"11:22:33:44:55:66"
-        }
+def my_getenv(ql: Qiling):
+    env = {
+        "ID"      : b"000000000000000",
+        "ethaddr" : b"11:22:33:44:55:66"
+    }
 
-        params = ql.os.resolve_fcall_params({'key': STRING})
-        value = env.get(params["key"], b"")
+    params = ql.os.resolve_fcall_params({'key': STRING})
+    value = env.get(params["key"], b"")
 
-        value_addr = ql.os.heap.alloc(len(value))
-        ql.mem.write(value_addr, value)
+    value_addr = ql.os.heap.alloc(len(value))
+    ql.mem.write(value_addr, value)
 
-        ql.arch.regs.r0 = value_addr
-        ql.arch.regs.arch_pc = ql.arch.regs.lr
+    ql.arch.regs.r0 = value_addr
+    ql.arch.regs.arch_pc = ql.arch.regs.lr
 
-    def get_password(ql: Qiling):
-        password_raw = ql.mem.read(ql.arch.regs.r0, ql.arch.regs.r2)
 
-        password = ''
-        for item in password_raw:
-            if 0 <= item <= 9:
-                password += chr(item + 48)
-            else:
-                password += chr(item + 87)
+def get_password(ql: Qiling):
+    # we land on a memcmp call, where the real password is being compared to
+    # the one provided by the user. we can follow the arguments to read the
+    # real password
 
-        print("The password is: %s" % password)
+    params = ql.os.resolve_fcall_params({
+        'ptr1': POINTER,    # points to real password
+        'ptr2': POINTER,    # points to user provided password
+        'size': SIZE_T      # comparison length
+        })
 
-    def partial_run_init(ql: Qiling):
-        # argv prepare
-        ql.arch.regs.arch_sp -= 0x30
-        arg0_ptr = ql.arch.regs.arch_sp
-        ql.mem.write(arg0_ptr, b"kaimendaji")
+    ptr1 = params['ptr1']
+    size = params['size']
 
-        ql.arch.regs.arch_sp -= 0x10
-        arg1_ptr = ql.arch.regs.arch_sp
-        ql.mem.write(arg1_ptr, b"000000")   # arbitrary password
+    password_raw = ql.mem.read(ptr1, size)
 
-        ql.arch.regs.arch_sp -= 0x20
-        argv_ptr = ql.arch.regs.arch_sp
-        ql.mem.write_ptr(argv_ptr, arg0_ptr)
-        ql.mem.write_ptr(argv_ptr + ql.arch.pointersize, arg1_ptr)
+    def __hex_digit(ch: int) -> str:
+        off = ord('0') if ch in range(10) else ord('a') - 10
 
-        ql.arch.regs.r2 = 2
-        ql.arch.regs.r3 = argv_ptr
+        return chr(ch + off)
 
-    with open("../examples/rootfs/blob/u-boot.bin.img", "rb") as f:
-        uboot_code = f.read()
+    # should be: "013f1f"
+    password = "".join(__hex_digit(ch) for ch in password_raw)
 
-    ql = Qiling(code=uboot_code[0x40:], archtype=QL_ARCH.ARM, ostype=QL_OS.BLOB, profile="uboot_bin.ql", verbose=QL_VERBOSE.OFF)
+    print(f'The password is: {password}')
 
-    image_base_addr = ql.loader.load_address
-    ql.hook_address(my_getenv, image_base_addr + 0x13AC0)
-    ql.hook_address(get_password, image_base_addr + 0x48634)
 
-    partial_run_init(ql)
+def partial_run_init(ql: Qiling):
+    # argv prepare
+    ql.arch.regs.arch_sp -= 0x30
+    arg0_ptr = ql.arch.regs.arch_sp
+    ql.mem.write(arg0_ptr, b"kaimendaji")
 
-    ql.run(image_base_addr + 0x486B4, image_base_addr + 0x48718)
+    ql.arch.regs.arch_sp -= 0x10
+    arg1_ptr = ql.arch.regs.arch_sp
+    ql.mem.write(arg1_ptr, b"000000")   # arbitrary password
+
+    ql.arch.regs.arch_sp -= 0x20
+    argv_ptr = ql.arch.regs.arch_sp
+    ql.mem.write_ptr(argv_ptr, arg0_ptr)
+    ql.mem.write_ptr(argv_ptr + ql.arch.pointersize, arg1_ptr)
+
+    ql.arch.regs.r2 = 2
+    ql.arch.regs.r3 = argv_ptr
 
 
 if __name__ == "__main__":
-    get_kaimendaji_password()
+    with open("../examples/rootfs/blob/u-boot.bin.img", "rb") as f:
+        uboot_code = f.read()
+
+    ql = Qiling(code=uboot_code[0x40:], archtype=QL_ARCH.ARM, ostype=QL_OS.BLOB, profile="uboot_bin.ql", verbose=QL_VERBOSE.DEBUG)
+
+    imgbase = ql.loader.images[0].base
+
+    ql.hook_address(my_getenv, imgbase + 0x13AC0)
+    ql.hook_address(get_password, imgbase + 0x48634)
+
+    partial_run_init(ql)
+
+    ql.run(imgbase + 0x486B4, imgbase + 0x48718)

--- a/examples/uboot_bin.ql
+++ b/examples/uboot_bin.ql
@@ -1,5 +1,6 @@
 [CODE]
 ram_size = 0xa00000
+load_address = 0x80800000
 entry_point = 0x80800000
 heap_size = 0x300000
 

--- a/qiling/debugger/gdb/xml/cortex_m/arm-m-profile.xml
+++ b/qiling/debugger/gdb/xml/cortex_m/arm-m-profile.xml
@@ -25,4 +25,10 @@
   <reg name="pc" bitsize="32" type="code_ptr"/>
 
   <reg name="xpsr" bitsize="32" regnum="25"/>
+  <reg name="msp" bitsize="32"/>
+  <reg name="psp" bitsize="32"/>
+  <reg name="primask" bitsize="32"/>
+  <reg name="basepri" bitsize="32"/>
+  <reg name="faultmask" bitsize="32"/>
+  <reg name="control" bitsize="32"/>
 </feature>

--- a/qiling/debugger/gdb/xml/cortex_m/target.xml
+++ b/qiling/debugger/gdb/xml/cortex_m/target.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2009-2016 Free Software Foundation, Inc.
+
+ *!Copying and distribution of this file, with or without modification,
+ *!are permitted in any medium without royalty provided the copyright
+ *!notice and this notice are preserved.  -->
+
+<!DOCTYPE target SYSTEM "gdb-target.dtd">
+<target xmlns:xi="http://www.w3.org/2001/XInclude">
+    <architecture>armv7-m</architecture>
+    <xi:include href="arm-m-profile.xml"/>
+</target>

--- a/qiling/debugger/gdb/xmlregs.py
+++ b/qiling/debugger/gdb/xmlregs.py
@@ -13,14 +13,21 @@ from qiling.arch.arm_const import (
     reg_map_q as arm_regs_q,
     reg_map_s as arm_regs_s
 )
+
+from qiling.arch.cortex_m_const import (
+    reg_map as conretx_m_regs
+)
+
 from qiling.arch.arm64_const import (
     reg_map as arm64_regs,
     reg_map_v as arm64_regs_v,
     reg_map_fp as arm64_reg_map_fp
 )
+
 from qiling.arch.mips_const import (
     reg_map as mips_regs_gpr
 )
+
 from qiling.arch.x86_const import (
     reg_map_32 as x86_regs_32,
     reg_map_64 as x86_regs_64,
@@ -133,7 +140,7 @@ class QlGdbFeatures:
             QL_ARCH.X86:      dict(**x86_regs_32, **x86_regs_misc, **x86_regs_cr, **x86_regs_st, **x86_regs_xmm),
             QL_ARCH.X8664:    dict(**x86_regs_64, **x86_regs_misc, **x86_regs_cr, **x86_regs_st, **x86_regs_xmm, **x86_regs_ymm),
             QL_ARCH.ARM:      dict(**arm_regs, **arm_regs_vfp, **arm_regs_q, **arm_regs_s),
-            QL_ARCH.CORTEX_M: arm_regs,
+            QL_ARCH.CORTEX_M: dict(**conretx_m_regs),
             QL_ARCH.ARM64:    dict(**arm64_regs, **arm64_regs_v, **arm64_reg_map_fp),
             QL_ARCH.MIPS:     dict(**mips_regs_gpr)
         }[archtype]

--- a/qiling/debugger/gdb/xmlregs.py
+++ b/qiling/debugger/gdb/xmlregs.py
@@ -15,7 +15,7 @@ from qiling.arch.arm_const import (
 )
 
 from qiling.arch.cortex_m_const import (
-    reg_map as conretx_m_regs
+    reg_map as coretx_m_regs
 )
 
 from qiling.arch.arm64_const import (
@@ -140,7 +140,7 @@ class QlGdbFeatures:
             QL_ARCH.X86:      dict(**x86_regs_32, **x86_regs_misc, **x86_regs_cr, **x86_regs_st, **x86_regs_xmm),
             QL_ARCH.X8664:    dict(**x86_regs_64, **x86_regs_misc, **x86_regs_cr, **x86_regs_st, **x86_regs_xmm, **x86_regs_ymm),
             QL_ARCH.ARM:      dict(**arm_regs, **arm_regs_vfp, **arm_regs_q, **arm_regs_s),
-            QL_ARCH.CORTEX_M: dict(**conretx_m_regs),
+            QL_ARCH.CORTEX_M: dict(**coretx_m_regs),
             QL_ARCH.ARM64:    dict(**arm64_regs, **arm64_regs_v, **arm64_reg_map_fp),
             QL_ARCH.MIPS:     dict(**mips_regs_gpr)
         }[archtype]

--- a/qiling/debugger/gdb/xmlregs.py
+++ b/qiling/debugger/gdb/xmlregs.py
@@ -15,7 +15,7 @@ from qiling.arch.arm_const import (
 )
 
 from qiling.arch.cortex_m_const import (
-    reg_map as coretx_m_regs
+    reg_map as cortex_m_regs
 )
 
 from qiling.arch.arm64_const import (
@@ -140,7 +140,7 @@ class QlGdbFeatures:
             QL_ARCH.X86:      dict(**x86_regs_32, **x86_regs_misc, **x86_regs_cr, **x86_regs_st, **x86_regs_xmm),
             QL_ARCH.X8664:    dict(**x86_regs_64, **x86_regs_misc, **x86_regs_cr, **x86_regs_st, **x86_regs_xmm, **x86_regs_ymm),
             QL_ARCH.ARM:      dict(**arm_regs, **arm_regs_vfp, **arm_regs_q, **arm_regs_s),
-            QL_ARCH.CORTEX_M: dict(**coretx_m_regs),
+            QL_ARCH.CORTEX_M: dict(**cortex_m_regs),
             QL_ARCH.ARM64:    dict(**arm64_regs, **arm64_regs_v, **arm64_reg_map_fp),
             QL_ARCH.MIPS:     dict(**mips_regs_gpr)
         }[archtype]

--- a/qiling/debugger/qdb/context.py
+++ b/qiling/debugger/qdb/context.py
@@ -57,7 +57,7 @@ class Context:
         """Helper function for disassembling.
         """
 
-        insn_bytes = self.read_insn(address)
+        insn_bytes = self.read_insn(address) or b''
         insn = None
 
         if insn_bytes:
@@ -75,7 +75,7 @@ class Context:
             A tuple of: instruction address, size, mnemonic and operands
         """
 
-        insn_bytes = self.read_insn(address)
+        insn_bytes = self.read_insn(address) or b''
         insn = None
 
         if insn_bytes:

--- a/qiling/debugger/qdb/qdb.py
+++ b/qiling/debugger/qdb/qdb.py
@@ -136,10 +136,7 @@ class QlQdb(Cmd, QlDebugger):
         with self.__set_temp(self.ql, 'verbose', QL_VERBOSE.DISABLED):
             self.ql.os.run()
 
-        if self.ql.os.type is QL_OS.BLOB:
-            self.ql.loader.entry_point = self.ql.loader.load_address
-
-        elif init_hook:
+        if init_hook:
             for each_hook in init_hook:
                 self.do_breakpoint(each_hook)
 

--- a/qiling/loader/blob.py
+++ b/qiling/loader/blob.py
@@ -15,7 +15,8 @@ class QlLoaderBLOB(QlLoader):
         self.load_address = 0
 
     def run(self):
-        self.load_address = self.ql.os.entry_point      # for consistency
+        self.load_address = self.ql.os.load_address
+        self.entry_point = self.ql.os.entry_point
 
         code_begins = self.load_address
         code_size = self.ql.os.code_ram_size
@@ -28,8 +29,10 @@ class QlLoaderBLOB(QlLoader):
         self.images.append(Image(code_begins, code_ends, 'blob_code'))
 
         # FIXME: heap starts above end of ram??
+        # FIXME: heap should be allocated by OS, not loader
         heap_base = code_ends
         heap_size = int(self.ql.os.profile.get("CODE", "heap_size"), 16)
         self.ql.os.heap = QlMemoryHeap(self.ql, heap_base, heap_base + heap_size)
 
+        # FIXME: stack pointer should be a configurable profile setting
         self.ql.arch.regs.arch_sp = code_ends - 0x1000

--- a/qiling/os/blob/blob.py
+++ b/qiling/os/blob/blob.py
@@ -9,6 +9,7 @@ from qiling.const import QL_ARCH, QL_OS
 from qiling.os.fcall import QlFunctionCall
 from qiling.os.os import QlOs
 
+
 class QlOsBlob(QlOs):
     """ QlOsBlob for bare barines.
 
@@ -21,7 +22,7 @@ class QlOsBlob(QlOs):
     type = QL_OS.BLOB
 
     def __init__(self, ql: Qiling):
-        super(QlOsBlob, self).__init__(ql)
+        super().__init__(ql)
 
         self.ql = ql
 
@@ -39,11 +40,14 @@ class QlOsBlob(QlOs):
         self.fcall = QlFunctionCall(ql, cc)
 
     def run(self):
-        if self.ql.entry_point:
+        # if entry point was set explicitly, override the default one
+        if self.ql.entry_point is not None:
             self.entry_point = self.ql.entry_point
 
-        self.exit_point = self.ql.loader.load_address + len(self.ql.code)
-        if self.ql.exit_point:
+        self.exit_point = self.load_address + len(self.ql.code)
+
+        # if exit point was set explicitly, override the default one
+        if self.ql.exit_point is not None:
             self.exit_point = self.ql.exit_point
 
         self.ql.emu_start(self.entry_point, self.exit_point, self.ql.timeout, self.ql.count)

--- a/qiling/os/os.py
+++ b/qiling/os/os.py
@@ -89,6 +89,7 @@ class QlOs:
         if self.ql.code:
             # this shellcode entrypoint does not work for windows
             # windows shellcode entry point will comes from pe loader
+            self.load_address = self.profile.getint('CODE', 'load_address')
             self.entry_point = self.profile.getint('CODE', 'entry_point')
             self.code_ram_size = self.profile.getint('CODE', 'ram_size')
 

--- a/qiling/profiles/linux.ql
+++ b/qiling/profiles/linux.ql
@@ -1,6 +1,7 @@
 [CODE]
 # ram_size 0xa00000 is 10MB
 ram_size = 0xa00000
+load_address = 0x1000000
 entry_point = 0x1000000
 
 

--- a/qiling/profiles/windows.ql
+++ b/qiling/profiles/windows.ql
@@ -23,6 +23,7 @@ KI_USER_SHARED_DATA = 0x7ffe0000
 [CODE]
 # ram_size 0xa00000 is 10MB
 ram_size = 0xa00000
+load_address = 0x1000000
 entry_point = 0x1000000
 
 [KERNEL]

--- a/tests/profiles/uboot_bin.ql
+++ b/tests/profiles/uboot_bin.ql
@@ -1,5 +1,6 @@
 [CODE]
 ram_size = 0xa00000
+load_address = 0x80800000
 entry_point = 0x80800000
 heap_size = 0x300000
 

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -10,13 +10,17 @@ sys.path.append("..")
 
 from qiling.core import Qiling
 from qiling.const import QL_ARCH, QL_OS, QL_VERBOSE
-from qiling.os.const import STRING
+from qiling.os.const import STRING, POINTER, SIZE_T
 
 
 class BlobTest(unittest.TestCase):
     def test_uboot_arm(self):
-        def my_getenv(ql, *args, **kwargs):
-            env = {"ID": b"000000000000000", "ethaddr": b"11:22:33:44:55:66"}
+        def my_getenv(ql: Qiling):
+            env = {
+                "ID": b"000000000000000",
+                "ethaddr": b"11:22:33:44:55:66"
+            }
+
             params = ql.os.resolve_fcall_params({'key': STRING})
             value = env.get(params["key"], b"")
 
@@ -26,12 +30,23 @@ class BlobTest(unittest.TestCase):
             ql.arch.regs.r0 = value_addr
             ql.arch.regs.arch_pc = ql.arch.regs.lr
 
-        def check_password(ql, *args, **kwargs):
-            passwd_output = ql.mem.read(ql.arch.regs.r0, ql.arch.regs.r2)
-            passwd_input = ql.mem.read(ql.arch.regs.r1, ql.arch.regs.r2)
-            self.assertEqual(passwd_output, passwd_input)
+        def check_password(ql: Qiling):
+            params = ql.os.resolve_fcall_params({
+                'ptr1': POINTER,  # points to real password
+                'ptr2': POINTER,  # points to user provided password
+                'size': SIZE_T    # comparison length
+            })
 
-        def partial_run_init(ql):
+            ptr1 = params['ptr1']
+            ptr2 = params['ptr2']
+            size = params['size']
+
+            real_password = ql.mem.read(ptr1, size)
+            user_password = ql.mem.read(ptr2, size)
+
+            self.assertSequenceEqual(real_password, user_password, seq_type=bytearray)
+
+        def partial_run_init(ql: Qiling):
             # argv prepare
             ql.arch.regs.arch_sp -= 0x30
             arg0_ptr = ql.arch.regs.arch_sp
@@ -56,13 +71,14 @@ class BlobTest(unittest.TestCase):
 
         ql = Qiling(code=uboot_code[0x40:], archtype=QL_ARCH.ARM, ostype=QL_OS.BLOB, profile="profiles/uboot_bin.ql", verbose=QL_VERBOSE.DEBUG)
 
-        image_base_addr = ql.loader.load_address
-        ql.hook_address(my_getenv, image_base_addr + 0x13AC0)
-        ql.hook_address(check_password, image_base_addr + 0x48634)
+        imgbase = ql.loader.images[0].base
+
+        ql.hook_address(my_getenv, imgbase + 0x13AC0)
+        ql.hook_address(check_password, imgbase + 0x48634)
 
         partial_run_init(ql)
 
-        ql.run(image_base_addr + 0x486B4, image_base_addr + 0x48718)
+        ql.run(imgbase + 0x486B4, imgbase + 0x48718)
 
         del ql
 


### PR DESCRIPTION
Highlights:
 - BLOB entry point and load address decoupled. Now it is possible to define a load address different than the entry point
 - BLOB example and test explained
 - Fixed qdb crash on disassembling instructions on allocated memory boundaries
 - Fixed gdb registers reference for ARM Cortex-M

Fixes #1568, #1580