### PR TITLE
Fix elf stack, pe stack and pe sections memory protection

### DIFF
--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -88,7 +88,7 @@ class QlLoaderELF(QlLoader):
         stack_address = self.profile.getint('stack_address')
         stack_size = self.profile.getint('stack_size')
         top_of_stack = stack_address + stack_size
-        self.ql.mem.map(stack_address, stack_size, info='[stack]')
+        self.ql.mem.map(stack_address, stack_size, UC_PROT_READ | UC_PROT_WRITE, info='[stack]')
 
         self.path = self.ql.path
 

--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -92,13 +92,9 @@ class QlLoaderELF(QlLoader):
         elffile = ELFFile(fstream)
         elftype = elffile['e_type']
 
-        stack_perm = UC_PROT_NONE
-        for seg in elffile.iter_segments('PT_GNU_STACK'):
-            stack_perm = QlLoaderELF.seg_perm_to_uc_prot(seg['p_flags'])
-
-        QlLoaderELF.seg_perm_to_uc_prot(stack_perm)
-
         # setup program stack
+        stack_seg = elffile.iter_segments('PT_GNU_STACK')
+        stack_perm = QlLoaderELF.seg_perm_to_uc_prot(next(stack_seg)['p_flags'])
         stack_address = self.profile.getint('stack_address')
         stack_size = self.profile.getint('stack_size')
         top_of_stack = stack_address + stack_size

--- a/qiling/loader/elf.py
+++ b/qiling/loader/elf.py
@@ -84,12 +84,6 @@ class QlLoaderELF(QlLoader):
 
         self.profile = self.ql.os.profile[f'OS{self.ql.arch.bits}']
 
-        # setup program stack
-        stack_address = self.profile.getint('stack_address')
-        stack_size = self.profile.getint('stack_size')
-        top_of_stack = stack_address + stack_size
-        self.ql.mem.map(stack_address, stack_size, UC_PROT_READ | UC_PROT_WRITE, info='[stack]')
-
         self.path = self.ql.path
 
         with open(self.path, 'rb') as infile:
@@ -97,6 +91,18 @@ class QlLoaderELF(QlLoader):
 
         elffile = ELFFile(fstream)
         elftype = elffile['e_type']
+
+        stack_perm = UC_PROT_NONE
+        for seg in elffile.iter_segments('PT_GNU_STACK'):
+            stack_perm = QlLoaderELF.seg_perm_to_uc_prot(seg['p_flags'])
+
+        QlLoaderELF.seg_perm_to_uc_prot(stack_perm)
+
+        # setup program stack
+        stack_address = self.profile.getint('stack_address')
+        stack_size = self.profile.getint('stack_size')
+        top_of_stack = stack_address + stack_size
+        self.ql.mem.map(stack_address, stack_size, stack_perm, info='[stack]')
 
         # is it a driver?
         if elftype == 'ET_REL':

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -382,9 +382,7 @@ class Process:
         dll_len = image_size
 
         self.dll_size += dll_len
-        self.ql.mem.map(dll_base, dll_len, UC_PROT_READ, info=dll_name)
-        self.protect_sections(dll_base, dll)
-        self.ql.mem.write(dll_base, bytes(data))
+        _map_sections_(self.ql, dll, dll_base, dll_len, dll_name)
 
         if dll_base == self.dll_last_address:
             self.dll_last_address = self.ql.mem.align_up(self.dll_last_address + dll_len, 0x10000)
@@ -815,6 +813,35 @@ class Process:
         cookie = secrets.randbits(self.ql.arch.bits - 16)
 
         self.ql.mem.write_ptr(cookie_rva + image_base, cookie)
+            
+def _map_sections_(ql : Qiling, pe : pefile.PE, image_base: int, image_size : int, image_name : str):
+            """Load file sections to memory, each in its own memory region protected by
+            its defined permissions. That allows separation of code and data, which makes
+            it easier to detect abnomal behavior or memory corruptions.
+            """
+
+            # load the header
+            hdr_base = image_base
+            hdr_perm = UC_PROT_READ
+
+            ql.mem.map(hdr_base, image_size, hdr_perm, image_name)
+
+            # load sections
+            for section in pe.sections:
+                if not section.IMAGE_SCN_MEM_DISCARDABLE:
+                    sec_name = section.Name.rstrip(b'\x00').decode()
+                    sec_data = bytes(section.get_data(ignore_padding=True))
+                    sec_base = image_base + section.VirtualAddress
+                    sec_size = (int(section.Misc_VirtualSize / pe.OPTIONAL_HEADER.SectionAlignment) + 1) * pe.OPTIONAL_HEADER.SectionAlignment
+
+                    sec_perm = sum((
+                        section.IMAGE_SCN_MEM_READ * UC_PROT_READ,
+                        section.IMAGE_SCN_MEM_WRITE * UC_PROT_WRITE,
+                        section.IMAGE_SCN_MEM_EXECUTE * UC_PROT_EXEC
+                    ))
+
+                    ql.mem.protect(sec_base, sec_size, sec_perm)
+            ql.mem.write(image_base, bytes(pe.get_memory_mapped_image()))
 
 class QlLoaderPE(QlLoader, Process):
     def __init__(self, ql: Qiling, libcache: bool):
