### PR TITLE
Reset emu state after a failing DllMain

### DIFF
--- a/qiling/loader/pe.py
+++ b/qiling/loader/pe.py
@@ -462,6 +462,10 @@ class Process:
             self.ql.log.error(f'Error encountered while running {dll_name} DllMain, bailing')
 
             self.ql.arch.regs.restore(regs_state)
+
+            # emu_start leaves the state at STARTED when it raises; reset it so a single
+            # failing DllMain does not gate every subsequently loaded DLL's entry point.
+            self.ql._state = QL_STATE.STOPPED
         else:
             fcall.cc.unwind(len(args))
 


### PR DESCRIPTION
## Summary

When a DLL's `DllMain` raises a `UcError`, `emu_start()` propagates the exception
without clearing `ql._state` (it only sets `STOPPED` on the success path), so the
state is left at `STARTED`. `call_dll_entrypoint()` (`qiling/loader/pe.py`) catches
the error and restores registers but never resets the state. Because DLL loading
gates on `emu_state is not STARTED` before running any later DLL's `DllMain`, one
early failure silently disables `DllMain` for every DLL loaded afterwards — with no
log output.

This resets `ql._state` to `STOPPED` on the exception path, mirroring what
`emu_start()` does on success.

## Verification

Verified on Windows: with a `DllMain` that raises, DLLs loaded afterwards now have
their `DllMain` executed instead of being silently skipped.

## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [ ] The reference of the new code is pointed out.

### Extra tests?

- [ ] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [x] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)
