### PR TITLE
Fix broken __future__ import in IDA plugin custom_script

### DIFF
--- a/examples/extensions/idaplugin/custom_script.py
+++ b/examples/extensions/idaplugin/custom_script.py
@@ -1,4 +1,4 @@
-from future import __annotations__
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, List
 


### PR DESCRIPTION
## Checklist

### Which kind of PR do you create?

- [x] This PR only contains minor fixes.
- [ ] This PR contains major feature update.
- [ ] This PR introduces a new function/api for Qiling Framework.

### Coding convention?

- [x] The new code conforms to Qiling Framework naming convention.
- [x] The imports are arranged properly.
- [x] Essential comments are added.
- [x] The reference of the new code is pointed out.

### Extra tests?

- [x] No extra tests are needed for this PR.
- [ ] I have added enough tests for this PR.
- [ ] Tests will be added after some discussion and review.

### Changelog?

- [x] This PR doesn't need to update Changelog.
- [ ] Changelog will be updated after some proper review.
- [ ] Changelog has been updated in my PR.

### Target branch?

- [x] The target branch is dev branch.

### One last thing

- [x] I have read the [contribution guide](https://docs.qiling.io/en/latest/contribution/)

-----

## What this fixes

The first line of `examples/extensions/idaplugin/custom_script.py` reads:

```python
from future import __annotations__
```

The module name and the imported symbol are swapped. The intended statement is
the PEP 563 future statement:

```python
from __future__ import annotations
```

## Why it is broken either way

**Without the third-party `future` package installed** (the common case), the
import fails outright, so the `QILING_IDA` class is never defined:

```
ModuleNotFoundError: No module named 'future'
```

**With that package installed**, the import silently succeeds — but it binds the
module's own empty `__annotations__` dict (`{}`), not the PEP 563 feature:

```python
>>> from future import __annotations__
>>> type(__annotations__), __annotations__
(<class 'dict'>, {})
```

So deferred annotation evaluation is never enabled, while this file depends on
it: the method signatures annotate `ql: Qiling`, and `Qiling` is imported under
`if TYPE_CHECKING:` only — it does not exist at runtime.

## Verification

Importing the file as it currently stands, with `future` unavailable:

```
ModuleNotFoundError: import of future halted; None in sys.modules
```

With the one-line change applied:

```
imported with no error, class available: QILING_IDA
```

## Possible relation to #1516

Issue #1516 reports these two errors when using the IDA plugin:

```
AttributeError: module 'demo' has no attribute 'QILING_IDA'
AttributeError: 'NoneType' object has no attribute 'custom_prepare'
```

Both follow naturally from this import failure: if the custom script cannot be
imported, `QILING_IDA` is never defined on the module, the plugin gets `None`
back, and the subsequent `custom_prepare` call fails on that `None`. I have not
been able to confirm the full plugin flow end-to-end under IDA, so I am flagging
this as a likely — not certain — fix for that issue.

## Scope

One line, one file. No behavioural change beyond making the example importable.