@@ -881,44 +908,19 @@ class QlLoaderPE(QlLoader, Process):
         self.cmdline = bytes(f'{cmdline} {cmdargs}\x00', "utf-8")
 
         self.load(pe)
-    
-    def protect_sections(self, image_base: int, pe: pefile.PE):
-        for section in pe.sections:
-            mem_prot = UC_PROT_NONE
-            prot_num = 0
-            log_str = str(section.Name, 'utf-8') + ' section memory protection: '
-            prot_str = [None, None, None]
-
-            if section.Characteristics & pefile.SECTION_CHARACTERISTICS['IMAGE_SCN_MEM_EXECUTE']:
-                mem_prot |= UC_PROT_EXEC
-                prot_str[prot_num] = 'IMAGE_SCN_MEM_EXECUTE'
-                prot_num += 1
-            if section.Characteristics & pefile.SECTION_CHARACTERISTICS['IMAGE_SCN_MEM_READ']:
-                mem_prot |= UC_PROT_READ
-                prot_str[prot_num] = 'IMAGE_SCN_MEM_READ'
-                prot_num += 1
-            if section.Characteristics & pefile.SECTION_CHARACTERISTICS['IMAGE_SCN_MEM_WRITE']:
-                mem_prot |= UC_PROT_WRITE
-                prot_str[prot_num] = 'IMAGE_SCN_MEM_WRITE'
-                prot_num += 1
-            
-            for i in range(prot_num):
-                if i != 0:
-                    log_str += ', '
-                log_str += prot_str[i]
-
-            self.ql.log.info(log_str)
-            self.ql.mem.protect(image_base + section.VirtualAddress, (int(section.Misc_VirtualSize / pe.OPTIONAL_HEADER.SectionAlignment) + 1) * pe.OPTIONAL_HEADER.SectionAlignment, mem_prot)
 
     def load(self, pe: Optional[pefile.PE]):
         # set stack pointer
         self.ql.log.info("Initiate stack address at 0x%x " % self.stack_address)
-        self.ql.mem.map(self.stack_address, self.stack_size, UC_PROT_READ | UC_PROT_WRITE, info="[stack]")
+        self.ql.mem.map(self.stack_address, self.stack_size, info="[stack]")
 
         if pe is not None:
             image_name = os.path.basename(self.path)
             image_base = pe.OPTIONAL_HEADER.ImageBase
             image_size = self.ql.mem.align_up(pe.OPTIONAL_HEADER.SizeOfImage)
+
+            if pe.OPTIONAL_HEADER.DllCharacteristics & pefile.DLL_CHARACTERISTICS['IMAGE_DLLCHARACTERISTICS_NX_COMPAT']:
+                self.ql.mem.protect(self.stack_address, self.stack_size, UC_PROT_WRITE | UC_PROT_READ)
 
             # if default base address is taken, use the one specified in profile
             if not self.ql.mem.is_available(image_base, image_size):
@@ -932,8 +934,7 @@ class QlLoaderPE(QlLoader, Process):
             self.ql.log.info(f'Loading {self.path} to {image_base:#x}')
             self.ql.log.info(f'PE entry point at {self.entry_point:#x}')
 
-            self.ql.mem.map(image_base, image_size, UC_PROT_READ, info=f'{image_name}')
-            self.protect_sections(image_base, pe)
+            _map_sections_(self.ql, pe, image_base, image_size, image_name)
             self.images.append(Image(image_base, image_base + pe.NT_HEADERS.OPTIONAL_HEADER.SizeOfImage, os.path.abspath(self.path)))
 
             if self.is_driver:
@@ -963,7 +964,6 @@ class QlLoaderPE(QlLoader, Process):
             pe.parse_data_directories()
 
             # done manipulating pe file; write its contents into memory
-            self.ql.mem.write(image_base, bytes(pe.get_memory_mapped_image()))
 
             if self.is_driver:
                 # security cookie can be written only after image has been loaded to memory

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, MutableMapping, NamedTuple, O
 
 from unicorn import UcError
 from unicorn.x86_const import UC_X86_REG_CR4, UC_X86_REG_CR8
