### PR TITLE
Fix capstone 6 compatibility for ARM64 and RISC-V

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ keywords = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-capstone = "^5"
+capstone = ">=5,<7"
 unicorn = "2.1.3"
 pefile = ">=2022.5.30"
 python-registry = "^1.3.1"

--- a/qiling/arch/arm64.py
+++ b/qiling/arch/arm64.py
@@ -7,7 +7,10 @@ from functools import cached_property
 from typing import Optional
 
 from unicorn import Uc, UC_ARCH_ARM64, UC_MODE_ARM
-from capstone import Cs, CS_ARCH_ARM64, CS_MODE_ARM
+try:
+    from capstone import Cs, CS_ARCH_AARCH64 as CS_ARCH_ARM64, CS_MODE_ARM
+except ImportError:
+    from capstone import Cs, CS_ARCH_ARM64, CS_MODE_ARM
 from keystone import Ks, KS_ARCH_ARM64, KS_MODE_ARM
 
 from qiling import Qiling

--- a/qiling/arch/riscv.py
+++ b/qiling/arch/riscv.py
@@ -56,11 +56,14 @@ class QlArchRISCV(QlArch):
     @cached_property
     def disassembler(self) -> Cs:
         try:
-            from capstone import CS_ARCH_RISCV, CS_MODE_RISCV32, CS_MODE_RISCVC
+            from capstone import CS_ARCH_RISCV, CS_MODE_RISCV32
         except ImportError:
             raise QlErrorNotImplemented("Capstone does not yet support riscv, upgrade to capstone 5.0")
-        else:
-            return Cs(CS_ARCH_RISCV, CS_MODE_RISCV32 + CS_MODE_RISCVC)
+        try:
+            from capstone import CS_MODE_RISCV_C as CS_MODE_RISCVC
+        except ImportError:
+            from capstone import CS_MODE_RISCVC
+        return Cs(CS_ARCH_RISCV, CS_MODE_RISCV32 + CS_MODE_RISCVC)
 
     @cached_property
     def assembler(self) -> Ks:

--- a/qiling/arch/riscv64.py
+++ b/qiling/arch/riscv64.py
@@ -38,11 +38,14 @@ class QlArchRISCV64(QlArchRISCV):
     @cached_property
     def disassembler(self) -> Cs:
         try:
-            from capstone import CS_ARCH_RISCV, CS_MODE_RISCV64, CS_MODE_RISCVC
+            from capstone import CS_ARCH_RISCV, CS_MODE_RISCV64
         except ImportError:
             raise QlErrorNotImplemented("Capstone does not yet support riscv, upgrade to capstone 5.0")
-        else:
-            return Cs(CS_ARCH_RISCV, CS_MODE_RISCV64 + CS_MODE_RISCVC)
+        try:
+            from capstone import CS_MODE_RISCV_C as CS_MODE_RISCVC
+        except ImportError:
+            from capstone import CS_MODE_RISCVC
+        return Cs(CS_ARCH_RISCV, CS_MODE_RISCV64 + CS_MODE_RISCVC)
 
     @cached_property
     def assembler(self) -> Ks:


### PR DESCRIPTION
Capstone 6 renamed several architecture constants in its Python bindings:
- CS_ARCH_ARM64 -> CS_ARCH_AARCH64 (old name removed)
- CS_MODE_RISCVC -> CS_MODE_RISCV_C (old name still aliased in v6, but future
  versions may drop it)

This PR:
- Adds try/except fallback in arm64.py for the ARM64 / AARCH64 rename
- Adds forward-compatible try/except in riscv.py and riscv64.py for RISCVC /
  RISCV_C
- Relaxes the capstone dependency from ^5 to >=5,<7 to allow capstone 6.x

Target branch: dev

Checklist:
- [x] This PR only contains minor fixes.
- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] No extra tests are needed for this PR.
- [x] This PR doesn't need to update Changelog.
- [x] The target branch is dev branch.
