### PR TITLE
Fix FLS FiberManager writing last_error to a dead attribute

### DIFF
--- a/qiling/os/windows/fiber.py
+++ b/qiling/os/windows/fiber.py
@@ -33,7 +33,7 @@ class FiberManager:
 
     def free(self, idx: int) -> bool:
         if idx not in self.fibers:
-            self.last_error = ERROR_INVALID_PARAMETER
+            self.ql.os.last_error = ERROR_INVALID_PARAMETER
             return False
 
         fiber = self.fibers[idx]
@@ -99,7 +99,7 @@ class FiberManager:
 
     def set(self, idx: int, data: int) -> bool:
         if idx not in self.fibers:
-            self.last_error = ERROR_INVALID_PARAMETER
+            self.ql.os.last_error = ERROR_INVALID_PARAMETER
             return False
 
         self.fibers[idx].data = data
@@ -108,7 +108,7 @@ class FiberManager:
 
     def get(self, idx: int) -> int:
         if idx not in self.fibers:
-            self.last_error = ERROR_INVALID_PARAMETER
+            self.ql.os.last_error = ERROR_INVALID_PARAMETER
             return 0
 
         return self.fibers[idx].data


### PR DESCRIPTION
## Summary

  `FiberManager` (`qiling/os/windows/fiber.py`) reports `ERROR_INVALID_PARAMETER`
  for an invalid FLS index by writing `self.last_error` in `free()`, `set()` and
  `get()`. But `self.last_error` is a plain attribute on the `FiberManager`
  instance that **nothing ever reads** — it is written in three places and read
  in none.

  The Windows last-error that `GetLastError` returns lives on `ql.os.last_error`
  (`hook_GetLastError` returns it, `hook_SetLastError` writes it, and every other
  kernel32 hook sets errors via `ql.os.last_error = ...`). Because the FLS code
  wrote the wrong object, `FlsFree` / `FlsSetValue` / `FlsGetValue` never actually
  surfaced `ERROR_INVALID_PARAMETER` to the emulated program: a guest calling one
  of these with a bad index, then `GetLastError()` to disambiguate the result,
  would see a stale/zero error code.

  ## Fix

  Route the three writes to `self.ql.os.last_error` (the `FiberManager` already
  holds `self.ql`), making the FLS error path consistent with the rest of
  kernel32. No API surface or signature changes; 3 lines in one file.

  This is independent of #1637 (which adds `FlsGetValue2`/`get_noerr`). It is worth
  noting the two interact: only once the last-error actually lands on
  `ql.os.last_error` does the intended `FlsGetValue` (sets error on bad index) vs
  `FlsGetValue2` (does not) distinction become observable to the guest.

  ## Checklist

  ### Which kind of PR do you create?

  - [x] This PR only contains minor fixes.
  - [ ] This PR contains major feature update.
  - [ ] This PR introduces a new function/api for Qiling Framework.

  ### Coding convention?

  - [x] The new code conforms to Qiling Framework naming convention.
  - [x] The imports are arranged properly.
  - [x] Essential comments are added.
  - [ ] The reference of the new code is pointed out.

  ### Extra tests?

  - [ ] No extra tests are needed for this PR.
  - [ ] I have added enough tests for this PR.
  - [x] Tests will be added after some discussion and review.

  ### Changelog?

  - [x] This PR doesn't need to update Changelog.
  - [ ] Changelog will be updated after some proper review.
  - [ ] Changelog has been updated in my PR.

  ### Target branch?

  - [x] The target branch is dev branch.

  ### One last thing

  - [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)