+from unicorn.unicorn_const import UC_PROT_READ, UC_PROT_WRITE, UC_PROT_EXEC, UC_PROT_NONE
 
 from qiling.arch.x86_const import FS_SEGMENT_ADDR, GS_SEGMENT_ADDR
 from qiling.const import QL_ARCH, QL_STATE
@@ -381,7 +382,8 @@ class Process:
         dll_len = image_size
 
         self.dll_size += dll_len
-        self.ql.mem.map(dll_base, dll_len, info=dll_name)
+        self.ql.mem.map(dll_base, dll_len, UC_PROT_READ, info=dll_name)
+        self.protect_sections(dll_base, dll)
         self.ql.mem.write(dll_base, bytes(data))
 
         if dll_base == self.dll_last_address:
@@ -879,11 +881,39 @@ class QlLoaderPE(QlLoader, Process):
         self.cmdline = bytes(f'{cmdline} {cmdargs}\x00', "utf-8")
 
         self.load(pe)
+    
+    def protect_sections(self, image_base: int, pe: pefile.PE):
+        for section in pe.sections:
+            mem_prot = UC_PROT_NONE
+            prot_num = 0
+            log_str = str(section.Name, 'utf-8') + ' section memory protection: '
+            prot_str = [None, None, None]
+
+            if section.Characteristics & pefile.SECTION_CHARACTERISTICS['IMAGE_SCN_MEM_EXECUTE']:
+                mem_prot |= UC_PROT_EXEC
+                prot_str[prot_num] = 'IMAGE_SCN_MEM_EXECUTE'
+                prot_num += 1
+            if section.Characteristics & pefile.SECTION_CHARACTERISTICS['IMAGE_SCN_MEM_READ']:
+                mem_prot |= UC_PROT_READ
+                prot_str[prot_num] = 'IMAGE_SCN_MEM_READ'
+                prot_num += 1
+            if section.Characteristics & pefile.SECTION_CHARACTERISTICS['IMAGE_SCN_MEM_WRITE']:
+                mem_prot |= UC_PROT_WRITE
+                prot_str[prot_num] = 'IMAGE_SCN_MEM_WRITE'
+                prot_num += 1
+            
+            for i in range(prot_num):
+                if i != 0:
+                    log_str += ', '
+                log_str += prot_str[i]
+
+            self.ql.log.info(log_str)
+            self.ql.mem.protect(image_base + section.VirtualAddress, (int(section.Misc_VirtualSize / pe.OPTIONAL_HEADER.SectionAlignment) + 1) * pe.OPTIONAL_HEADER.SectionAlignment, mem_prot)
 
     def load(self, pe: Optional[pefile.PE]):
         # set stack pointer
         self.ql.log.info("Initiate stack address at 0x%x " % self.stack_address)
-        self.ql.mem.map(self.stack_address, self.stack_size, info="[stack]")
+        self.ql.mem.map(self.stack_address, self.stack_size, UC_PROT_READ | UC_PROT_WRITE, info="[stack]")
 
         if pe is not None:
             image_name = os.path.basename(self.path)
@@ -902,7 +932,8 @@ class QlLoaderPE(QlLoader, Process):
             self.ql.log.info(f'Loading {self.path} to {image_base:#x}')
             self.ql.log.info(f'PE entry point at {self.entry_point:#x}')
 
-            self.ql.mem.map(image_base, image_size, info=f'{image_name}')
+            self.ql.mem.map(image_base, image_size, UC_PROT_READ, info=f'{image_name}')
+            self.protect_sections(image_base, pe)
             self.images.append(Image(image_base, image_base + pe.NT_HEADERS.OPTIONAL_HEADER.SizeOfImage, os.path.abspath(self.path)))
 
             if self.is_driver:

--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -382,7 +382,8 @@ class Process:
         dll_len = image_size
 
         self.dll_size += dll_len
-        _map_sections_(self.ql, dll, dll_base, dll_len, dll_name)
+        _map_pe_(self.ql, dll, dll_base, dll_len, dll_name)
+        self.ql.mem.write(dll_base, bytes(data))
 
         if dll_base == self.dll_last_address:
             self.dll_last_address = self.ql.mem.align_up(self.dll_last_address + dll_len, 0x10000)
@@ -813,12 +814,18 @@ class Process:
         cookie = secrets.randbits(self.ql.arch.bits - 16)
 
         self.ql.mem.write_ptr(cookie_rva + image_base, cookie)
-            
-def _map_sections_(ql : Qiling, pe : pefile.PE, image_base: int, image_size : int, image_name : str):
+
+def _map_pe_(ql : Qiling, pe : pefile.PE, image_base: int, image_size : int, image_name : str):
             """Load file sections to memory, each in its own memory region protected by
             its defined permissions. That allows separation of code and data, which makes
             it easier to detect abnomal behavior or memory corruptions.
             """
