### PR TITLE
gdb: report SIGTRAP (not SIGTERM) on single-step

### DIFF
--- a/qiling/debugger/gdb/gdb.py
+++ b/qiling/debugger/gdb/gdb.py
@@ -30,7 +30,7 @@ from unicorn.unicorn_const import (
 )
 
 from qiling import Qiling
-from qiling.const import QL_ARCH, QL_ENDIAN, QL_OS, QL_STATE
+from qiling.const import QL_ARCH, QL_ENDIAN, QL_OS
 from qiling.debugger import QlDebugger
 from qiling.debugger.gdb.xmlregs import QlGdbFeatures
 from qiling.debugger.gdb.utils import QlGdbUtils
@@ -55,6 +55,21 @@ SIGTERM = 15
 SIGCHLD = 16
 SIGCONT = 17
 SIGSTOP = 18
+
+# translate a unicorn cpu fault into the closest posix signal, shared by the
+# continue ('c') and single-step ('s') handlers when emulation faults
+UC_ERROR_SIGMAP = {
+    UC_ERR_READ_UNMAPPED   : SIGSEGV,
+    UC_ERR_WRITE_UNMAPPED  : SIGSEGV,
+    UC_ERR_FETCH_UNMAPPED  : SIGSEGV,
+    UC_ERR_WRITE_PROT      : SIGSEGV,
+    UC_ERR_READ_PROT       : SIGSEGV,
+    UC_ERR_FETCH_PROT      : SIGSEGV,
+    UC_ERR_READ_UNALIGNED  : SIGBUS,
+    UC_ERR_WRITE_UNALIGNED : SIGBUS,
+    UC_ERR_FETCH_UNALIGNED : SIGBUS,
+    UC_ERR_INSN_INVALID    : SIGILL
+}
 
 # common replies
 REPLY_ACK = b'+'
@@ -226,21 +241,8 @@ class QlGdb(QlDebugger):
             try:
                 self.gdb.resume_emu()
             except UcError as err:
-                sigmap = {
-                    UC_ERR_READ_UNMAPPED   : SIGSEGV,
-                    UC_ERR_WRITE_UNMAPPED  : SIGSEGV,
-                    UC_ERR_FETCH_UNMAPPED  : SIGSEGV,
-                    UC_ERR_WRITE_PROT      : SIGSEGV,
-                    UC_ERR_READ_PROT       : SIGSEGV,
-                    UC_ERR_FETCH_PROT      : SIGSEGV,
-                    UC_ERR_READ_UNALIGNED  : SIGBUS,
-                    UC_ERR_WRITE_UNALIGNED : SIGBUS,
-                    UC_ERR_FETCH_UNALIGNED : SIGBUS,
-                    UC_ERR_INSN_INVALID    : SIGILL
-                }
-
                 # determine signal from uc error; default to SIGTERM
-                reply = f'S{sigmap.get(err.errno, SIGTERM):02x}'
+                reply = f'S{UC_ERROR_SIGMAP.get(err.errno, SIGTERM):02x}'
 
             except KeyboardInterrupt:
                 # emulation was interrupted with ctrl+c
@@ -678,11 +680,23 @@ class QlGdb(QlDebugger):
             """Perform a single step.
             """
 
-            self.gdb.resume_emu(steps=1)
+            try:
+                self.gdb.resume_emu(steps=1)
+            except UcError as err:
+                # stepping faulted; report the closest posix signal
+                return f'S{UC_ERROR_SIGMAP.get(err.errno, SIGTERM):02x}'
 
-            # if emulation has been stopped, signal program termination
-            if self.ql.emu_state is QL_STATE.STOPPED:
-                return f'S{SIGTERM:02x}'
+            except KeyboardInterrupt:
+                # emulation was interrupted with ctrl+c
+                return f'S{SIGINT:02x}'
+
+            # emu_start always leaves emu_state as STOPPED after a step, so that
+            # cannot tell an ordinary step apart from the guest exiting (see
+            # issues #1377 and #1538). instead, the guest has terminated only
+            # when the step carried pc all the way to the emulation exit point.
+            if getattr(self.ql.arch, 'effective_pc', self.ql.arch.regs.arch_pc) == self.gdb.exit_point:
+                # program terminated; report its exit code
+                return f'W{self.ql.os.exit_code:02x}'
 
             # otherwise, this is just single stepping
             return f'S{SIGTRAP:02x}'

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -44,6 +44,55 @@ class SimpleGdbClient:
         self.__file.flush()
 
 
