### PR TITLE
Terminate the emulated process on an illegal-instruction CPU exception

### DIFF
--- a/qiling/arch/mips_const.py
+++ b/qiling/arch/mips_const.py
@@ -3,7 +3,16 @@
 # Cross Platform and Multi Architecture Advanced Binary Emulation Framework
 #
 
+from enum import IntEnum
+
 from unicorn.mips_const import *
+
+
+class EXCP(IntEnum):
+    # subset of QEMU's MIPS exception codes, as reported to unicorn interrupt hooks
+    SYSCALL = 17   # system call
+    BREAK   = 18   # breakpoint
+    RI      = 20   # reserved (illegal) instruction
 
 reg_map = {
     "r0":  UC_MIPS_REG_0,

--- a/qiling/os/linux/linux.py
+++ b/qiling/os/linux/linux.py
@@ -12,6 +12,7 @@ from qiling import Qiling
 from qiling.arch.x86_const import GS_SEGMENT_ADDR, GS_SEGMENT_SIZE
 from qiling.arch.x86_utils import GDTManager, SegmentManager86, SegmentManager64
 from qiling.arch import arm_utils
+from qiling.arch.cortex_m_const import EXCP
 from qiling.cc import QlCC, intel, arm, mips, riscv, ppc
 from qiling.const import QL_ARCH, QL_OS
 from qiling.os.fcall import QlFunctionCall
@@ -56,7 +57,8 @@ class QlOsLinux(QlOsPosix):
         # ARM
         if self.ql.arch.type == QL_ARCH.ARM:
             self.ql.arch.enable_vfp()
-            self.ql.hook_intno(self.hook_syscall, 2)
+            self.ql.hook_intno(self.hook_syscall, EXCP.SWI)
+            self.ql.hook_intno(self.hook_cpu_exception, EXCP.UDEF)
             self.thread_class = thread.QlLinuxARMThread
             arm_utils.init_linux_traps(self.ql, {
                 'memory_barrier': 0xffff0fa0,
@@ -72,7 +74,8 @@ class QlOsLinux(QlOsPosix):
         # ARM64
         elif self.ql.arch.type == QL_ARCH.ARM64:
             self.ql.arch.enable_vfp()
-            self.ql.hook_intno(self.hook_syscall, 2)
+            self.ql.hook_intno(self.hook_syscall, EXCP.SWI)
+            self.ql.hook_intno(self.hook_cpu_exception, EXCP.UDEF)
             self.thread_class = thread.QlLinuxARM64Thread
 
         # X86
@@ -136,6 +139,23 @@ class QlOsLinux(QlOsPosix):
 
     def hook_syscall(self, ql, intno = None):
         return self.load_syscall()
+
+    def hook_cpu_exception(self, ql, intno = None):
+        # A cpu exception the kernel would turn into a fatal signal that
+        # terminates the process (e.g. SIGILL on an undefined instruction).
+        # Emulate that termination by stopping cleanly instead of letting the
+        # unhandled-interrupt dispatcher raise QlErrorCoreHook. This commonly
+        # happens with shellcode that falls through into trailing data once a
+        # terminal syscall (e.g. a denied execve) returns instead of replacing
+        # the image.
+        signame = {
+            EXCP.UDEF: 'SIGILL',
+        }.get(intno, f'exception {intno:#x}')
+
+        pc = ql.arch.regs.arch_pc
+
+        ql.log.debug(f'CPU raised {signame} at {pc:#x}; terminating emulated process')
+        ql.stop()
 
     def register_function_after_load(self, function):
         if function not in self.function_after_load_list:

--- a/qiling/os/linux/linux.py
+++ b/qiling/os/linux/linux.py
@@ -13,6 +13,7 @@ from qiling.arch.x86_const import GS_SEGMENT_ADDR, GS_SEGMENT_SIZE
 from qiling.arch.x86_utils import GDTManager, SegmentManager86, SegmentManager64
 from qiling.arch import arm_utils
 from qiling.arch.cortex_m_const import EXCP
+from qiling.arch.mips_const import EXCP as MIPS_EXCP
 from qiling.cc import QlCC, intel, arm, mips, riscv, ppc
 from qiling.const import QL_ARCH, QL_OS
 from qiling.os.fcall import QlFunctionCall
@@ -68,7 +69,8 @@ class QlOsLinux(QlOsPosix):
 
         # MIPS32
         elif self.ql.arch.type == QL_ARCH.MIPS:
-            self.ql.hook_intno(self.hook_syscall, 17)
+            self.ql.hook_intno(self.hook_syscall, MIPS_EXCP.SYSCALL)
+            self.ql.hook_intno(self.hook_cpu_exception, MIPS_EXCP.RI)
             self.thread_class = thread.QlLinuxMIPS32Thread
 
         # ARM64
@@ -149,7 +151,8 @@ class QlOsLinux(QlOsPosix):
         # terminal syscall (e.g. a denied execve) returns instead of replacing
         # the image.
         signame = {
-            EXCP.UDEF: 'SIGILL',
+            EXCP.UDEF:      'SIGILL',   # ARM / ARM64 undefined instruction
+            MIPS_EXCP.RI:   'SIGILL',   # MIPS reserved (illegal) instruction
         }.get(intno, f'exception {intno:#x}')
 
         pc = ql.arch.regs.arch_pc

--- a/tests/test_shellcode.py
+++ b/tests/test_shellcode.py
@@ -123,6 +123,29 @@ class TestShellcode(unittest.TestCase):
         ql.os.set_syscall('execve', graceful_execve, QL_INTERCEPT.EXIT)
         ql.run()
 
+    # the tests above end the emulation from the execve hook, so they never reach
+    # the shellcode's trailing '/bin/sh' string. the two below deliberately let
+    # execve return and fall through into it: those bytes are not valid code, so
+    # the cpu raises an undefined/reserved instruction exception. the kernel would
+    # deliver a fatal SIGILL and terminate the process, and qiling must do the
+    # same. before this fix nothing hooked those exceptions, so the unhandled
+    # interrupt was turned into QlErrorCoreHook and ql.run() blew up.
+    def _run_past_execve(self, code: bytes, archtype: QL_ARCH):
+        def returning_execve(ql: Qiling, pathname: int, argv: int, envp: int, retval: int):
+            assert retval != 0, 'execve is not expected to return on success'
+
+        ql = Qiling(code=code, archtype=archtype, ostype=QL_OS.LINUX, verbose=QL_VERBOSE.OFF)
+        ql.os.set_syscall('execve', returning_execve, QL_INTERCEPT.EXIT)
+        ql.run()
+
+    def test_linux_arm64_illegal_instruction(self):
+        print("Linux ARM 64bit illegal instruction")
+        self._run_past_execve(ARM64_LIN, QL_ARCH.ARM64)
+
+    def test_linux_mips32_illegal_instruction(self):
+        print("Linux MIPS 32bit EL illegal instruction")
+        self._run_past_execve(MIPS32EL_LIN, QL_ARCH.MIPS)
+
     # #This shellcode needs to be changed to something simpler not requiring rootfs
     # def test_windows_x86(self):
     #     print("Windows X86 32bit Shellcode")


### PR DESCRIPTION
Fixes problem 1 of #1629 ("Unhandled CPU exception on ARM64 / ARM / MIPS (`QlErrorCoreHook`)").

Split out of #1630, as requested — this is the framework half. Problem 2 of #1629 (the Windows missing-DLL handling in `examples/shellcode_run.py`) stays in #1630.

### Problem

`examples/shellcode_run.py` crashes on its very first stage.

The shellcodes in that example are connect-back shells: they build a socket, then call `execve("/bin/sh", ...)`, which on success never returns. The `/bin/sh` string and the sockaddr they reference are stored as **trailing data after the last instruction** — that is safe precisely because `execve` does not return.

Since `execve` was patched to return `-1` for paths outside the rootfs, that assumption no longer holds. The example passes no rootfs, so `execve` fails, returns, and the CPU walks straight off the end of the code into that trailing data and tries to execute it.

Here is the ARM64 stage disassembled (offsets relative to the load address):

```
  0x0000: eor  x2, x2, x2
  0x0004: mov  x1, #1
  0x0008: mov  x0, #2
  0x000c: mov  x8, #0xc6          ; 198 = socket
  0x0010: svc  #0
  0x0014: mov  x6, x0             ; save sockfd
  0x0018: adr  x1, #0x58          ; -> sockaddr, stored below
  0x001c: mov  x2, #0x10
  0x0020: mov  x8, #0xcb          ; 203 = connect
  0x0024: svc  #0
  ...
  0x0044: adr  x0, #0x60          ; -> "/bin/sh", stored below
  0x0048: eor  x2, x2, x2
  0x004c: eor  x1, x1, x1
  0x0050: mov  x8, #0xdd          ; 221 = execve   <-- the call in question
  0x0054: svc  #0                 ; never returns... except now it does
  ---------------- end of code, start of data ----------------
  0x0058: 02 00 04 d2             ; sockaddr_in: AF_INET + port
  0x005c: 7f 00 00 01             ; 127.0.0.1
  0x0060: 2f 62 69 6e 2f 73 68 00 ; "/bin/sh\0"
```

Execution resumes at `0x0058`. Those bytes happen to decode as a valid instruction, but `0x005c` (`7f 00 00 01`) does not decode at all — an undefined instruction.

The MIPS32 stage is the same shape, more compactly:

```
  0x0000: slti   $a2, $zero, -1
  0x0004: bltzal $a2, 0x4
  0x0008: slti   $a1, $zero, -1
  0x000c: addiu  $a0, $ra, 0x1001
  0x0010: addiu  $a0, $a0, -0xff1  ; $a0 -> "/bin/sh"
  0x0014: addiu  $v0, $zero, 0xfab ; 4011 = execve   <-- the call in question
  0x0018: syscall
  ---------------- end of code, start of data ----------------
  0x001c: 2f 62 69 6e 2f 73 68     ; "/bin/sh"
```

So on both architectures the CPU raises an illegal-instruction exception:

- ARM64 / ARM — undefined instruction, `EXCP_UDEF`
- MIPS — reserved instruction, `EXCP_RI` (20)

The Linux OS layer only hooks the syscall trap (`2` for ARM/ARM64, `17` for MIPS), so these exceptions reach the unhandled-interrupt dispatcher and abort the whole run with:

```
qiling.exception.QlErrorCoreHook: _hook_intr_cb : not handled
```

A real kernel would deliver a fatal SIGILL and terminate the process rather than crashing the framework.

### Change

Hook the relevant exception numbers and stop cleanly instead:

- ARM / ARM64 — `EXCP.UDEF`
- MIPS — a new `EXCP.RI` in `qiling/arch/mips_const.py` (a small named subset of QEMU's MIPS exception codes, so the syscall hook stops using the bare `17` too)

`hook_cpu_exception` logs which signal the CPU raised and at what PC, then calls `ql.stop()`.

### Tests

The existing shellcode tests end emulation from their `execve` hook (`graceful_execve` calls `ql.stop()`), so they never reach the trailing data and never execute it as code — they pass with or without this fix.

`test_linux_arm64_illegal_instruction` and `test_linux_mips32_illegal_instruction` deliberately let `execve` return and fall through into it, reproducing #1629 problem 1. Both fail on `dev` with `QlErrorCoreHook: _hook_intr_cb : not handled` and pass with this change.

`test_shellcode` (8 tests) passes; `test_elf` passes apart from `test_elf_linux_x8664_epoll_server`, which fails identically on unmodified `dev` in my environment (the host denies `epoll_ctl`).

End to end: with this branch, `examples/shellcode_run.py` (run from `examples/`) gets past all five Linux stages instead of aborting on the first one.

### Known gap

The same fall-through on a MIPS **big-endian** shellcode segfaults the interpreter rather than raising an exception, so no hook can catch it. This is an upstream Unicorn bug, unrelated to this change: a single `uc_emu_start` on MIPS32 big-endian with a non-word-aligned `until` address crashes, with no Qiling involved. Little-endian returns a clean error for the same input, and word-aligned `until` values are fine on both. It reproduces on unicorn 2.1.3 and on current unicorn `dev`. The MIPS shellcodes are 35 bytes, so `until` lands unaligned — which is why the little-endian stage is fixed here and the big-endian one is not.