+
+            # if sections are aligned to page, we can map them separately
+            sec_alignment = pe.OPTIONAL_HEADER.SectionAlignment
+            if (sec_alignment % ql.mem.pagesize) != 0:
+                ql.mem.map(image_base, image_size, info=f'{image_name}')
+                return
 
             # load the header
             hdr_base = image_base
@@ -828,20 +835,18 @@ def _map_sections_(ql : Qiling, pe : pefile.PE, image_base: int, image_size : in
 
             # load sections
             for section in pe.sections:
-                if not section.IMAGE_SCN_MEM_DISCARDABLE:
-                    sec_name = section.Name.rstrip(b'\x00').decode()
-                    sec_data = bytes(section.get_data(ignore_padding=True))
-                    sec_base = image_base + section.VirtualAddress
-                    sec_size = (int(section.Misc_VirtualSize / pe.OPTIONAL_HEADER.SectionAlignment) + 1) * pe.OPTIONAL_HEADER.SectionAlignment
+                sec_name = section.Name.rstrip(b'\x00').decode()
+                sec_base = image_base + section.VirtualAddress
+                sec_size = ql.mem.align_up(section.Misc_VirtualSize, sec_alignment)
 
-                    sec_perm = sum((
-                        section.IMAGE_SCN_MEM_READ * UC_PROT_READ,
-                        section.IMAGE_SCN_MEM_WRITE * UC_PROT_WRITE,
-                        section.IMAGE_SCN_MEM_EXECUTE * UC_PROT_EXEC
-                    ))
+                sec_perm = sum((
+                    section.IMAGE_SCN_MEM_READ * UC_PROT_READ,
+                    section.IMAGE_SCN_MEM_WRITE * UC_PROT_WRITE,
+                    section.IMAGE_SCN_MEM_EXECUTE * UC_PROT_EXEC
+                ))
 
-                    ql.mem.protect(sec_base, sec_size, sec_perm)
-            ql.mem.write(image_base, bytes(pe.get_memory_mapped_image()))
+                ql.mem.protect(sec_base, sec_size, sec_perm)
+                ql.mem.change_mapinfo(sec_base, sec_base+sec_size, new_perms=sec_perm, new_info=f'{image_name} {sec_name}')
 
 class QlLoaderPE(QlLoader, Process):
     def __init__(self, ql: Qiling, libcache: bool):
@@ -934,7 +939,8 @@ class QlLoaderPE(QlLoader, Process):
             self.ql.log.info(f'Loading {self.path} to {image_base:#x}')
             self.ql.log.info(f'PE entry point at {self.entry_point:#x}')
 
-            _map_sections_(self.ql, pe, image_base, image_size, image_name)
+            _map_pe_(self.ql, pe, image_base, image_size, image_name)
+
             self.images.append(Image(image_base, image_base + pe.NT_HEADERS.OPTIONAL_HEADER.SizeOfImage, os.path.abspath(self.path)))
 
             if self.is_driver:
@@ -964,6 +970,7 @@ class QlLoaderPE(QlLoader, Process):
             pe.parse_data_directories()
 
             # done manipulating pe file; write its contents into memory
+            self.ql.mem.write(image_base, bytes(pe.get_memory_mapped_image()))
 
             if self.is_driver:
                 # security cookie can be written only after image has been loaded to memory


### PR DESCRIPTION
<!-- 
We highly appreciate your interest and contribution to our project. 
Before submiting your PR, please finish the checklist below. 
-->

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [ ] The imports are arranged properly.
- [ ] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [ ] This PR doesn't need to update Changelog.
- [x] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

When running some pe binaries and having them throwing unhandled exceptions, I noticed that all all the protections are RWX by default.
That could be used to detect qiling from a malware perspective and here's how it can be done:
```cpp
#include <iostream>
#include <windows.h>

static void qiling_detected()       //Runs if the stack is executable which isn't normal for modern winodws systems
{
    printf("[-]Will terminate because qiling was detected...");
    ExitProcess(0);
}
static LONG doing_evil_stuff(_EXCEPTION_POINTERS* ExceptionInfo)    //Runs if the stack is not executable which is the norm for modern windows systems
{
    printf("[+]No qiling, doing evil stuff");
    return 0;
}


int main()
{
    DWORD old_mem = 0;
    byte some_code[3] = { 0 };          //call [rcx]
    some_code[0] = 0xff;                //ret
    some_code[1] = 0xd1;
    some_code[2] = 0xc3;
    //The call rcx, ret, is executed on the stack which isn't supposed to happen
    void(__fastcall * shellcode)(void*) = (void(__fastcall *)(void*)) (void*)some_code;

    AddVectoredExceptionHandler(1, doing_evil_stuff);
    shellcode(&qiling_detected);

    return 0;
}
```