+class ReadingGdbClient:
+    """A minimal gdb remote client that can also read replies, so tests can
+    assert on the stop-reply packets the server sends back.
+    """
+
+    def __init__(self, host: str, port: int):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((host, port))
+        sock.settimeout(10)
+
+        self.__sock = sock
+        self.__buf = b''
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, ex_type, ex_value, ex_traceback):
+        self.__sock.close()
+
+    @staticmethod
+    def checksum(data: str) -> int:
+        return sum(ord(c) for c in data) & 0xff
+
+    def send(self, msg: str):
+        self.__sock.sendall(f'${msg}#{ReadingGdbClient.checksum(msg):02x}'.encode('latin'))
+
+    def read_packet(self) -> str:
+        """Read a single '$<data>#<checksum>' reply, skipping any '+'/'-' acks.
+        """
+
+        # wait for a packet start marker
+        while b'$' not in self.__buf:
+            self.__buf += self.__sock.recv(4096)
+
+        start = self.__buf.index(b'$')
+
+        # wait until the terminating '#' and its two checksum digits arrived
+        while True:
+            end = self.__buf.find(b'#', start)
+            if end != -1 and len(self.__buf) >= end + 3:
+                break
+            self.__buf += self.__sock.recv(4096)
+
+        data = self.__buf[start + 1:end]
+        self.__buf = self.__buf[end + 3:]
+
+        return data.decode('latin')
+
+
 class DebuggerTest(unittest.TestCase):
     def test_gdbdebug_file_server(self):
         ql = Qiling(["../examples/rootfs/x8664_linux/bin/x8664_hello"], "../examples/rootfs/x8664_linux", verbose=QL_VERBOSE.DEBUG)
@@ -167,6 +216,43 @@ class DebuggerTest(unittest.TestCase):
 
         ql.run()
         del ql
+
+    def test_gdbdebug_stepi_reports_sigtrap(self):
+        # regression for issues #1377 and #1538: a single-step ('s') used to be
+        # answered with a SIGTERM stop-reply because emu_state is always STOPPED
+        # after a step, which made gdb clients believe the program had died. the
+        # stop-reply for an ordinary step must be a SIGTRAP ('S05'), never a
+        # SIGTERM ('S0f').
+        ql = Qiling(["../examples/rootfs/x8664_linux/bin/x8664_hello"], "../examples/rootfs/x8664_linux", verbose=QL_VERBOSE.OFF)
+        ql.debugger = 'gdb:127.0.0.1:9996'
+
+        replies = []
+
+        def gdb_test_client():
+            # yield to allow ql to launch its gdbserver
+            time.sleep(1.337 * 2)
+
+            with ReadingGdbClient('127.0.0.1', 9996) as client:
+                client.send('qSupported:multiprocess+;swbreak+;hwbreak+;vContSupported+;xmlRegisters=i386')
+                client.read_packet()
+                client.send('QStartNoAckMode')
+                client.read_packet()
+
+                # step a few instructions; every reply must be a SIGTRAP stop
+                for _ in range(3):
+                    client.send('s')
+                    replies.append(client.read_packet())
+
+                client.send('k')
+
+        thread = threading.Thread(target=gdb_test_client, daemon=True)
+        thread.start()
+
+        ql.run()
+        thread.join(timeout=30)
+        del ql
+
+        self.assertEqual(replies, ['S05', 'S05', 'S05'])
 
     def test_gdbdebug_shellcode_server(self):
         X8664_LIN = bytes.fromhex('31c048bbd19d9691d08c97ff48f7db53545f995257545eb03b0f05')


### PR DESCRIPTION
## Summary

Single-stepping over Qiling's gdb stub disconnects the client: after the first `s` (step-instruction) the stub sends a **SIGTERM** stop-reply, so the client believes the program died. This is reported in **#1538** and is the same root cause behind **#1377**.

`handle_s` decided the reply from `ql.emu_state`:

```python
self.gdb.resume_emu(steps=1)
if self.ql.emu_state is QL_STATE.STOPPED:   # always true after a step
    return f'S{SIGTERM:02x}'
return f'S{SIGTRAP:02x}'
```

But `Qiling.emu_start` **unconditionally** sets the state to `QL_STATE.STOPPED` once it has run the requested step count, so the guard is true on *every* step — the `SIGTRAP` branch is dead code. (Diagnosed in detail by @cbdm in #1377.)

## Fix

Give `handle_s` the same exit-vs-trap discrimination `handle_c` already uses: a step reports `SIGTRAP` unless it carried `pc` all the way to the emulation exit point, in which case the guest really has terminated and we reply `W{exit_code}`.

While here:
- wrap the step in the same `UcError` / `KeyboardInterrupt` handling as `handle_c`, so a fault *while stepping* maps to a signal (`SIGSEGV`/`SIGBUS`/`SIGILL`) instead of crashing the stub with an unhandled exception;
- hoist the duplicated uc-error→signal map to a module-level `UC_ERROR_SIGMAP` shared by `handle_c` and `handle_s`.

This supersedes the common "just comment out the two lines" workaround, which leaves the client unable to detect real termination ("bad exit if you step too much").

## Test

Adds `test_gdbdebug_stepi_reports_sigtrap`, which single-steps over the stub and asserts the stop-reply is `S05` (SIGTRAP). Against the unpatched stub it fails with `S0f` (SIGTERM); with the fix it passes. The existing debugger tests only *sent* packets and never read replies, so this gap went uncaught — the test adds a small reply-reading client.

Verified locally: full `test_debugger.py` suite passes (5 tests), and an end-to-end check with `gdb-multiarch` against a dynamically-linked AArch64 busybox now single-steps cleanly (no `SIGTERM, Terminated`) and reports a clean exit on `continue`.

Fixes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)