### PR TITLE
Fix Windows breakage

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -644,6 +644,7 @@ class Process:
 
                 # DLLs that seem to contain most of the requested symbols
                 key_dlls = (
+                    'kernel32.dll',
                     'ntdll.dll',
                     'kernelbase.dll',
                     'ucrtbase.dll'

--- a/tests/test_pe_sys.py
+++ b/tests/test_pe_sys.py
@@ -219,8 +219,8 @@ class PETest(unittest.TestCase):
         fcall.writeParams(((DWORD, 0),))
 
         # run until third stop
-        # TODO: Should stop at 0x10423, but for now just stop at 0x0001066a
-        amsint32.hook_address(hook_third_stop_address, 0x0001066a, stops)
+        # TODO: Should stop at 0x10423, but for now just stop at 0x10430
+        amsint32.hook_address(hook_third_stop_address, 0x10430, stops)
         amsint32.run(begin=0x102D0)
 
         self.assertTrue(stops[0])


### PR DESCRIPTION
Fix the recent breakage introduced by Github retiring `windows-2019` and moving to `windows-latest`.

Highlights:
 - Adding `kernel32.dll` to key dlls table, per @uintmax's analysis on #1594
 - Adjusting `sality` test to end on a different exit point