### PR TITLE
return EISDIR in case ql_syscall_read is attempted on directory

### DIFF
--- a/qiling/os/posix/syscall/unistd.py
+++ b/qiling/os/posix/syscall/unistd.py
@@ -415,6 +415,8 @@ def ql_syscall_read(ql: Qiling, fd: int, buf: int, length: int):
 
     try:
         data = f.read(length)
+    except IsADirectoryError:
+        return -EISDIR
     except ConnectionError:
         ql.log.debug('read failed due to a connection error')
         return -EIO


### PR DESCRIPTION
This minor fix ensures that if you open a fd on a directory and then try to read it, the correct error code is returned in stead of an exception. 

## Checklist

### Which kind of PR do you create?

- [X] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [X] The new code conforms to Qiling Framework naming convention.
- [X] The imports are arranged properly.
- [X] Essential comments are added.
- [X] The reference of the new code is pointed out.

### Extra tests?

- [X] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [X] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [X] The target branch is dev branch.

### One last thing

- [X] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----
